### PR TITLE
fix(ci): add merge coverage and update tests to worflow-tests-v2

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -133,7 +133,7 @@ jobs:
   coverage:
     name: Coverage
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # worflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       unit_tests: false

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -130,6 +130,22 @@ jobs:
           image: europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid:${{ needs.build-docker.outputs.docker_build_version }}
           suffix: ${{ steps.revision.outputs.suffix }}
           flags: --timeout=600s
+  coverage:
+    name: Coverage
+    if: github.event.pull_request.merged == true
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@12c56020e16036982e6cc529848edeedfc705865 # worflow-tests-v2
+    with:
+      source_branch: ${{ github.event.pull_request.base.ref }}
+      unit_tests: false
+      integration_tests: false
+      coverage: true
+      unconditional: true
+      unit_coverage_command: "nix run .#coverage-unit"
+      integration_coverage_command: "touch coverage.lcov"
+      runner: self-hosted-hoprnet-bigger
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   notify:
     name: Notify failure
     needs:
@@ -137,6 +153,7 @@ jobs:
       - build-docker
       - build-docker-with-anvil
       - deploy-dev
+      - coverage
     if: ${{ always() && failure() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -153,7 +153,7 @@ jobs:
       - build-docker-with-anvil
       - deploy-dev
       - coverage
-    if: ${{ always() && failure() }}
+    if: ${{ always() && github.event.pull_request.merged == true && !success() }}
     runs-on: ubuntu-latest
     steps:
       - name: Notify failed merge pipeline

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -133,15 +133,14 @@ jobs:
   coverage:
     name: Coverage
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@12c56020e16036982e6cc529848edeedfc705865 # worflow-tests-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # worflow-tests-v3
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       unit_tests: false
       integration_tests: false
-      coverage: true
+      unit_coverage: true
       unconditional: true
       unit_coverage_command: "nix run .#coverage-unit"
-      integration_coverage_command: "touch coverage.lcov"
       runner: self-hosted-hoprnet-bigger
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -95,7 +95,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@bbd22e57cf954c15f0a6051d59329857809141dd # workflow-tests-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@12c56020e16036982e6cc529848edeedfc705865 # worflow-tests-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -95,7 +95,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # worflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -95,12 +95,12 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@12c56020e16036982e6cc529848edeedfc705865 # worflow-tests-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # worflow-tests-v3
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true
       unit_test_command: "nix run -L .#test"
-      coverage: true
+      unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
       runner: self-hosted-hoprnet-bigger
       test_timeout: 30


### PR DESCRIPTION
## Summary

- Update tests workflow to workflow-tests-v3 in PR.yaml with explicit `unit_coverage` toggle
- Add unconditional coverage job to merge.yaml for post-merge coverage on main
- Add coverage to notify job dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code coverage tracking and reporting for merged pull requests to enhance code quality assurance, measurement, and overall development standards across the entire codebase.
  * Updated GitHub Actions workflow configurations including updated workflow reference versions and refined test input parameter mappings to improve and optimize continuous integration and testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->