### PR TITLE
feat: allow configuring simulated tx delay in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-client"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.8.0"
+version     = "0.8.1"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
As in title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 0.8.1

* **New Features**
  * Test client now supports configurable transaction simulation delays. Developers can customize delay timing between confirmations and transaction tracking, with a sensible default of 1 second, enabling more flexible testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->