### PR TITLE
fix: increase block range to 100k

### DIFF
--- a/bloklid/src/network.rs
+++ b/bloklid/src/network.rs
@@ -98,8 +98,8 @@ impl Network {
     pub fn max_block_range(&self) -> u32 {
         match self {
             Network::AnvilLocalhost => 10000,
-            Network::Rotsee => 10000,
-            Network::Jura => 10000,
+            Network::Rotsee => 100_000,
+            Network::Jura => 100_000,
         }
     }
 


### PR DESCRIPTION
As per the title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased maximum block range limits for certain network configurations, enabling larger block queries to be processed efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->