### PR TITLE
fix(indexer): Prevent race-condition in event handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-chain-indexer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0"
 name        = "blokli-chain-indexer"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.10.0"
+version     = "0.11.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/chain/indexer/src/handlers/announcements.rs
+++ b/chain/indexer/src/handlers/announcements.rs
@@ -12,7 +12,10 @@ use hopr_primitive_types::{
 use tracing::{debug, error, warn};
 
 use super::{ContractEventHandlers, helpers::construct_account_update};
-use crate::errors::{CoreEthereumIndexerError, Result};
+use crate::{
+    errors::{CoreEthereumIndexerError, Result},
+    state::IndexerEvent,
+};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {
@@ -37,9 +40,11 @@ where
         tx_index: u32,
         log_index: u32,
         is_synced: bool,
-    ) -> Result<()> {
+    ) -> Result<Vec<IndexerEvent>> {
         #[cfg(all(feature = "prometheus", not(test)))]
         METRIC_INDEXER_LOG_COUNTERS.increment(&["announcements"]);
+
+        let mut events = Vec::new();
 
         match event {
             HoprAnnouncementsEvents::AddressAnnouncement(address_announcement) => {
@@ -54,7 +59,7 @@ where
                         address = %address_announcement.node,
                         "encountered empty multiaddress announcement",
                     );
-                    return Ok(());
+                    return Ok(events);
                 }
                 let node_address: Address = address_announcement.node.to_hopr_address();
 
@@ -75,8 +80,7 @@ where
                 if is_synced {
                     match construct_account_update(tx.as_ref(), &node_address).await {
                         Ok(account) => {
-                            self.indexer_state
-                                .publish_event(crate::state::IndexerEvent::AccountUpdated(account));
+                            events.push(crate::state::IndexerEvent::AccountUpdated(account));
                         }
                         Err(e) => {
                             warn!("Failed to construct account update for AddressAnnouncement: {}", e);
@@ -133,8 +137,7 @@ where
                                 if is_synced {
                                     match construct_account_update(tx.as_ref(), &chain_key).await {
                                         Ok(account) => {
-                                            self.indexer_state
-                                                .publish_event(crate::state::IndexerEvent::AccountUpdated(account));
+                                            events.push(crate::state::IndexerEvent::AccountUpdated(account));
                                         }
                                         Err(e) => {
                                             warn!("Failed to construct account update for KeyBinding: {}", e);
@@ -167,8 +170,7 @@ where
                         if is_synced {
                             match construct_account_update(tx.as_ref(), &node_address).await {
                                 Ok(account) => {
-                                    self.indexer_state
-                                        .publish_event(crate::state::IndexerEvent::AccountUpdated(account));
+                                    events.push(crate::state::IndexerEvent::AccountUpdated(account));
                                 }
                                 Err(e) => {
                                     warn!("Failed to construct account update for RevokeAnnouncement: {}", e);
@@ -198,10 +200,9 @@ where
                 // Publish subscription event only when indexer is in synced mode
                 if is_synced {
                     let fee_str = fee.amount().to_string();
-                    self.indexer_state
-                        .publish_event(crate::state::IndexerEvent::KeyBindingFeeUpdated(TokenValueString(
-                            fee_str,
-                        )));
+                    events.push(crate::state::IndexerEvent::KeyBindingFeeUpdated(TokenValueString(
+                        fee_str,
+                    )));
                 }
             }
             HoprAnnouncementsEvents::LedgerDomainSeparatorUpdated(ledger_domain_separator) => {
@@ -229,7 +230,7 @@ where
             }
         }
 
-        Ok(())
+        Ok(events)
     }
 }
 
@@ -275,7 +276,8 @@ mod tests {
             inner: Arc::new(rpc_operations),
         };
 
-        let (handlers, _state, mut event_receiver) = init_handlers_with_events(clonable_rpc_operations, db.clone());
+        let (handlers, indexer_state, mut event_receiver) =
+            init_handlers_with_events(clonable_rpc_operations, db.clone());
 
         let keybinding = KeyBinding::new(*SELF_CHAIN_ADDRESS, &SELF_PRIV_KEY);
 
@@ -303,10 +305,15 @@ mod tests {
             key_id: 0.into(),
         };
 
-        db.begin_transaction()
+        let events = db
+            .begin_transaction()
             .await?
             .perform(|tx| Box::pin(async move { handlers.process_log_event(tx, keybinding_log, true).await }))
             .await?;
+
+        for event in events {
+            indexer_state.publish_event(event);
+        }
 
         // Verify AccountUpdated event was published
         let _event = tokio::time::timeout(Duration::from_millis(100), event_receiver.recv())
@@ -332,7 +339,7 @@ mod tests {
             //
             inner: Arc::new(rpc_operations),
         };
-        let (handlers, _indexer_state, mut event_receiver) =
+        let (handlers, indexer_state, mut event_receiver) =
             init_handlers_with_events(clonable_rpc_operations, db.clone());
 
         // Assume that there is a keybinding
@@ -376,7 +383,8 @@ mod tests {
         };
 
         let handlers_clone = handlers.clone();
-        db.begin_transaction()
+        let events = db
+            .begin_transaction()
             .await?
             .perform(|tx| {
                 Box::pin(async move {
@@ -386,6 +394,10 @@ mod tests {
                 })
             })
             .await?;
+
+        for event in events {
+            indexer_state.publish_event(event);
+        }
 
         // Empty multiaddress announcement should not publish an event
 
@@ -424,7 +436,8 @@ mod tests {
         };
 
         let handlers_clone = handlers.clone();
-        db.begin_transaction()
+        let events = db
+            .begin_transaction()
             .await?
             .perform(|tx| {
                 Box::pin(async move {
@@ -434,6 +447,10 @@ mod tests {
                 })
             })
             .await?;
+
+        for event in events {
+            indexer_state.publish_event(event);
+        }
 
         // Verify AccountUpdated event was published with the multiaddress
         let event = try_recv_event(&mut event_receiver).expect("Expected AccountUpdated event to be published");
@@ -536,7 +553,8 @@ mod tests {
             //
             inner: Arc::new(rpc_operations),
         };
-        let (handlers, _state, mut event_receiver) = init_handlers_with_events(clonable_rpc_operations, db.clone());
+        let (handlers, indexer_state, mut event_receiver) =
+            init_handlers_with_events(clonable_rpc_operations, db.clone());
 
         let test_multiaddr: Multiaddr = "/ip4/1.2.3.4/tcp/56".parse()?;
 
@@ -578,10 +596,15 @@ mod tests {
             key_id: 1.into(),
         };
 
-        db.begin_transaction()
+        let events = db
+            .begin_transaction()
             .await?
             .perform(|tx| Box::pin(async move { handlers.process_log_event(tx, revoke_announcement_log, true).await }))
             .await?;
+
+        for event in events {
+            indexer_state.publish_event(event);
+        }
 
         // Verify AccountUpdated event was published
         let _event = try_recv_event(&mut event_receiver).expect("Expected AccountUpdated event to be published");
@@ -602,7 +625,8 @@ mod tests {
         let clonable_rpc_operations = ClonableMockOperations {
             inner: Arc::new(rpc_operations),
         };
-        let (handlers, _state, mut event_receiver) = init_handlers_with_events(clonable_rpc_operations, db.clone());
+        let (handlers, indexer_state, mut event_receiver) =
+            init_handlers_with_events(clonable_rpc_operations, db.clone());
 
         // Initial fee should be empty/none
         let data = db.get_indexer_data(None).await?;
@@ -618,10 +642,15 @@ mod tests {
 
         let log = event_to_log(event, handlers.addresses.announcements);
 
-        db.begin_transaction()
+        let events = db
+            .begin_transaction()
             .await?
             .perform(|tx| Box::pin(async move { handlers.process_log_event(tx, log, true).await }))
             .await?;
+
+        for event in events {
+            indexer_state.publish_event(event);
+        }
 
         // Verify KeyBindingFeeUpdated event was published
         let event = try_recv_event(&mut event_receiver).expect("Expected KeyBindingFeeUpdated event to be published");

--- a/chain/indexer/src/handlers/channels.rs
+++ b/chain/indexer/src/handlers/channels.rs
@@ -32,9 +32,11 @@ where
         tx_index: u32,
         log_index: u32,
         is_synced: bool,
-    ) -> Result<()> {
+    ) -> Result<Vec<crate::state::IndexerEvent>> {
         #[cfg(all(feature = "prometheus", not(test)))]
         METRIC_INDEXER_LOG_COUNTERS.increment(&["channels"]);
+
+        let mut events = Vec::new();
 
         match event {
             HoprChannelsEvents::ChannelBalanceDecreased(balance_decreased) => {
@@ -95,8 +97,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            self.indexer_state
-                                .publish_event(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelBalanceDecreased");
@@ -104,7 +105,7 @@ where
                     }
                 }
 
-                Ok(())
+                Ok(events)
             }
             HoprChannelsEvents::ChannelBalanceIncreased(balance_increased) => {
                 let channel_id = balance_increased.channelId.0.into();
@@ -164,8 +165,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            self.indexer_state
-                                .publish_event(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelBalanceIncreased");
@@ -173,7 +173,7 @@ where
                     }
                 }
 
-                Ok(())
+                Ok(events)
             }
             HoprChannelsEvents::ChannelClosed(channel_closed) => {
                 let channel_id = channel_closed.channelId.0.into();
@@ -231,8 +231,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            self.indexer_state
-                                .publish_event(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelClosed");
@@ -240,7 +239,7 @@ where
                     }
                 }
 
-                Ok(())
+                Ok(events)
             }
             HoprChannelsEvents::ChannelOpened(channel_opened) => {
                 let source: Address = channel_opened.source.to_hopr_address();
@@ -278,7 +277,7 @@ where
                             .await
                             .ok();
 
-                        return Ok(());
+                        return Ok(events);
                     }
 
                     trace!(%source, %destination, %channel_id, "on_channel_reopened_event");
@@ -318,8 +317,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            self.indexer_state
-                                .publish_event(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelOpened");
@@ -327,7 +325,7 @@ where
                     }
                 }
 
-                Ok(())
+                Ok(events)
             }
             HoprChannelsEvents::TicketRedeemed(ticket_redeemed) => {
                 let channel_id = ticket_redeemed.channelId.0.into();
@@ -379,8 +377,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            self.indexer_state
-                                .publish_event(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for TicketRedeemed");
@@ -388,7 +385,7 @@ where
                     }
                 }
 
-                Ok(())
+                Ok(events)
             }
             HoprChannelsEvents::OutgoingChannelClosureInitiated(closure_initiated) => {
                 let channel_id = closure_initiated.channelId.0.into();
@@ -440,8 +437,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            self.indexer_state
-                                .publish_event(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for OutgoingChannelClosureInitiated");
@@ -449,7 +445,7 @@ where
                     }
                 }
 
-                Ok(())
+                Ok(events)
             }
             HoprChannelsEvents::DomainSeparatorUpdated(domain_separator_updated) => {
                 self.db
@@ -460,7 +456,7 @@ where
                     )
                     .await?;
 
-                Ok(())
+                Ok(events)
             }
             HoprChannelsEvents::LedgerDomainSeparatorUpdated(ledger_domain_separator_updated) => {
                 self.db
@@ -471,7 +467,7 @@ where
                     )
                     .await?;
 
-                Ok(())
+                Ok(events)
             }
         }
     }

--- a/chain/indexer/src/handlers/oracles.rs
+++ b/chain/indexer/src/handlers/oracles.rs
@@ -9,7 +9,7 @@ use hopr_primitive_types::{prelude::HoprBalance, traits::IntoEndian};
 use tracing::{debug, info, trace};
 
 use super::ContractEventHandlers;
-use crate::errors::Result;
+use crate::{errors::Result, state::IndexerEvent};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {
@@ -31,7 +31,7 @@ where
         tx: &OpenTransaction,
         event: HoprWinningProbabilityOracleEvents,
         _is_synced: bool,
-    ) -> Result<()> {
+    ) -> Result<Vec<IndexerEvent>> {
         #[cfg(all(feature = "prometheus", not(test)))]
         METRIC_INDEXER_LOG_COUNTERS.increment(&["winning_probability_oracle"]);
 
@@ -71,7 +71,7 @@ where
                 );
             }
         }
-        Ok(())
+        Ok(vec![])
     }
 
     pub(super) async fn on_ticket_price_oracle_event(
@@ -79,7 +79,7 @@ where
         tx: &OpenTransaction,
         event: HoprTicketPriceOracleEvents,
         _is_synced: bool,
-    ) -> Result<()> {
+    ) -> Result<Vec<IndexerEvent>> {
         #[cfg(all(feature = "prometheus", not(test)))]
         METRIC_INDEXER_LOG_COUNTERS.increment(&["ticket_price_oracle"]);
 
@@ -101,7 +101,7 @@ where
                 // ignore ownership transfer event
             }
         }
-        Ok(())
+        Ok(vec![])
     }
 }
 

--- a/chain/indexer/src/handlers/stake_factory.rs
+++ b/chain/indexer/src/handlers/stake_factory.rs
@@ -7,7 +7,7 @@ use hopr_primitive_types::prelude::{SerializableLog, ToHex};
 use tracing::{error, info};
 
 use super::ContractEventHandlers;
-use crate::errors::Result;
+use crate::{errors::Result, state::IndexerEvent};
 
 impl<T, Db> ContractEventHandlers<T, Db>
 where
@@ -47,7 +47,8 @@ where
         block: u64,
         tx_index: u64,
         log_index: u64,
-    ) -> Result<()> {
+    ) -> Result<Vec<IndexerEvent>> {
+        let mut events = Vec::new();
         if let HoprNodeStakeFactoryEvents::NewHoprNodeStakeModuleForSafe(deployed) = event {
             let module_addr = deployed.module.to_hopr_address();
             let safe_addr = deployed.safe.to_hopr_address();
@@ -88,8 +89,7 @@ where
 
             // Emit SafeDeployed event if synced
             if is_synced {
-                self.indexer_state
-                    .publish_event(crate::state::IndexerEvent::SafeDeployed(safe_addr));
+                events.push(crate::state::IndexerEvent::SafeDeployed(safe_addr));
             }
         } else {
             error!(
@@ -98,7 +98,7 @@ where
             );
         }
 
-        Ok(())
+        Ok(events)
     }
 }
 

--- a/chain/indexer/src/handlers/tokens.rs
+++ b/chain/indexer/src/handlers/tokens.rs
@@ -6,7 +6,7 @@ use hopr_primitive_types::prelude::Address;
 use tracing::{debug, trace};
 
 use super::ContractEventHandlers;
-use crate::errors::Result;
+use crate::{errors::Result, state::IndexerEvent};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {
@@ -28,7 +28,7 @@ where
         _tx: &OpenTransaction,
         event: HoprTokenEvents,
         _is_synced: bool,
-    ) -> Result<()> {
+    ) -> Result<Vec<IndexerEvent>> {
         #[cfg(all(feature = "prometheus", not(test)))]
         METRIC_INDEXER_LOG_COUNTERS.increment(&["token"]);
 
@@ -117,6 +117,6 @@ where
             }
         }
 
-        Ok(())
+        Ok(vec![])
     }
 }


### PR DESCRIPTION
Fixes #171 

Before the events would be published within the database transaction, which would lead to race conditions. Even worse an event could have been published more than once since db transactions can be executed multiple times internally.

This fix moves the event publishing to after the db transaction has committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version**
  * Bumped package version to 0.11.0.

* **Refactor**
  * Restructured event handling throughout the indexer to improve reliability and consistency. Events are now accumulated and published after transaction commits, ensuring better data consistency.
  * Consolidated event emission logic across multiple handlers for streamlined event processing.

* **Tests**
  * Added verification tests to ensure events are published correctly after transactions complete.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->