### PR TITLE
fix: resolve safe redeem stats initialization and bump version to 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.23.2"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-client"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.23.1"
+version     = "0.23.2"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-client"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.23.0"
+version     = "0.23.1"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-client"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.23.2"
+version     = "0.23.1"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -499,30 +499,32 @@ impl<M: BlokliTestStateMutator + Send + Sync> BlokliQueryClient for BlokliTestCl
     }
 
     async fn query_redeemed_stats(&self, selector: RedeemedStatsSelector) -> Result<RedeemedStats> {
-        let state = self.state.read();
+        let state = self.state.upgradable_read();
 
         let maybe_safe = match selector {
             RedeemedStatsSelector::SafeAddress(addr) => Some(addr),
             RedeemedStatsSelector::SafeAndNodeAddress { safe_address, .. } => Some(safe_address),
             RedeemedStatsSelector::NodeAddress(_) => None,
         };
+
         if let Some(safe_address) = maybe_safe {
             let safe_address_hex = hex::encode(safe_address);
             if !state.deployed_safes.contains_key(&safe_address_hex) {
                 return Err(ErrorKind::NoData.into());
             }
 
-            Ok(self
-                .state
-                .read()
-                .safe_redeem_stats
-                .entry(safe_address_hex.clone())
-                .or_insert_with(|| RedeemedStats {
+            if let Some(v) = state.safe_redeem_stats.get(&safe_address_hex) {
+                Ok(v.clone())
+            } else {
+                let mut state = parking_lot::RwLockUpgradableReadGuard::upgrade(state);
+                let stats = RedeemedStats {
                     __typename: "RedeemedStats".to_string(),
                     redeemed_amount: TokenValueString("0 wxHOPR".into()),
                     redemption_count: Uint64("0".into()),
-                })
-                .clone())
+                };
+                state.safe_redeem_stats.insert(safe_address_hex, stats.clone());
+                Ok(stats)
+            }
         } else {
             Err(ErrorKind::NoData.into())
         }

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -516,15 +516,15 @@ impl<M: BlokliTestStateMutator + Send + Sync> BlokliQueryClient for BlokliTestCl
                 .state
                 .read()
                 .safe_redeem_stats
-                .get(&safe_address_hex)
-                .cloned()
-                .ok_or(ErrorKind::NoData)?)
+                .entry(safe_address_hex.clone())
+                .or_insert_with(|| RedeemedStats {
+                    __typename: "RedeemedStats".to_string(),
+                    redeemed_amount: TokenValueString("0 wxHOPR".into()),
+                    redemption_count: Uint64("0".into()),
+                })
+                .clone())
         } else {
-            Ok(RedeemedStats {
-                __typename: "RedeemedStats".to_string(),
-                redeemed_amount: TokenValueString("0 wxHOPR".into()),
-                redemption_count: Uint64("0".into()),
-            })
+            Err(ErrorKind::NoData.into())
         }
     }
 


### PR DESCRIPTION
The testing client redeem stats initialization was incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.23.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->