### PR TITLE
fix: expose more types from the blokli client

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-client"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.4.0"
+version     = "0.4.1"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/client/src/api/v1/mod.rs
+++ b/client/src/api/v1/mod.rs
@@ -1,7 +1,7 @@
 mod graphql;
 pub mod types {
     pub use super::graphql::{
-        ChannelStatus, Hex32, TokenValueString, Uint64,
+        ChannelStatus, DateTime, Hex32, TokenValueString, Uint64,
         accounts::Account,
         balances::{HoprBalance, NativeBalance, SafeHoprAllowance},
         channels::Channel,

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -19,6 +19,20 @@ pub struct BlokliTestClient {
     pub tx_client: Option<MockBlokliTransactionClientImpl>,
 }
 
+impl std::fmt::Debug for BlokliTestClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlokliTestClient")
+            .field("accounts", &self.accounts)
+            .field("native_balances", &self.native_balances)
+            .field("token_balances", &self.token_balances)
+            .field("safe_allowances", &self.safe_allowances)
+            .field("channels", &self.channels)
+            .field("chain_info", &self.chain_info)
+            .field("version", &self.version)
+            .finish_non_exhaustive()
+    }
+}
+
 mockall::mock! {
     pub BlokliTransactionClientImpl {}
     #[async_trait::async_trait]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DateTime type is now publicly accessible in the API exports for developer integration.

* **Tests**
  * Transaction client mock expanded with additional async methods supporting transaction submission, status tracking, and confirmation operations.

* **Chores**
  * Version bumped to 0.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->