### PR TITLE
feat: add packet-key account query option to blokli-inspector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,13 +2056,14 @@ dependencies = [
 
 [[package]]
 name = "blokli-inspector"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blokli-client 0.17.0",
  "clap",
  "futures",
  "hex",
+ "hopr-crypto-types",
  "hopr-primitive-types",
  "serde",
  "serde_json",

--- a/bloklid/src/network.rs
+++ b/bloklid/src/network.rs
@@ -24,8 +24,7 @@ pub enum Network {
     Rotsee,
     /// Jura testnet (staging network)
     #[serde(alias = "jura")]
-    Jura
-
+    Jura,
 }
 
 impl Network {

--- a/inspector/Cargo.toml
+++ b/inspector/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-inspector"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.5.0"
+version     = "0.6.0"
 
 
 [dependencies]
@@ -14,6 +14,7 @@ blokli-client        = { workspace = true, features = ["serde"] }
 clap                 = { workspace = true }
 futures              = { workspace = true }
 hex                  = { workspace = true }
+hopr-crypto-types    = { workspace = true }
 hopr-primitive-types = { workspace = true }
 serde                = { workspace = true }
 serde_json           = { workspace = true }


### PR DESCRIPTION
The `blokli-inspector` now allows to query accounts using packet key or PeerId.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added packet key-based account selection method, providing users with an alternative way to identify accounts. Supports multiple identification formats for enhanced flexibility.

* **Chores**
  * Updated package version to 0.6.0
  * Integrated new cryptographic types dependency for core functionality

* **Style**
  * Applied minor formatting improvements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->