### PR TITLE
fix: do not push any safe data for other networks than rotsee or dufour

### DIFF
--- a/db/core/src/db.rs
+++ b/db/core/src/db.rs
@@ -228,10 +228,9 @@ impl BlokliDb {
                     .await
                     .map_err(|e| DbSqlError::Construction(format!("cannot apply index migrations: {e}")))?;
             } else {
-                return Err(DbSqlError::Construction(format!(
-                    "cannot apply index migrations for unknown network {}",
-                    cfg.network_name
-                )));
+                MigratorIndex::<{ SafeDataOrigin::NoData as u8 }>::up(&db, None)
+                    .await
+                    .map_err(|e| DbSqlError::Construction(format!("cannot apply index migrations: {e}")))?;
             }
 
             MigratorChainLogs::up(logs_db.as_ref().unwrap(), None)
@@ -250,10 +249,9 @@ impl BlokliDb {
                     .await
                     .map_err(|e| DbSqlError::Construction(format!("cannot apply migrations: {e}")))?;
             } else {
-                return Err(DbSqlError::Construction(format!(
-                    "cannot apply migrations for unknown network {}",
-                    cfg.network_name
-                )));
+                Migrator::<{ SafeDataOrigin::NoData as u8 }>::up(&db, None)
+                    .await
+                    .map_err(|e| DbSqlError::Construction(format!("cannot apply migrations: {e}")))?;
             }
         }
 


### PR DESCRIPTION
As in title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database migration behavior for unknown networks. The system now gracefully processes migrations using a fallback mechanism instead of immediately failing, while maintaining all existing error handling for actual migration failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->