### PR TITLE
feat(config): Allow partial configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,4 @@ You can override any configuration setting using environment variables.
 | `api.bind_address`           | `BLOKLI_API_BIND_ADDRESS`           |
 | `api.playground_enabled`     | `BLOKLI_API_PLAYGROUND_ENABLED`     |
 | `api.health.max_indexer_lag` | `BLOKLI_API_HEALTH_MAX_INDEXER_LAG` |
-| `api.health.timeout_ms`      | `BLOKLI_API_HEALTH_TIMEOUT_MS`      |
+| `api.health.timeout`         | `BLOKLI_API_HEALTH_TIMEOUT`         |

--- a/api/tests/health_api_integration_test.rs
+++ b/api/tests/health_api_integration_test.rs
@@ -149,7 +149,7 @@ async fn setup_test_environment() -> anyhow::Result<TestContext> {
         contract_addresses: contract_addrs,
         health: HealthConfig {
             max_indexer_lag: 10,
-            timeout_ms: 5000,
+            timeout: std::time::Duration::from_millis(5000),
         },
         ..Default::default()
     };

--- a/bloklid/example-config.toml
+++ b/bloklid/example-config.toml
@@ -83,5 +83,5 @@ playground_enabled = true
 [api.health]
 # Maximum allowed indexer lag (in blocks) before readiness check fails (default: 10)
 max_indexer_lag = 10
-# Timeout for health check queries in milliseconds (default: 5000)
-timeout_ms = 5000
+# Timeout for health check queries (in milliseconds, default: 5000)
+timeout = 5000

--- a/bloklid/src/main.rs
+++ b/bloklid/src/main.rs
@@ -136,7 +136,7 @@ impl Args {
             ("BLOKLI_API_PLAYGROUND_ENABLED", "api.playground_enabled"),
             // API Health
             ("BLOKLI_API_HEALTH_MAX_INDEXER_LAG", "api.health.max_indexer_lag"),
-            ("BLOKLI_API_HEALTH_TIMEOUT_MS", "api.health.timeout_ms"),
+            ("BLOKLI_API_HEALTH_TIMEOUT", "api.health.timeout"),
         ];
 
         for (env_var, config_key) in env_mappings {
@@ -375,7 +375,7 @@ async fn run() -> errors::Result<()> {
                 contract_addresses: contracts,
                 health: blokli_api::config::HealthConfig {
                     max_indexer_lag: api_config.health.max_indexer_lag,
-                    timeout_ms: api_config.health.timeout_ms,
+                    timeout: api_config.health.timeout,
                 },
             };
 

--- a/tests/smoke/config-smoke.toml
+++ b/tests/smoke/config-smoke.toml
@@ -46,4 +46,4 @@ playground_enabled = true
 [api.health]
 # Allow higher lag for smoke tests since we're starting from scratch
 max_indexer_lag = 100
-timeout_ms      = 5000
+timeout         = 5000


### PR DESCRIPTION
Before a partial configuration would break startup because the configuration validation failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration key from `timeout_ms` to `timeout` in example configurations and environment variable from `BLOKLI_API_HEALTH_TIMEOUT_MS` to `BLOKLI_API_HEALTH_TIMEOUT`.

* **Chores**
  * Enhanced configuration system with improved default value support for partial configuration loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->