### PR TITLE
fix: winn prob rounding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-db"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -720,7 +720,7 @@ checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "opentelemetry",
  "opentelemetry-http",
  "reqwest 0.12.28",
@@ -2513,7 +2513,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3408,7 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4588,7 +4588,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4608,7 +4608,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5547,7 +5547,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6917,7 +6917,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8221,7 +8221,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9248,7 +9248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -9260,7 +9260,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -9277,25 +9277,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -9340,7 +9327,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-chain-api"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -733,13 +733,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more",
  "nybbles",
  "serde",
@@ -3481,9 +3480,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "fastrlp"
@@ -3594,7 +3590,6 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "fastrand",
  "futures-core",
  "futures-sink",
  "spin",
@@ -3823,10 +3818,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4069,7 +4062,6 @@ dependencies = [
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
- "tokio",
  "tracing",
  "url",
 ]
@@ -4091,7 +4083,6 @@ dependencies = [
  "resolv-conf",
  "smallvec 1.15.1",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
@@ -4125,7 +4116,7 @@ dependencies = [
 [[package]]
 name = "hopli"
 version = "0.17.0"
-source = "git+https://github.com/hoprnet/hopli?branch=main#a0d6e2b043641e6f853b7ea00ff2d6198039f0d0"
+source = "git+https://github.com/hoprnet/hopli?branch=main#60c76c8f2faeac9dd6e05db52a2e94431c1a7372"
 dependencies = [
  "alloy-transport-http",
  "anyhow",
@@ -4150,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "hopr-async-runtime"
 version = "0.4.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#f8cb931967e665d3beac67f74c0adca23230ee48"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "auto_impl",
  "futures",
@@ -4161,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "hopr-bindings"
 version = "4.7.0"
-source = "git+https://github.com/hoprnet/contracts?branch=main#a0db96f1c614624cf815ec30244b597f35634900"
+source = "git+https://github.com/hoprnet/contracts?branch=main#da7effb8a708eca4fc1a73d276645ce7ce21d2e8"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4177,8 +4168,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-types"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#bdfa78c491d040d5a29e803d6cf6d84dad79e97f"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#c5a65c8c020748718e1b74d930ec21fe6dfd5f2e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4198,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "hopr-crypto-keypair"
 version = "0.5.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#f8cb931967e665d3beac67f74c0adca23230ee48"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "hex",
  "hopr-platform",
@@ -4214,12 +4205,13 @@ dependencies = [
 
 [[package]]
 name = "hopr-crypto-packet"
-version = "1.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#f8cb931967e665d3beac67f74c0adca23230ee48"
+version = "1.3.0"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "flagset",
  "hex",
  "hopr-crypto-sphinx",
+ "hopr-parallelize",
  "hopr-types",
  "strum 0.28.0",
  "thiserror 2.0.18",
@@ -4228,8 +4220,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-crypto-random"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#bdfa78c491d040d5a29e803d6cf6d84dad79e97f"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#c5a65c8c020748718e1b74d930ec21fe6dfd5f2e"
 dependencies = [
  "generic-array 1.3.5",
  "rand 0.10.0",
@@ -4237,8 +4229,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-crypto-sphinx"
-version = "0.11.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#f8cb931967e665d3beac67f74c0adca23230ee48"
+version = "0.12.0"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "bimap",
  "curve25519-dalek",
@@ -4253,8 +4245,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-crypto-types"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#bdfa78c491d040d5a29e803d6cf6d84dad79e97f"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#c5a65c8c020748718e1b74d930ec21fe6dfd5f2e"
 dependencies = [
  "aes",
  "blake3",
@@ -4285,8 +4277,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-internal-types"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#bdfa78c491d040d5a29e803d6cf6d84dad79e97f"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#c5a65c8c020748718e1b74d930ec21fe6dfd5f2e"
 dependencies = [
  "aquamarine",
  "async-trait",
@@ -4294,10 +4286,10 @@ dependencies = [
  "hex-literal",
  "hopr-crypto-random",
  "hopr-crypto-types",
- "hopr-parallelize",
  "hopr-primitive-types",
  "multiaddr",
  "num_enum",
+ "rayon",
  "serde",
  "serde_bytes",
  "smart-default",
@@ -4309,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "hopr-metrics"
 version = "1.3.2"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#f8cb931967e665d3beac67f74c0adca23230ee48"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "prometheus",
 ]
@@ -4317,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-types"
 version = "1.2.0"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#f8cb931967e665d3beac67f74c0adca23230ee48"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -4332,7 +4324,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_bytes",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tracing",
@@ -4340,8 +4332,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-parallelize"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#bdfa78c491d040d5a29e803d6cf6d84dad79e97f"
+version = "0.2.2"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "futures",
  "lazy_static",
@@ -4354,15 +4346,15 @@ dependencies = [
 [[package]]
 name = "hopr-platform"
 version = "0.3.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#f8cb931967e665d3beac67f74c0adca23230ee48"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#3cb0862f5e1c239b71a58cf3d4a28efd3dbc0f26"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "hopr-primitive-types"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#bdfa78c491d040d5a29e803d6cf6d84dad79e97f"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#c5a65c8c020748718e1b74d930ec21fe6dfd5f2e"
 dependencies = [
  "bigdecimal",
  "chrono",
@@ -4379,14 +4371,13 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.0.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#bdfa78c491d040d5a29e803d6cf6d84dad79e97f"
+version = "1.2.0"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#c5a65c8c020748718e1b74d930ec21fe6dfd5f2e"
 dependencies = [
  "hopr-chain-types",
  "hopr-crypto-random",
  "hopr-crypto-types",
  "hopr-internal-types",
- "hopr-parallelize",
  "hopr-primitive-types",
 ]
 
@@ -4597,7 +4588,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4819,7 +4810,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "rayon",
  "serde",
  "serde_core",
 ]
@@ -5114,9 +5104,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "liblzma"
@@ -5260,6 +5250,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5317,6 +5318,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "merlin"
@@ -5501,6 +5511,19 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -6176,11 +6199,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -7106,9 +7129,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "2.0.0-rc.35"
+version = "2.0.0-rc.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c847ddcc05ba1c4a8ad6bf781ac8d3750123f6e95642c2268b0551101931de"
+checksum = "4b846dc1c7fefbea372c03765ff08307d68894bbad8c73b66176dcd53a3ee131"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7118,6 +7141,7 @@ dependencies = [
  "futures-util",
  "itertools 0.14.0",
  "log",
+ "mac_address",
  "ouroboros",
  "pgvector",
  "rust_decimal",
@@ -7150,9 +7174,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-cli"
-version = "2.0.0-rc.35"
+version = "2.0.0-rc.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19cac0ea172be551704a2c1dba1bea5a3057b2ed70b8a2819f965c501d1ffc07"
+checksum = "cd9b34d4c8e615079c04eb7863a429c2d2a8bf9c934eb9eeb580f51f36367124"
 dependencies = [
  "chrono",
  "clap",
@@ -7171,9 +7195,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-codegen"
-version = "2.0.0-rc.35"
+version = "2.0.0-rc.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4698fb9fdfcd68ab17ac63d748f9084982b33564c48b7769504fd42ca6699e5"
+checksum = "d1000f8f2bb04efa159871778e5107054a9dee04bfb70a030666b9ea49ae3ceb"
 dependencies = [
  "heck 0.5.0",
  "pluralizer",
@@ -7187,9 +7211,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "2.0.0-rc.35"
+version = "2.0.0-rc.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a172f9ceaceafa0fe40f6f15df0231750755284c80bd8ba98d10d5ae611ecaf0"
+checksum = "b449fe660e4d365f335222025df97ae01e670ef7ad788b3c67db9183b6cb0474"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
@@ -7203,9 +7227,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-migration"
-version = "2.0.0-rc.35"
+version = "2.0.0-rc.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c011930d0cd0d0157d93ef9ad1fdd7a4002f28c082d0c49fabc5f0f445c8e925"
+checksum = "b3ceb928aac8be83332d34d1fdbc827d43696135a800723ffeb2e0b33b7b495e"
 dependencies = [
  "async-trait",
  "clap",
@@ -7756,12 +7780,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8363,7 +8387,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -8513,6 +8537,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8528,12 +8561,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -8894,9 +8927,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -9387,15 +9420,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -9427,28 +9451,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9473,12 +9480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9489,12 +9490,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9509,22 +9504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9539,12 +9522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9555,12 +9532,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9575,12 +9546,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9593,16 +9558,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -9771,18 +9730,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-db-migration"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,25 +102,24 @@ rstest-log = "0.2.0"
 rust-stream-ext-concurrent = "1.0.0"
 rustls = { version = "0.23", default-features = false, features = ["std"] }
 rustls-pemfile = "2.1"
-sea-orm = { version = "2.0.0-rc.9", default-features = false, features = [
+sea-orm = { version = "2.0.0-rc.37", default-features = false, features = [
   "debug-print",
   "macros",
   "runtime-tokio-rustls",
   "sqlx-postgres",
   "with-chrono",
 ] }
-sea-orm-cli = { version = "2.0.0-rc.9", default-features = false, features = [
+sea-orm-cli = { version = "2.0.0-rc.37", default-features = false, features = [
   "codegen",
   "runtime-tokio-rustls",
 ] }
-sea-orm-migration = { version = "2.0.0-rc.9", default-features = false, features = [
+sea-orm-migration = { version = "2.0.0-rc.37", default-features = false, features = [
   "cli",
   "sqlx-postgres",
   "with-chrono",
 ] }
-sea-query = { version = "1.0.0-rc.14", default-features = false }
-# Removed: sea-query-binder is incompatible with sea-query 1.0.0-rc.14
-# SeaORM 2.0.0-rc.9 uses its own internal sea-query-sqlx for database integration
+sea-query = { version = "1.0.0-rc.31", default-features = false }
+# Keep sea-query aligned with SeaORM RC line to avoid resolver drift.
 seaography = { version = "2.0.0-rc.2", features = ["with-chrono"] }
 semver = "1.0.26"
 serde = { version = "1.0", features = ["derive"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.16.2"
+version     = "0.16.3"
 
 [lints]
 workspace = true

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -1244,9 +1244,7 @@ impl QueryRoot {
             }
         }
 
-        // f32 -> f64 is widening, always safe
-        #[allow(clippy::cast_lossless)]
-        let min_ticket_winning_probability = chain_info.min_incoming_ticket_win_prob as f64;
+        let min_ticket_winning_probability = chain_info.min_incoming_ticket_win_prob;
 
         // Convert domain separators from binary to hex strings
         let channel_dst = match chain_info.channels_dst.as_ref() {

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -1227,7 +1227,7 @@ impl SubscriptionRoot {
             };
 
             TicketParameters {
-                min_ticket_winning_probability: info.min_incoming_ticket_win_prob as f64,
+                min_ticket_winning_probability: info.min_incoming_ticket_win_prob,
                 ticket_price: TokenValueString(ticket_price),
             }
         }))

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -110,8 +110,8 @@ async fn capture_watermark_synchronized(
 
     let watermark = Watermark {
         block: chain_info.last_indexed_block,
-        tx_index: chain_info.last_indexed_tx_index.unwrap_or(0),
-        log_index: chain_info.last_indexed_log_index.unwrap_or(0),
+        tx_index: chain_info.last_indexed_tx_index,
+        log_index: chain_info.last_indexed_log_index,
     };
 
     // Subscribe to event bus and shutdown signal while still holding the lock
@@ -1456,8 +1456,8 @@ mod tests {
         let chain_info = chain_info::ActiveModel {
             id: Set(1),
             last_indexed_block: Set(block),
-            last_indexed_tx_index: Set(Some(tx_index)),
-            last_indexed_log_index: Set(Some(log_index)),
+            last_indexed_tx_index: Set(tx_index),
+            last_indexed_log_index: Set(log_index),
             ticket_price: Set(None),
             key_binding_fee: Set(None),
             channels_dst: Set(None),
@@ -1925,8 +1925,8 @@ mod tests {
         let chain_info = chain_info::ActiveModel {
             id: Set(1),
             last_indexed_block: Set(100),
-            last_indexed_tx_index: Set(Some(0)),
-            last_indexed_log_index: Set(Some(0)),
+            last_indexed_tx_index: Set(0),
+            last_indexed_log_index: Set(0),
             ticket_price: Set(None),
             key_binding_fee: Set(Some(starting_fee.to_be_bytes().into())),
             channels_dst: Set(None),

--- a/api/tests/channel_and_chain_api_integration_test.rs
+++ b/api/tests/channel_and_chain_api_integration_test.rs
@@ -122,8 +122,8 @@ async fn setup_chain_info(db: &BlokliDb) -> Result<()> {
     let chain_info = blokli_db_entity::chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(1000),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         ticket_price: Set(Some(vec![0u8; 12])),
         key_binding_fee: Set(Some(vec![0u8; 12])),
         min_incoming_ticket_win_prob: Set(0.5_f64),
@@ -793,8 +793,8 @@ async fn test_chain_info_query_with_null_optional_fields() -> Result<()> {
     let chain_info = blokli_db_entity::chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(500),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         ticket_price: Set(None),                    // NULL
         key_binding_fee: Set(None),                 // NULL
         min_incoming_ticket_win_prob: Set(0.0_f64), // Zero value

--- a/api/tests/channel_and_chain_api_integration_test.rs
+++ b/api/tests/channel_and_chain_api_integration_test.rs
@@ -126,7 +126,7 @@ async fn setup_chain_info(db: &BlokliDb) -> Result<()> {
         last_indexed_log_index: Set(Some(0)),
         ticket_price: Set(Some(vec![0u8; 12])),
         key_binding_fee: Set(Some(vec![0u8; 12])),
-        min_incoming_ticket_win_prob: Set(0.5_f32),
+        min_incoming_ticket_win_prob: Set(0.5_f64),
         channels_dst: Set(Some(vec![1u8; 32])),
         ledger_dst: Set(Some(vec![2u8; 32])),
         safe_registry_dst: Set(Some(vec![3u8; 32])),
@@ -797,7 +797,7 @@ async fn test_chain_info_query_with_null_optional_fields() -> Result<()> {
         last_indexed_log_index: Set(Some(0)),
         ticket_price: Set(None),                    // NULL
         key_binding_fee: Set(None),                 // NULL
-        min_incoming_ticket_win_prob: Set(0.0_f32), // Zero value
+        min_incoming_ticket_win_prob: Set(0.0_f64), // Zero value
         channels_dst: Set(None),                    // NULL
         ledger_dst: Set(None),                      // NULL
         safe_registry_dst: Set(None),               // NULL

--- a/api/tests/channel_graph_subscription_test.rs
+++ b/api/tests/channel_graph_subscription_test.rs
@@ -133,8 +133,8 @@ async fn update_watermark(db: &BlokliDb, block: i64, tx_index: i64, log_index: i
     let chain_info_model = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block),
-        last_indexed_tx_index: Set(Some(tx_index)),
-        last_indexed_log_index: Set(Some(log_index)),
+        last_indexed_tx_index: Set(tx_index),
+        last_indexed_log_index: Set(log_index),
         ticket_price: Set(None),
         channels_dst: Set(None),
         ledger_dst: Set(None),

--- a/api/tests/channel_subscription_test.rs
+++ b/api/tests/channel_subscription_test.rs
@@ -119,8 +119,8 @@ async fn update_watermark(db: &BlokliDb, block: i64, tx_index: i64, log_index: i
     let chain_info_model = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block),
-        last_indexed_tx_index: Set(Some(tx_index)),
-        last_indexed_log_index: Set(Some(log_index)),
+        last_indexed_tx_index: Set(tx_index),
+        last_indexed_log_index: Set(log_index),
         ticket_price: Set(None),
         min_incoming_ticket_win_prob: Set(0.0),
         channels_dst: Set(None),

--- a/api/tests/graphql_readiness_gate_test.rs
+++ b/api/tests/graphql_readiness_gate_test.rs
@@ -62,8 +62,8 @@ async fn update_chain_info_with_current_block(
     let chain_info = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block_number),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         min_incoming_ticket_win_prob: Set(0.0),
         ..Default::default()
     };

--- a/api/tests/health_api_integration_test.rs
+++ b/api/tests/health_api_integration_test.rs
@@ -43,8 +43,8 @@ async fn update_chain_info(db: &DatabaseConnection, block_number: i64) -> anyhow
     let chain_info = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block_number),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         min_incoming_ticket_win_prob: Set(0.0),
         ..Default::default()
     };

--- a/api/tests/sse_keepalive_integration_test.rs
+++ b/api/tests/sse_keepalive_integration_test.rs
@@ -22,8 +22,8 @@ async fn test_sse_keepalive_comments_emitted() -> anyhow::Result<()> {
     let chain_info = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block_number),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         min_incoming_ticket_win_prob: Set(0.0),
         ..Default::default()
     };
@@ -89,8 +89,8 @@ async fn test_sse_keepalive_uuid_identifier_format() -> anyhow::Result<()> {
     let chain_info = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block_number),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         min_incoming_ticket_win_prob: Set(0.0),
         ..Default::default()
     };
@@ -164,8 +164,8 @@ async fn test_sse_identifier_uniqueness() -> anyhow::Result<()> {
     let chain_info = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block_number),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         min_incoming_ticket_win_prob: Set(0.0),
         ..Default::default()
     };
@@ -222,8 +222,8 @@ async fn test_sse_identifier_uniqueness() -> anyhow::Result<()> {
     let chain_info1 = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block_number1),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         min_incoming_ticket_win_prob: Set(0.0),
         ..Default::default()
     };
@@ -233,8 +233,8 @@ async fn test_sse_identifier_uniqueness() -> anyhow::Result<()> {
     let chain_info2 = chain_info::ActiveModel {
         id: Set(1),
         last_indexed_block: Set(block_number2),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
         min_incoming_ticket_win_prob: Set(0.0),
         ..Default::default()
     };

--- a/api/tests/ticket_parameters_subscription_test.rs
+++ b/api/tests/ticket_parameters_subscription_test.rs
@@ -48,8 +48,8 @@ async fn init_chain_info_with_params(
         ledger_dst: Set(None),
         safe_registry_dst: Set(None),
         channel_closure_grace_period: Set(None),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
     };
     chain_info.insert(db).await?;
     Ok(())
@@ -180,8 +180,8 @@ async fn test_ticket_parameters_subscription_handles_missing_ticket_price() {
         ledger_dst: Set(None),
         safe_registry_dst: Set(None),
         channel_closure_grace_period: Set(None),
-        last_indexed_tx_index: Set(Some(0)),
-        last_indexed_log_index: Set(Some(0)),
+        last_indexed_tx_index: Set(0),
+        last_indexed_log_index: Set(0),
     };
     chain_info.insert(db.conn(TargetDb::Index)).await.unwrap();
 

--- a/api/tests/ticket_parameters_subscription_test.rs
+++ b/api/tests/ticket_parameters_subscription_test.rs
@@ -29,7 +29,7 @@ async fn init_chain_info_with_params(
     db: &sea_orm::DatabaseConnection,
     block: i64,
     ticket_price: HoprBalance,
-    min_win_prob: f32,
+    min_win_prob: f64,
 ) -> Result<(), sea_orm::DbErr> {
     // Delete any existing entry first
     ChainInfoEntity::delete_many().exec(db).await?;
@@ -113,7 +113,7 @@ async fn test_ticket_parameters_subscription_emits_initial_values() {
 
     // Initialize chain_info with ticket parameters
     let ticket_price = HoprBalance::from(1000_u64); // 1000 wei
-    let min_win_prob = 0.75_f32;
+    let min_win_prob = 0.0000125_f64;
 
     init_chain_info_with_params(db.conn(TargetDb::Index), 100, ticket_price, min_win_prob)
         .await
@@ -156,7 +156,7 @@ async fn test_ticket_parameters_subscription_emits_initial_values() {
 
     // Verify winning probability
     let prob = params["minTicketWinningProbability"].as_f64().unwrap();
-    assert!((prob - 0.75).abs() < 0.001);
+    assert!((prob - 0.0000125).abs() < 1e-17);
 }
 
 #[tokio::test]

--- a/api/tests/ticket_parameters_subscription_test.rs
+++ b/api/tests/ticket_parameters_subscription_test.rs
@@ -156,7 +156,7 @@ async fn test_ticket_parameters_subscription_emits_initial_values() {
 
     // Verify winning probability
     let prob = params["minTicketWinningProbability"].as_f64().unwrap();
-    assert!((prob - 0.0000125).abs() < 1e-17);
+    assert_eq!(prob, 0.0000125_f64);
 }
 
 #[tokio::test]
@@ -213,7 +213,7 @@ async fn test_ticket_parameters_subscription_handles_missing_ticket_price() {
     // Default to "0 wxHOPR" when ticket_price is None
     assert_eq!(params["ticketPrice"].as_str().unwrap(), "0 wxHOPR");
     let prob = params["minTicketWinningProbability"].as_f64().unwrap();
-    assert!((prob - 0.5).abs() < 0.001);
+    assert_eq!(prob, 0.5_f64);
 }
 
 #[tokio::test]
@@ -253,7 +253,7 @@ async fn test_ticket_parameters_subscription_handles_zero_values() {
 
     assert_eq!(params["ticketPrice"].as_str().unwrap(), "0 wxHOPR");
     let prob = params["minTicketWinningProbability"].as_f64().unwrap();
-    assert!((prob - 0.0).abs() < 0.001);
+    assert_eq!(prob, 0.0_f64);
 }
 
 #[tokio::test]
@@ -294,7 +294,7 @@ async fn test_ticket_parameters_subscription_handles_max_values() {
     // Max u64 value with token identifier
     assert_eq!(params["ticketPrice"].as_str().unwrap(), "18.446744073709551615 wxHOPR");
     let prob = params["minTicketWinningProbability"].as_f64().unwrap();
-    assert!((prob - 1.0).abs() < 0.001);
+    assert_eq!(prob, 1.0_f64);
 }
 
 #[tokio::test]
@@ -335,7 +335,7 @@ async fn test_subscription_receives_ticket_price_update() {
         initial_data["ticketParametersUpdated"]["minTicketWinningProbability"]
             .as_f64()
             .unwrap(),
-        0.5
+        0.5_f64
     );
 
     // Update ticket price in database
@@ -346,7 +346,7 @@ async fn test_subscription_receives_ticket_price_update() {
     // Publish event through IndexerState
     indexer_state.publish_event(IndexerEvent::TicketParametersUpdated(TicketParameters {
         ticket_price: TokenValueString("0.000000000000002 wxHOPR".to_string()),
-        min_ticket_winning_probability: 0.5,
+        min_ticket_winning_probability: 0.5_f64,
     }));
 
     // Should receive update
@@ -365,7 +365,7 @@ async fn test_subscription_receives_ticket_price_update() {
         updated_data["ticketParametersUpdated"]["minTicketWinningProbability"]
             .as_f64()
             .unwrap(),
-        0.5
+        0.5_f64
     );
 }
 
@@ -428,7 +428,7 @@ async fn test_subscription_receives_winning_probability_update() {
     let prob = updated_data["ticketParametersUpdated"]["minTicketWinningProbability"]
         .as_f64()
         .unwrap();
-    assert!((prob - 0.9).abs() < 0.01, "Expected ~0.9, got {}", prob);
+    assert_eq!(prob, 0.9_f64);
     assert_eq!(
         updated_data["ticketParametersUpdated"]["ticketPrice"].as_str().unwrap(),
         "0.000000000000001 wxHOPR"
@@ -491,7 +491,7 @@ async fn test_subscription_receives_both_parameters_update() {
     let prob = updated_data["ticketParametersUpdated"]["minTicketWinningProbability"]
         .as_f64()
         .unwrap();
-    assert!((prob - 0.95).abs() < 0.01, "Expected ~0.95, got {}", prob);
+    assert_eq!(prob, 0.95_f64);
 }
 
 #[tokio::test]
@@ -530,7 +530,7 @@ async fn test_subscription_receives_multiple_updates() {
     // Publish event 1 through IndexerState
     indexer_state.publish_event(IndexerEvent::TicketParametersUpdated(TicketParameters {
         ticket_price: TokenValueString("0.0000000000000002 wxHOPR".to_string()),
-        min_ticket_winning_probability: 0.1,
+        min_ticket_winning_probability: 0.1_f64,
     }));
 
     let update1 = tokio::time::timeout(Duration::from_secs(3), stream.next())
@@ -552,7 +552,7 @@ async fn test_subscription_receives_multiple_updates() {
     // Publish event 2 through IndexerState
     indexer_state.publish_event(IndexerEvent::TicketParametersUpdated(TicketParameters {
         ticket_price: TokenValueString("0.0000000000000003 wxHOPR".to_string()),
-        min_ticket_winning_probability: 0.1,
+        min_ticket_winning_probability: 0.1_f64,
     }));
 
     let update2 = tokio::time::timeout(Duration::from_secs(3), stream.next())

--- a/chain/api/Cargo.toml
+++ b/chain/api/Cargo.toml
@@ -4,7 +4,7 @@ description = "Implements the main HOPR chain interface"
 edition     = "2021"
 license     = "GPL-3.0-only"
 name        = "blokli-chain-api"
-version     = "0.6.1"
+version     = "0.6.2"
 
 [lib]
 crate-type = ["rlib"]

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -86,11 +86,11 @@ impl<T: BlokliDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static>
         indexer_cfg: IndexerConfig,
         rpc_url: String,
     ) -> Result<Self> {
-        // TODO: extract this from the global config type
-        let mut rpc_http_config = blokli_chain_rpc::HttpPostRequestorConfig::default();
-        if let Some(max_rpc_req) = chain_config.max_requests_per_sec {
-            rpc_http_config.max_requests_per_sec = Some(max_rpc_req); // override the default if set
-        }
+        // TODO: extract this from the global config type and use the custom max_requests_per_sec field when set
+        // let mut rpc_http_config = blokli_chain_rpc::HttpPostRequestorConfig::default();
+        // if let Some(max_rpc_req) = chain_config.max_requests_per_sec {
+        //     rpc_http_config.max_requests_per_sec = Some(max_rpc_req); // override the default if set
+        // }
 
         // TODO(#7140): replace this DefaultRetryPolicy with a custom one that computes backoff with the number of
         // retries

--- a/db/core/Cargo.toml
+++ b/db/core/Cargo.toml
@@ -61,7 +61,6 @@ hopr-platform = { workspace = true }
 hopr-types = { workspace = true, features = [
   "crypto",
   "internal",
-  "parallelize",
   "primitive",
 ] }
 

--- a/db/core/Cargo.toml
+++ b/db/core/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-db"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.12.2"
+version     = "0.12.3"
 
 [lints]
 workspace = true

--- a/db/core/src/db.rs
+++ b/db/core/src/db.rs
@@ -188,19 +188,17 @@ impl BlokliDb {
         };
 
         // Apply migrations based on database backend
-        if is_sqlite && logs_db.is_some() {
+        if is_sqlite {
             // For SQLite with dual databases: run separate migrations on each database
             MigratorIndex::<{ SafeDataOrigin::NoData as u8 }>::up(&db, None)
                 .await
                 .map_err(|e| DbSqlError::Construction(format!("cannot apply index migrations: {e}")))?;
 
-            MigratorChainLogs::up(logs_db.as_ref().unwrap(), None)
-                .await
-                .map_err(|e| DbSqlError::Construction(format!("cannot apply logs migrations: {e}")))?;
-        } else if is_sqlite {
-            Migrator::<{ SafeDataOrigin::NoData as u8 }>::up(&db, None)
-                .await
-                .map_err(|e| DbSqlError::Construction(format!("cannot apply migrations: {e}")))?;
+            if let Some(ref logs_database) = logs_db {
+                MigratorChainLogs::up(logs_database, None)
+                    .await
+                    .map_err(|e| DbSqlError::Construction(format!("cannot apply logs migrations: {e}")))?;
+            }
         } else {
             Migrator::<{ SafeDataOrigin::NoData as u8 }>::up(&db, None)
                 .await
@@ -276,7 +274,10 @@ impl BlokliDb {
     /// For SQLite with dual databases, returns the logs database connection.
     /// For PostgreSQL or single-database mode, returns the primary database connection.
     pub(crate) fn logs_db(&self) -> &sea_orm::DatabaseConnection {
-        self.logs_db.as_ref().unwrap_or(&self.db)
+        match self.logs_db.as_ref() {
+            Some(logs_db) => logs_db,
+            None => &self.db,
+        }
     }
 
     /// Initialize ChainInfo singleton entry if it doesn't exist.

--- a/db/core/src/info.rs
+++ b/db/core/src/info.rs
@@ -1,4 +1,4 @@
-// Allow casts for u32 block numbers and f64→f32 precision loss (acceptable for probabilities)
+// Allow casts for u32 block numbers
 #![allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
 
 use async_trait::async_trait;
@@ -215,8 +215,7 @@ impl BlokliDbInfoOperations for BlokliDb {
                             channels_dst,
                             ticket_price: model.ticket_price.map(HoprBalance::from_be_bytes),
                             key_binding_fee: model.key_binding_fee.map(HoprBalance::from_be_bytes),
-                            minimum_incoming_ticket_winning_prob: (model.min_incoming_ticket_win_prob as f64)
-                                .try_into()?,
+                            minimum_incoming_ticket_winning_prob: model.min_incoming_ticket_win_prob.try_into()?,
                             channel_closure_grace_period: model
                                 .channel_closure_grace_period
                                 .and_then(|p| u64::try_from(p).ok()),
@@ -271,7 +270,7 @@ impl BlokliDbInfoOperations for BlokliDb {
                 Box::pin(async move {
                     chain_info::ActiveModel {
                         id: Set(SINGULAR_TABLE_FIXED_ID),
-                        min_incoming_ticket_win_prob: Set(win_prob.as_f64() as f32),
+                        min_incoming_ticket_win_prob: Set(win_prob.as_f64()),
                         ..Default::default()
                     }
                     .update(tx.as_ref())

--- a/db/core/src/version.rs
+++ b/db/core/src/version.rs
@@ -239,8 +239,8 @@ mod tests {
         let chain_info_update = chain_info::ActiveModel {
             id: Set(1),
             last_indexed_block: Set(100),
-            last_indexed_tx_index: Set(Some(5)),
-            last_indexed_log_index: Set(Some(10)),
+            last_indexed_tx_index: Set(5),
+            last_indexed_log_index: Set(10),
             ..Default::default()
         };
         chain_info_update.update(db.conn(crate::TargetDb::Index)).await?;
@@ -282,8 +282,8 @@ mod tests {
             chain_info_after.last_indexed_block, 0,
             "Data should be reset to default"
         );
-        assert_eq!(chain_info_after.last_indexed_tx_index, None);
-        assert_eq!(chain_info_after.last_indexed_log_index, None);
+        assert_eq!(chain_info_after.last_indexed_tx_index, 0);
+        assert_eq!(chain_info_after.last_indexed_log_index, 0);
 
         Ok(())
     }
@@ -334,8 +334,8 @@ mod tests {
         let chain_info_update = chain_info::ActiveModel {
             id: Set(1),
             last_indexed_block: Set(42),
-            last_indexed_tx_index: Set(Some(7)),
-            last_indexed_log_index: Set(Some(3)),
+            last_indexed_tx_index: Set(7),
+            last_indexed_log_index: Set(3),
             ..Default::default()
         };
         chain_info_update.update(db.conn(crate::TargetDb::Index)).await?;
@@ -354,8 +354,8 @@ mod tests {
             .await?
             .unwrap();
         assert_eq!(chain_info_after.last_indexed_block, 42, "Data should be preserved");
-        assert_eq!(chain_info_after.last_indexed_tx_index, Some(7));
-        assert_eq!(chain_info_after.last_indexed_log_index, Some(3));
+        assert_eq!(chain_info_after.last_indexed_tx_index, 7);
+        assert_eq!(chain_info_after.last_indexed_log_index, 3);
 
         Ok(())
     }

--- a/db/core/src/version.rs
+++ b/db/core/src/version.rs
@@ -2,7 +2,7 @@ use blokli_db_entity::prelude::{
     Account, AccountState, Announcement, ChainInfo, Channel, ChannelState, HoprBalance, HoprNodeSafeRegistration,
     HoprSafeContract, HoprSafeContractState, Log, LogStatus, LogTopicInfo, NativeBalance,
 };
-use sea_orm::{ConnectionTrait, DatabaseConnection, EntityTrait, Statement};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, Statement};
 use tracing::{info, warn};
 
 use crate::errors::{DbSqlError, Result};
@@ -135,10 +135,11 @@ async fn clear_all_data(db: &DatabaseConnection, logs_db: Option<&DatabaseConnec
     // Clear logs database data (if separate)
     if let Some(logs_conn) = logs_db {
         clear_logs_data(logs_conn).await?;
-    } else {
+    } else if db.get_database_backend() != DbBackend::Sqlite {
         // PostgreSQL: logs are in the same database
         clear_logs_data(db).await?;
     }
+    // For SQLite without a separate logs database, log tables don't exist — skip
 
     Ok(())
 }

--- a/db/core/src/version.rs
+++ b/db/core/src/version.rs
@@ -138,6 +138,10 @@ async fn clear_all_data(db: &DatabaseConnection, logs_db: Option<&DatabaseConnec
     } else if db.get_database_backend() != DbBackend::Sqlite {
         // PostgreSQL: logs are in the same database
         clear_logs_data(db).await?;
+    } else {
+        tracing::warn!(
+            "Database is SQLite without separate logs database, skipping logs data clear. Should not happen"
+        );
     }
     // For SQLite without a separate logs database, log tables don't exist — skip
 

--- a/db/migration/Cargo.toml
+++ b/db/migration/Cargo.toml
@@ -6,7 +6,7 @@ license     = "GPL-3.0-only"
 name        = "blokli-db-migration"
 publish     = false
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.9.3"
+version     = "0.9.4"
 
 [features]
 default = ["sqlite"]

--- a/db/migration/src/lib.rs
+++ b/db/migration/src/lib.rs
@@ -793,6 +793,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_chain_info_watermark_indices_default_to_zero() {
+        let db = setup_test_db().await;
+        Migrator::<{ SafeDataOrigin::NoData as u8 }>::up(&db, None)
+            .await
+            .unwrap();
+
+        db.execute_raw(Statement::from_string(
+            DbBackend::Sqlite,
+            "DELETE FROM chain_info".to_string(),
+        ))
+        .await
+        .unwrap();
+
+        db.execute_raw(Statement::from_string(
+            DbBackend::Sqlite,
+            "INSERT INTO chain_info (id) VALUES (1)".to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let row = db
+            .query_one_raw(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT last_indexed_tx_index, last_indexed_log_index FROM chain_info WHERE id = 1".to_string(),
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+
+        let tx_index: i64 = row.try_get("", "last_indexed_tx_index").unwrap();
+        let log_index: i64 = row.try_get("", "last_indexed_log_index").unwrap();
+        assert_eq!(tx_index, 0, "last_indexed_tx_index should default to 0");
+        assert_eq!(log_index, 0, "last_indexed_log_index should default to 0");
+    }
+
+    #[tokio::test]
     async fn test_v3_safe_data_migration_rotsee() -> anyhow::Result<()> {
         let db = setup_test_db().await;
         Migrator::<{ SafeDataOrigin::NoData as u8 }>::up(&db, None).await?;

--- a/db/migration/src/lib.rs
+++ b/db/migration/src/lib.rs
@@ -34,6 +34,7 @@ mod m030_migrate_v3_safes;
 mod m031_remove_ticket_params_notify_trigger;
 mod m032_safe_contract_temporal_schema;
 mod m033_update_current_state_views;
+mod m034_alter_chain_info_win_prob_to_double;
 
 /// This is a special block ID that even pre-dates the v3 contract deployment on Gnosis chain,
 /// and therefore could be safely used to mark data added via the migration.
@@ -95,7 +96,8 @@ impl<const NETWORK: u8> Migrator<NETWORK> {
             Box::new(m031_remove_ticket_params_notify_trigger::Migration),
             Box::new(m032_safe_contract_temporal_schema::Migration),
             Box::new(m033_update_current_state_views::Migration),
-            // Note: m030 (safe CSV data) is added by network-specific impls AFTER m033
+            Box::new(m034_alter_chain_info_win_prob_to_double::Migration),
+            // Note: m030 (safe CSV data) is added by network-specific impls AFTER m034
             // because m030 now uses the temporal schema (hopr_safe_contract_state)
         ]
     }
@@ -155,7 +157,8 @@ impl<const NETWORK: u8> MigratorIndex<NETWORK> {
             Box::new(m031_remove_ticket_params_notify_trigger::Migration),
             Box::new(m032_safe_contract_temporal_schema::Migration),
             Box::new(m033_update_current_state_views::Migration),
-            // Note: m030 (safe CSV data) is added by network-specific impls AFTER m033
+            Box::new(m034_alter_chain_info_win_prob_to_double::Migration),
+            // Note: m030 (safe CSV data) is added by network-specific impls AFTER m034
             // because m030 now uses the temporal schema (hopr_safe_contract_state)
         ]
     }

--- a/db/migration/src/m001_create_index_tables.rs
+++ b/db/migration/src/m001_create_index_tables.rs
@@ -198,7 +198,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(ChainInfo::SafeRegistryDST).binary_len(32).null())
                     .col(
                         ColumnDef::new(ChainInfo::MinIncomingTicketWinProb)
-                            .float()
+                            .double()
                             .not_null()
                             .default(DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB),
                     )

--- a/db/migration/src/m001_create_index_tables.rs
+++ b/db/migration/src/m001_create_index_tables.rs
@@ -198,7 +198,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(ChainInfo::SafeRegistryDST).binary_len(32).null())
                     .col(
                         ColumnDef::new(ChainInfo::MinIncomingTicketWinProb)
-                            .double()
+                            .float()
                             .not_null()
                             .default(DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB),
                     )

--- a/db/migration/src/m021_clear_index_data.rs
+++ b/db/migration/src/m021_clear_index_data.rs
@@ -101,7 +101,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(ChainInfo::SafeRegistryDST).binary_len(32).null())
                     .col(
                         ColumnDef::new(ChainInfo::MinIncomingTicketWinProb)
-                            .double()
+                            .float()
                             .not_null()
                             .default(1.0),
                     )

--- a/db/migration/src/m021_clear_index_data.rs
+++ b/db/migration/src/m021_clear_index_data.rs
@@ -101,7 +101,7 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(ChainInfo::SafeRegistryDST).binary_len(32).null())
                     .col(
                         ColumnDef::new(ChainInfo::MinIncomingTicketWinProb)
-                            .float()
+                            .double()
                             .not_null()
                             .default(1.0),
                     )

--- a/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
+++ b/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
@@ -56,6 +56,24 @@ FROM chain_info_old;
 DROP TABLE chain_info_old;
 ";
 
+const POSTGRES_UP_WATERMARK_INDEX_NORMALIZATION: &str = "
+UPDATE chain_info
+SET
+    last_indexed_tx_index = COALESCE(last_indexed_tx_index, 0),
+    last_indexed_log_index = COALESCE(last_indexed_log_index, 0);
+ALTER TABLE chain_info ALTER COLUMN last_indexed_tx_index SET DEFAULT 0;
+ALTER TABLE chain_info ALTER COLUMN last_indexed_log_index SET DEFAULT 0;
+ALTER TABLE chain_info ALTER COLUMN last_indexed_tx_index SET NOT NULL;
+ALTER TABLE chain_info ALTER COLUMN last_indexed_log_index SET NOT NULL;
+";
+
+const POSTGRES_DOWN_WATERMARK_INDEX_NORMALIZATION: &str = "
+ALTER TABLE chain_info ALTER COLUMN last_indexed_tx_index DROP NOT NULL;
+ALTER TABLE chain_info ALTER COLUMN last_indexed_log_index DROP NOT NULL;
+ALTER TABLE chain_info ALTER COLUMN last_indexed_tx_index DROP DEFAULT;
+ALTER TABLE chain_info ALTER COLUMN last_indexed_log_index DROP DEFAULT;
+";
+
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -127,6 +145,14 @@ impl MigrationTrait for Migration {
                 .await?;
         }
 
+        for statement in POSTGRES_UP_WATERMARK_INDEX_NORMALIZATION
+            .trim()
+            .split(';')
+            .filter(|s| !s.trim().is_empty())
+        {
+            db.execute_unprepared(statement.trim()).await?;
+        }
+
         Ok(())
     }
 
@@ -195,6 +221,14 @@ impl MigrationTrait for Migration {
                         .to_owned(),
                 )
                 .await?;
+        }
+
+        for statement in POSTGRES_DOWN_WATERMARK_INDEX_NORMALIZATION
+            .trim()
+            .split(';')
+            .filter(|s| !s.trim().is_empty())
+        {
+            db.execute_unprepared(statement.trim()).await?;
         }
 
         Ok(())

--- a/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
+++ b/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
@@ -1,4 +1,3 @@
-use hopr_types::internal::prelude::DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -18,44 +17,8 @@ impl MigrationTrait for Migration {
                     .await?;
             }
             sea_orm::DatabaseBackend::Sqlite => {
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "CREATE TABLE chain_info_min_incoming_ticket_win_prob_backup (id INTEGER PRIMARY KEY, \
-                         min_incoming_ticket_win_prob FLOAT)",
-                    )
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "INSERT INTO chain_info_min_incoming_ticket_win_prob_backup (id, \
-                         min_incoming_ticket_win_prob) SELECT id, min_incoming_ticket_win_prob FROM chain_info",
-                    )
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared("ALTER TABLE chain_info DROP COLUMN min_incoming_ticket_win_prob")
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared(&format!(
-                        "ALTER TABLE chain_info ADD COLUMN min_incoming_ticket_win_prob DOUBLE NOT NULL DEFAULT {}",
-                        DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB
-                    ))
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "UPDATE chain_info SET min_incoming_ticket_win_prob = (SELECT \
-                         CAST(min_incoming_ticket_win_prob AS REAL) FROM \
-                         chain_info_min_incoming_ticket_win_prob_backup WHERE \
-                         chain_info_min_incoming_ticket_win_prob_backup.id = chain_info.id)",
-                    )
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared("DROP TABLE chain_info_min_incoming_ticket_win_prob_backup")
-                    .await?;
+                // SQLite stores all floating point values as 64-bit IEEE 754 REAL internally,
+                // regardless of the declared column type (FLOAT or DOUBLE). No schema change needed.
             }
             _ => {}
         }
@@ -75,44 +38,7 @@ impl MigrationTrait for Migration {
                     .await?;
             }
             sea_orm::DatabaseBackend::Sqlite => {
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "CREATE TABLE chain_info_min_incoming_ticket_win_prob_backup (id INTEGER PRIMARY KEY, \
-                         min_incoming_ticket_win_prob DOUBLE)",
-                    )
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "INSERT INTO chain_info_min_incoming_ticket_win_prob_backup (id, \
-                         min_incoming_ticket_win_prob) SELECT id, min_incoming_ticket_win_prob FROM chain_info",
-                    )
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared("ALTER TABLE chain_info DROP COLUMN min_incoming_ticket_win_prob")
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared(&format!(
-                        "ALTER TABLE chain_info ADD COLUMN min_incoming_ticket_win_prob FLOAT NOT NULL DEFAULT {}",
-                        DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB
-                    ))
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "UPDATE chain_info SET min_incoming_ticket_win_prob = (SELECT \
-                         CAST(min_incoming_ticket_win_prob AS REAL) FROM \
-                         chain_info_min_incoming_ticket_win_prob_backup WHERE \
-                         chain_info_min_incoming_ticket_win_prob_backup.id = chain_info.id)",
-                    )
-                    .await?;
-                manager
-                    .get_connection()
-                    .execute_unprepared("DROP TABLE chain_info_min_incoming_ticket_win_prob_backup")
-                    .await?;
+                // SQLite: No change needed (see up() comments)
             }
             _ => {}
         }

--- a/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
+++ b/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
@@ -1,3 +1,4 @@
+use sea_orm::ConnectionTrait;
 use sea_orm_migration::prelude::*;
 
 #[derive(DeriveMigrationName)]
@@ -6,43 +7,134 @@ pub struct Migration;
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        match manager.get_database_backend() {
-            sea_orm::DatabaseBackend::Postgres => {
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "ALTER TABLE chain_info ALTER COLUMN min_incoming_ticket_win_prob TYPE DOUBLE PRECISION USING \
-                         min_incoming_ticket_win_prob::double precision",
+        let db = manager.get_connection();
+
+        // 1. Read current values before dropping the column
+        let select = Query::select()
+            .columns([ChainInfo::Id, ChainInfo::MinIncomingTicketWinProb])
+            .from(ChainInfo::Table)
+            .to_owned();
+
+        let rows = db.query_all(&select).await?;
+
+        let mut values: Vec<(i64, f64)> = Vec::new();
+        for row in rows {
+            let id: i64 = row.try_get("", "id")?;
+            let win_prob: f64 = row.try_get("", "min_incoming_ticket_win_prob")?;
+            values.push((id, win_prob));
+        }
+
+        // 2. Drop the old float column
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ChainInfo::Table)
+                    .drop_column(ChainInfo::MinIncomingTicketWinProb)
+                    .to_owned(),
+            )
+            .await?;
+
+        // 3. Add it back as double
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ChainInfo::Table)
+                    .add_column(
+                        ColumnDef::new(ChainInfo::MinIncomingTicketWinProb)
+                            .double()
+                            .not_null()
+                            .default(1.0),
                     )
-                    .await?;
-            }
-            sea_orm::DatabaseBackend::Sqlite => {
-                // SQLite stores all floating point values as 64-bit IEEE 754 REAL internally,
-                // regardless of the declared column type (FLOAT or DOUBLE). No schema change needed.
-            }
-            _ => {}
+                    .to_owned(),
+            )
+            .await?;
+
+        // 4. Restore values
+        for (id, win_prob) in values {
+            manager
+                .exec_stmt(
+                    Query::update()
+                        .table(ChainInfo::Table)
+                        .value(ChainInfo::MinIncomingTicketWinProb, win_prob)
+                        .and_where(Expr::col(ChainInfo::Id).eq(id))
+                        .to_owned(),
+                )
+                .await?;
         }
 
         Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        match manager.get_database_backend() {
-            sea_orm::DatabaseBackend::Postgres => {
-                manager
-                    .get_connection()
-                    .execute_unprepared(
-                        "ALTER TABLE chain_info ALTER COLUMN min_incoming_ticket_win_prob TYPE REAL USING \
-                         min_incoming_ticket_win_prob::real",
+        let db = manager.get_connection();
+
+        // 1. Read current values before dropping the column
+        let select = Query::select()
+            .columns([ChainInfo::Id, ChainInfo::MinIncomingTicketWinProb])
+            .from(ChainInfo::Table)
+            .to_owned();
+
+        let rows = db.query_all(&select).await?;
+
+        let mut values: Vec<(i64, f64)> = Vec::new();
+        for row in rows {
+            let id: i64 = row.try_get("", "id")?;
+            let win_prob: f64 = row.try_get("", "min_incoming_ticket_win_prob")?;
+            values.push((id, win_prob));
+        }
+
+        // 2. Drop the double column
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ChainInfo::Table)
+                    .drop_column(ChainInfo::MinIncomingTicketWinProb)
+                    .to_owned(),
+            )
+            .await?;
+
+        // 3. Add it back as float
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ChainInfo::Table)
+                    .add_column(
+                        ColumnDef::new(ChainInfo::MinIncomingTicketWinProb)
+                            .float()
+                            .not_null()
+                            .default(1.0),
                     )
-                    .await?;
-            }
-            sea_orm::DatabaseBackend::Sqlite => {
-                // SQLite: No change needed (see up() comments)
-            }
-            _ => {}
+                    .to_owned(),
+            )
+            .await?;
+
+        // 4. Restore values (precision may be reduced from f64 to f32)
+        for (id, win_prob) in values {
+            manager
+                .exec_stmt(
+                    Query::update()
+                        .table(ChainInfo::Table)
+                        .value(ChainInfo::MinIncomingTicketWinProb, win_prob)
+                        .and_where(Expr::col(ChainInfo::Id).eq(id))
+                        .to_owned(),
+                )
+                .await?;
         }
 
         Ok(())
     }
+}
+
+#[derive(DeriveIden)]
+#[allow(dead_code)]
+enum ChainInfo {
+    Table,
+    Id,
+    LastIndexedBlock,
+    TicketPrice,
+    ChannelsDST,
+    LedgerDST,
+    SafeRegistryDST,
+    MinIncomingTicketWinProb,
+    ChannelClosureGracePeriod,
 }

--- a/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
+++ b/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
@@ -4,10 +4,75 @@ use sea_orm_migration::prelude::*;
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
+/// SQLite table recreation SQL for `up`: changes min_incoming_ticket_win_prob from float to double.
+///
+/// SQLite does not support ALTER COLUMN, and DROP COLUMN + ADD COLUMN fails silently
+/// due to interactions between sqlx's foreign_keys pragma and statement caching.
+/// The workaround is to recreate the table with the desired schema.
+const SQLITE_UP: &str = "
+ALTER TABLE chain_info RENAME TO chain_info_old;
+CREATE TABLE chain_info (
+    id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    last_indexed_block integer NOT NULL DEFAULT 0,
+    ticket_price blob(12),
+    channels_dst blob(32),
+    ledger_dst blob(32),
+    safe_registry_dst blob(32),
+    min_incoming_ticket_win_prob double NOT NULL DEFAULT 1.0,
+    channel_closure_grace_period integer,
+    last_indexed_tx_index integer NOT NULL DEFAULT 0,
+    last_indexed_log_index integer NOT NULL DEFAULT 0,
+    key_binding_fee blob(12)
+);
+INSERT INTO chain_info SELECT
+    id, last_indexed_block, ticket_price, channels_dst, ledger_dst, safe_registry_dst,
+    min_incoming_ticket_win_prob, channel_closure_grace_period,
+    last_indexed_tx_index, last_indexed_log_index, key_binding_fee
+FROM chain_info_old;
+DROP TABLE chain_info_old;
+";
+
+/// SQLite table recreation SQL for `down`: changes min_incoming_ticket_win_prob from double to float.
+const SQLITE_DOWN: &str = "
+ALTER TABLE chain_info RENAME TO chain_info_old;
+CREATE TABLE chain_info (
+    id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    last_indexed_block integer NOT NULL DEFAULT 0,
+    ticket_price blob(12),
+    channels_dst blob(32),
+    ledger_dst blob(32),
+    safe_registry_dst blob(32),
+    min_incoming_ticket_win_prob float NOT NULL DEFAULT 1.0,
+    channel_closure_grace_period integer,
+    last_indexed_tx_index integer NOT NULL DEFAULT 0,
+    last_indexed_log_index integer NOT NULL DEFAULT 0,
+    key_binding_fee blob(12)
+);
+INSERT INTO chain_info SELECT
+    id, last_indexed_block, ticket_price, channels_dst, ledger_dst, safe_registry_dst,
+    min_incoming_ticket_win_prob, channel_closure_grace_period,
+    last_indexed_tx_index, last_indexed_log_index, key_binding_fee
+FROM chain_info_old;
+DROP TABLE chain_info_old;
+";
+
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let db = manager.get_connection();
+
+        if matches!(db.get_database_backend(), sea_orm::DatabaseBackend::Sqlite) {
+            // Temporarily disable foreign keys so DROP TABLE works reliably.
+            // sqlx sets PRAGMA foreign_keys = ON which can interfere with table operations.
+            db.execute_unprepared("PRAGMA foreign_keys = OFF").await?;
+            for statement in SQLITE_UP.trim().split(';').filter(|s| !s.trim().is_empty()) {
+                db.execute_unprepared(statement.trim()).await?;
+            }
+            db.execute_unprepared("PRAGMA foreign_keys = ON").await?;
+            return Ok(());
+        }
+
+        // PostgreSQL: DROP COLUMN + ADD COLUMN with value preservation.
 
         // 1. Read current values before dropping the column
         let select = Query::select()
@@ -67,6 +132,17 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let db = manager.get_connection();
+
+        if matches!(db.get_database_backend(), sea_orm::DatabaseBackend::Sqlite) {
+            db.execute_unprepared("PRAGMA foreign_keys = OFF").await?;
+            for statement in SQLITE_DOWN.trim().split(';').filter(|s| !s.trim().is_empty()) {
+                db.execute_unprepared(statement.trim()).await?;
+            }
+            db.execute_unprepared("PRAGMA foreign_keys = ON").await?;
+            return Ok(());
+        }
+
+        // PostgreSQL: DROP COLUMN + ADD COLUMN with value preservation.
 
         // 1. Read current values before dropping the column
         let select = Query::select()

--- a/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
+++ b/db/migration/src/m034_alter_chain_info_win_prob_to_double.rs
@@ -1,0 +1,122 @@
+use hopr_types::internal::prelude::DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            sea_orm::DatabaseBackend::Postgres => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "ALTER TABLE chain_info ALTER COLUMN min_incoming_ticket_win_prob TYPE DOUBLE PRECISION USING \
+                         min_incoming_ticket_win_prob::double precision",
+                    )
+                    .await?;
+            }
+            sea_orm::DatabaseBackend::Sqlite => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "CREATE TABLE chain_info_min_incoming_ticket_win_prob_backup (id INTEGER PRIMARY KEY, \
+                         min_incoming_ticket_win_prob FLOAT)",
+                    )
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "INSERT INTO chain_info_min_incoming_ticket_win_prob_backup (id, \
+                         min_incoming_ticket_win_prob) SELECT id, min_incoming_ticket_win_prob FROM chain_info",
+                    )
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared("ALTER TABLE chain_info DROP COLUMN min_incoming_ticket_win_prob")
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared(&format!(
+                        "ALTER TABLE chain_info ADD COLUMN min_incoming_ticket_win_prob DOUBLE NOT NULL DEFAULT {}",
+                        DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB
+                    ))
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "UPDATE chain_info SET min_incoming_ticket_win_prob = (SELECT \
+                         CAST(min_incoming_ticket_win_prob AS REAL) FROM \
+                         chain_info_min_incoming_ticket_win_prob_backup WHERE \
+                         chain_info_min_incoming_ticket_win_prob_backup.id = chain_info.id)",
+                    )
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared("DROP TABLE chain_info_min_incoming_ticket_win_prob_backup")
+                    .await?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        match manager.get_database_backend() {
+            sea_orm::DatabaseBackend::Postgres => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "ALTER TABLE chain_info ALTER COLUMN min_incoming_ticket_win_prob TYPE REAL USING \
+                         min_incoming_ticket_win_prob::real",
+                    )
+                    .await?;
+            }
+            sea_orm::DatabaseBackend::Sqlite => {
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "CREATE TABLE chain_info_min_incoming_ticket_win_prob_backup (id INTEGER PRIMARY KEY, \
+                         min_incoming_ticket_win_prob DOUBLE)",
+                    )
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "INSERT INTO chain_info_min_incoming_ticket_win_prob_backup (id, \
+                         min_incoming_ticket_win_prob) SELECT id, min_incoming_ticket_win_prob FROM chain_info",
+                    )
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared("ALTER TABLE chain_info DROP COLUMN min_incoming_ticket_win_prob")
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared(&format!(
+                        "ALTER TABLE chain_info ADD COLUMN min_incoming_ticket_win_prob FLOAT NOT NULL DEFAULT {}",
+                        DEFAULT_MINIMUM_INCOMING_TICKET_WIN_PROB
+                    ))
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared(
+                        "UPDATE chain_info SET min_incoming_ticket_win_prob = (SELECT \
+                         CAST(min_incoming_ticket_win_prob AS REAL) FROM \
+                         chain_info_min_incoming_ticket_win_prob_backup WHERE \
+                         chain_info_min_incoming_ticket_win_prob_backup.id = chain_info.id)",
+                    )
+                    .await?;
+                manager
+                    .get_connection()
+                    .execute_unprepared("DROP TABLE chain_info_min_incoming_ticket_win_prob_backup")
+                    .await?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}

--- a/design/target-db-schema.mmd
+++ b/design/target-db-schema.mmd
@@ -82,7 +82,7 @@ erDiagram
         binary(32) channels_dst "Channels destination"
         binary(32) ledger_dst "Ledger destination"
         binary(32) safe_registry_dst "Safe registry destination"
-        float min_incoming_ticket_win_prob "Min incoming ticket win probability"
+        double min_incoming_ticket_win_prob "Min incoming ticket win probability"
         bigint channel_closure_grace_period "Channel closure grace period in seconds (NULL)"
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1769737823,
-        "narHash": "sha256-DrBaNpZ+sJ4stXm+0nBX7zqZT9t9P22zbk6m5YhQxS4=",
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b2f45c3830aa96b7456a4c4bc327d04d7a43e1ba",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -143,11 +143,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769757415,
-        "narHash": "sha256-zuTcJSRun6JTM45mVsmNo3mU7mY4IW+w2UqTqsBTkAQ=",
+        "lastModified": 1773213477,
+        "narHash": "sha256-Pv1Z3QqGkSGEUV+9pM5vYIiI7VJo7Tfm6ZmR+JSp1zo=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "61da93df373693917db26418e40037a14f8c03bf",
+        "rev": "3c73daa86c823d706824fd9bbcb85aa23fd0f668",
         "type": "github"
       },
       "original": {
@@ -209,11 +209,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769741972,
-        "narHash": "sha256-RxSg1EioTWNpoLaykiT1UQKTo/K0PPdLqCyQgNjNqWs=",
+        "lastModified": 1773240384,
+        "narHash": "sha256-Q6pELKXlzuB9IdJxniNiMEpR+ws431OhwSR9su9WFx4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63590ac958a8af30ebd52c7a0309d8c52a94dd77",
+        "rev": "ca3ba3dee4060bc17c72673fbed3cbe3573bb89a",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1769461804,
-        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
         "type": "github"
       },
       "original": {
@@ -279,11 +279,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769069492,
-        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "lastModified": 1772893680,
+        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773025773,
-        "narHash": "sha256-Wik8+xApNfldpUFjPmJkPdg0RrvUPSWGIZis+A/0N1w=",
+        "lastModified": 1773216618,
+        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3c06fdbbd36ff60386a1e590ee0cd52dcd1892bf",
+        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
         "type": "github"
       },
       "original": {
@@ -335,11 +335,11 @@
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1768831671,
-        "narHash": "sha256-0mmlYRtZK+eomevkQCCH7PL8QlSuALZQsjLroCWGE08=",
+        "lastModified": 1772085240,
+        "narHash": "sha256-+NEcuhT2A0QQumVx9Ze6g2iuNicyuW028Jq/HUJHGh4=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "80ad871b93d15c7bccf71617f78f73c2d291a9c7",
+        "rev": "d3cc119973e484ea366f4b997b404bb00d7829ca",
         "type": "github"
       },
       "original": {
@@ -351,13 +351,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-P+ZslplK4cQ/wnV/wykVKb+yTCviI0eylA3sk9uHmRo=",
+        "narHash": "sha256-oEiXc95EghuYCudzkPA9XBFOnMdgWFfTO2/4XUfSTpc=",
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/a11f1ad/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/a11f1ad/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769742225,
-        "narHash": "sha256-roSD/OJ3x9nF+Dxr+/bLClX3U8FP9EkCQIFpzxKjSUM=",
+        "lastModified": 1773025773,
+        "narHash": "sha256-Wik8+xApNfldpUFjPmJkPdg0RrvUPSWGIZis+A/0N1w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bcdd8d37594f0e201639f55889c01c827baf5c75",
+        "rev": "3c06fdbbd36ff60386a1e590ee0cd52dcd1892bf",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.91"
+channel    = "1.93"
 components = ["cargo", "clippy", "rust-src"]
 profile    = "default"


### PR DESCRIPTION
The rounding issue visible in the redeemed ticket actually comes from how blokli stores the value coming from onchain. 
Stored as `f32` the value is rounded to some decimals creating artifacts in the value. Storing as `f64` is cleaner and reduces the approximation.

By updating the rust toolchain to 1.93, some additional warnings were raised by clippy. One of them is that the RPC rate limiting config parameter is not used. Opened an issue to address that #266 and commented out the piece of code until fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped API to 0.16.3, DB core to 0.12.3, migration crate to 0.9.4, chain API to 0.6.2
  * Updated Rust toolchain to 1.93

* **Database Migrations**
  * Added migration to convert chain_info.min_incoming_ticket_win_prob from float to double (higher precision)
  * Updated migration sequencing to include the new step

* **Behavior**
  * Improved SQLite handling for migrations and logs to avoid unintended operations
  * Removed a default RPC requestor override in chain API

* **Tests**
  * Updated tests and fixtures to use higher-precision values for min incoming ticket win probability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->