### PR TITLE
fix: entry point for darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -226,7 +226,11 @@
             inherit overlays;
           };
 
-          blokliAnvilEntrypoint = pkgs.writeShellScriptBin "blokli-anvil-entrypoint" (
+          blokliAnvilEntrypointX86_64 = pkgsLinux.writeShellScriptBin "blokli-anvil-entrypoint" (
+            builtins.readFile ./docker/blokli-anvil-entrypoint.sh
+          );
+
+          blokliAnvilEntrypointAarch64 = pkgsLinuxAarch64.writeShellScriptBin "blokli-anvil-entrypoint" (
             builtins.readFile ./docker/blokli-anvil-entrypoint.sh
           );
 
@@ -259,7 +263,7 @@
             };
             docker-blokli-anvil-x86_64-linux = nixLib.mkDockerImage {
               name = "bloklid-anvil";
-              Entrypoint = [ "${blokliAnvilEntrypoint}/bin/blokli-anvil-entrypoint" ];
+              Entrypoint = [ "${blokliAnvilEntrypointX86_64}/bin/blokli-anvil-entrypoint" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -268,7 +272,7 @@
                 bloklidPackages.binary-blokli-x86_64-linux
                 pkgsLinux.curl
                 pkgsLinux.foundry
-                blokliAnvilEntrypoint
+                blokliAnvilEntrypointX86_64
               ];
             };
 
@@ -299,7 +303,7 @@
             };
             docker-blokli-anvil-aarch64-linux = nixLib.mkDockerImage {
               name = "bloklid-anvil";
-              Entrypoint = [ "${blokliAnvilEntrypoint}/bin/blokli-anvil-entrypoint" ];
+              Entrypoint = [ "${blokliAnvilEntrypointAarch64}/bin/blokli-anvil-entrypoint" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -308,7 +312,7 @@
                 bloklidPackages.binary-blokli-aarch64-linux
                 pkgsLinuxAarch64.curl
                 pkgsLinuxAarch64.foundry
-                blokliAnvilEntrypoint
+                blokliAnvilEntrypointAarch64
               ];
             };
           };


### PR DESCRIPTION
The anvil entrypoint was built with the host pkgs (darwin), so the shebang pointed at a macOS bash inside the Linux image. That yields exec format error when the container starts. 

The PR switches to building the entrypoint with the matching Linux pkgs for each architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker images now support x86_64 and ARM64 (aarch64) architectures with platform-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->