### PR TITLE
feat: push the blokli+anvil docker image to the registry

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -36,6 +36,32 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
       docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
+  build-docker-with-anvil:
+    name: Docker anvil ${{ matrix.architecture }}
+    if: github.event.pull_request.merged == true
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker-image.yaml@build-docker-image-v1
+    strategy:
+      matrix:
+        include:
+          - architecture: x86_64-linux
+            command: nix run -L .#docker-blokli-anvil-upload-x86_64-linux
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    with:
+      source_branch: ${{ github.event.pull_request.base.ref }}
+      version_type: "pr"
+      architecture: ${{ matrix.architecture }}
+      cachix_cache_name: "blokli"
+      build_file: "bloklid/Cargo.toml"
+      build_command: ${{ matrix.command }}
+      docker_image_name: "bloklid-anvil"
+    secrets:
+      gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
   build-docker-manifest:
     if: github.event.pull_request.merged == true
     name: Docker manifest
@@ -48,6 +74,22 @@ jobs:
       docker_image_name: "bloklid"
       docker_build_version: ${{ needs.build-docker.outputs.docker_build_version }}
       docker_debug_version: ${{ needs.build-docker.outputs.docker_debug_version }}
+    secrets:
+      gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
+      docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}
+      docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
+  build-docker-manifest-anvil:
+    if: github.event.pull_request.merged == true
+    name: Docker manifest anvil
+    needs: build-docker-with-anvil
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker-manifest.yaml@build-docker-manifest-v1
+    permissions:
+      contents: read
+    with:
+      version_type: "pr"
+      docker_image_name: "bloklid-anvil"
+      docker_build_version: ${{ needs.build-docker-with-anvil.outputs.docker_build_version }}
+      docker_debug_version: ${{ needs.build-docker-with-anvil.outputs.docker_debug_version }}
     secrets:
       gcp_service_account: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY}}
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-chain-indexer"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/flake.nix
+++ b/flake.nix
@@ -321,9 +321,11 @@
             docker-blokli-upload-x86_64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-x86_64-linux;
             docker-blokli-dev-upload-x86_64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-x86_64-linux-dev;
             docker-blokli-profile-upload-x86_64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-x86_64-linux-profile;
+            docker-blokli-anvil-upload-x86_64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-anvil-x86_64-linux;
             docker-blokli-upload-aarch64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-aarch64-linux;
             docker-blokli-dev-upload-aarch64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-aarch64-linux-dev;
             docker-blokli-profile-upload-aarch64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-aarch64-linux-profile;
+            docker-blokli-anvil-upload-aarch64-linux = nixLib.mkDockerUploadApp bloklidDocker.docker-blokli-anvil-aarch64-linux;
           };
 
           utilityApps = {


### PR DESCRIPTION
Pushes the blokli+anvil docker image to our docker artifact registry.

Fixes #197 