### PR TITLE
fix(client): Add link to graphql api schema

### DIFF
--- a/client/build.rs
+++ b/client/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     cynic_codegen::register_schema("blokli")
-        .from_sdl_file("../design/target-api-schema.graphql")
+        .from_sdl_file("./target-api-schema.graphql")
         .unwrap()
         .as_default()
         .unwrap();

--- a/client/target-api-schema.graphql
+++ b/client/target-api-schema.graphql
@@ -1,0 +1,1 @@
+../design/target-api-schema.graphql


### PR DESCRIPTION
Needed because the file must be present in the crate directory in a sandboxed Nix build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized GraphQL schema file location within the project structure to improve build configuration efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->