### PR TITLE
feat(ci): add branches workflow for coverage on push

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -1,0 +1,30 @@
+---
+name: Branches
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: branches-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  coverage:
+    name: Coverage
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
+    with:
+      source_branch: ${{ github.ref_name }}
+      unit_tests: false
+      integration_tests: false
+      unit_coverage: true
+      unconditional: true
+      unit_coverage_command: "nix run .#coverage-unit"
+      runner: self-hosted-hoprnet-bigger
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -131,21 +131,6 @@ jobs:
           image: europe-west3-docker.pkg.dev/hoprassociation/docker-images/bloklid:${{ needs.build-docker.outputs.docker_build_version }}
           suffix: ${{ steps.revision.outputs.suffix }}
           flags: --timeout=600s
-  coverage:
-    name: Coverage
-    if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
-    with:
-      source_branch: ${{ github.event.pull_request.base.ref }}
-      unit_tests: false
-      integration_tests: false
-      unit_coverage: true
-      unconditional: true
-      unit_coverage_command: "nix run .#coverage-unit"
-      runner: self-hosted-hoprnet-bigger
-    secrets:
-      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   notify:
     name: Notify failure
     needs:
@@ -153,7 +138,6 @@ jobs:
       - build-docker
       - build-docker-with-anvil
       - deploy-dev
-      - coverage
     if: ${{ always() && github.event.pull_request.merged == true && !success() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds `branches.yaml` workflow triggered on push to `main` to run code coverage
- Removes the coverage job from `merge.yaml` (except hoprnet which had none)
- Codecov will now correctly attribute coverage to the merge commit on the default branch instead of the last PR commit
- Fixes hoprnet/gitops#340