### PR TITLE
feat: add query for safe by registered nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,27 @@ dependencies = [
 [[package]]
 name = "blokli-client"
 version = "0.15.0"
+source = "git+https://github.com/hoprnet/blokli#e20b05f1d57848c221573f49020fb984404d5165"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cynic",
+ "cynic-codegen",
+ "eventsource-client",
+ "futures",
+ "futures-time",
+ "hex",
+ "reqwest",
+ "serde_json",
+ "smart-default",
+ "thiserror 2.0.17",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "blokli-client"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1923,27 +1944,6 @@ dependencies = [
  "smart-default",
  "thiserror 2.0.17",
  "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "blokli-client"
-version = "0.15.0"
-source = "git+https://github.com/hoprnet/blokli#e20b05f1d57848c221573f49020fb984404d5165"
-dependencies = [
- "anyhow",
- "async-trait",
- "cynic",
- "cynic-codegen",
- "eventsource-client",
- "futures",
- "futures-time",
- "hex",
- "reqwest",
- "serde_json",
- "smart-default",
- "thiserror 2.0.17",
  "tracing",
  "url",
 ]
@@ -2029,7 +2029,7 @@ name = "blokli-inspector"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "blokli-client 0.15.0",
+ "blokli-client 0.16.0",
  "clap",
  "futures",
  "hex",
@@ -2048,7 +2048,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
- "blokli-client 0.15.0",
+ "blokli-client 0.16.0",
  "chrono",
  "clap",
  "futures",
@@ -4018,7 +4018,7 @@ dependencies = [
  "async-broadcast",
  "async-trait",
  "bincode",
- "blokli-client 0.15.0 (git+https://github.com/hoprnet/blokli)",
+ "blokli-client 0.15.0",
  "dashmap",
  "futures",
  "futures-concurrency",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-client"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.15.0"
+version     = "0.16.0"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/client/src/api/v1/graphql/safe.rs
+++ b/client/src/api/v1/graphql/safe.rs
@@ -27,6 +27,13 @@ pub struct QuerySafeByChainKey {
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(graphql_type = "QueryRoot", variables = "SafeVariables")]
+pub struct QuerySafeByRegisteredNode {
+    #[arguments(chainKey: $address)]
+    pub safe_by_registered_node: Option<SafeResult>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "QueryRoot", variables = "SafeVariables")]
 pub struct QuerySafeByAddress {
     #[arguments(address: $address)]
     pub safe: Option<SafeResult>,

--- a/client/src/api/v1/mod.rs
+++ b/client/src/api/v1/mod.rs
@@ -24,8 +24,8 @@ pub(crate) mod internal {
         graph::SubscribeGraph,
         info::{QueryChainInfo, QueryHealth, QueryVersion, SubscribeTicketParams},
         safe::{
-            ModuleAddressVariables, QueryModuleAddress, QuerySafeByAddress, QuerySafeByChainKey, SafeVariables,
-            SubscribeSafeDeployment,
+            ModuleAddressVariables, QueryModuleAddress, QuerySafeByAddress, QuerySafeByChainKey,
+            QuerySafeByRegisteredNode, SafeVariables, SubscribeSafeDeployment,
         },
         txs::{
             ConfirmTransactionVariables, MutateConfirmTransaction, MutateSendTransaction, MutateTrackTransaction,
@@ -116,6 +116,8 @@ pub enum SafeSelector {
     SafeAddress(ChainAddress),
     /// Select a safe by the owner's chain key.
     ChainKey(ChainAddress),
+    /// Select a safe by any of the registered nodes.
+    RegisteredNode(ChainAddress),
 }
 
 impl std::fmt::Debug for SafeSelector {
@@ -123,6 +125,7 @@ impl std::fmt::Debug for SafeSelector {
         match self {
             Self::SafeAddress(address) => write!(f, "SafeAddress({})", hex::encode(address)),
             Self::ChainKey(address) => write!(f, "ChainKey({})", hex::encode(address)),
+            Self::RegisteredNode(address) => write!(f, "RegisteredNode({})", hex::encode(address)),
         }
     }
 }

--- a/client/src/client/queries.rs
+++ b/client/src/client/queries.rs
@@ -60,6 +60,15 @@ impl GraphQlQueries {
         })
     }
 
+    /// `Safe` GraphQL query.
+    pub fn query_safe_by_registered_node(
+        address: &ChainAddress,
+    ) -> cynic::Operation<QuerySafeByRegisteredNode, SafeVariables> {
+        QuerySafeByRegisteredNode::build(SafeVariables {
+            address: address.encode_hex(),
+        })
+    }
+
     /// `ModuleAddressPrediction` GraphQL query.
     pub fn query_module_address_prediction(
         input: ModulePredictionInput,
@@ -171,6 +180,16 @@ impl BlokliQueryClient for BlokliClient {
                     .await?;
 
                 match response_to_data(res)?.safe_by_chain_key {
+                    Some(result) => result.into(),
+                    None => Ok(None),
+                }
+            }
+            SafeSelector::RegisteredNode(node_addr) => {
+                let res = self
+                    .build_query(GraphQlQueries::query_safe_by_registered_node(&node_addr))?
+                    .await?;
+
+                match response_to_data(res)?.safe_by_registered_node {
                     Some(result) => result.into(),
                     None => Ok(None),
                 }

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -477,6 +477,11 @@ impl<M: BlokliTestStateMutator + Send + Sync> BlokliQueryClient for BlokliTestCl
                 .values()
                 .find(|s| s.chain_key == hex::encode(chain_key))
                 .cloned()),
+            SafeSelector::RegisteredNode(node_address) => Ok(state
+                .deployed_safes
+                .values()
+                .find(|s| s.registered_nodes.contains(&hex::encode(node_address)))
+                .cloned()),
         }
     }
 


### PR DESCRIPTION
Allows querying safes by the nodes they are registered with

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to query safes by registered node address as an alternative lookup method.

* **Chores**
  * Bumped package version to 0.16.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->