### PR TITLE
ci: Bump version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,12 +91,14 @@ jobs:
       contents: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@d9cbfed445d62de384aeb200580a49b94d05309d # release-version-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@27fb7c9ad22da3361b1fb783c61ce06aa39dd62a # release-version-v2
         with:
           source_branch: ${{ github.ref_name }}
           file: bloklid/Cargo.toml
           release_type: "${{ inputs.release_type }}"
           package_name: "bloklid"
+          cachix_cache_name: "blokli"
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: "Blokli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",

--- a/bloklid/Cargo.toml
+++ b/bloklid/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "bloklid"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.8.2"
+version     = "0.8.3"
 
 [features]
 default = ["runtime-tokio"]


### PR DESCRIPTION
Bump manually the version as the previous closure of the release failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.8.3
  * Updated release workflow with improved caching support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->