### PR TITLE
feat: add transaction support to blokli-inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-inspector"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blokli-client",

--- a/inspector/Cargo.toml
+++ b/inspector/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-inspector"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.2.0"
+version     = "0.3.0"
 
 
 [dependencies]
@@ -18,7 +18,7 @@ hopr-primitive-types = { workspace = true }
 serde                = { workspace = true }
 serde_json           = { workspace = true }
 serde_yaml           = { workspace = true }
-tokio                = { workspace = true, features = ["signal", "tracing"] }
+tokio                = { workspace = true, features = ["io-std", "signal", "tracing"] }
 tracing-subscriber   = { workspace = true }
 url                  = { workspace = true }
 


### PR DESCRIPTION
Adds a `transaction` subcommand which allows to send transactions via blokli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Transaction CLI command to submit transactions with configurable options.
  * Support for payload input via arguments or standard input.
  * Added confirmation receipt waiting and transaction tracking features with polling.

* **Chores**
  * Bumped version to 0.3.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->