### PR TITLE
feat: add querying of safe by registered node via blokli-inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-inspector"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blokli-client 0.16.0",

--- a/inspector/Cargo.toml
+++ b/inspector/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-inspector"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.4.0"
+version     = "0.5.0"
 
 
 [dependencies]


### PR DESCRIPTION
As in title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying Safe contracts using registered node identifiers via the new `--registered-node` option, providing additional flexibility alongside existing address and owner-based queries.

* **Chores**
  * Version bumped to 0.5.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->