### PR TITLE
feat: Add nix build blokli-inspector

### DIFF
--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -41,6 +41,15 @@ in
     }
   );
 
+  # Blokli inspector
+  blokli-inspector = builders.local.callPackage nixLib.mkRustPackage {
+    inherit rev;
+    src = sources.main;
+    depsSrc = sources.deps;
+    cargoToml = ./../../inspector/Cargo.toml;
+    cargoExtraArgs = "--bins";
+  };
+
   # Production builds - optimized for deployment
   # x86_64 Linux builds with static linking for maximum portability
   binary-blokli-x86_64-linux =

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -334,7 +334,6 @@ async fn subscribe_ticket_params(#[future(awt)] fixture: IntegrationFixture) -> 
         )
         .await?;
 
-
     // wait for the latest ticket param update
     let deadline = Instant::now() + Duration::from_secs(subscription_timeout().as_secs());
     let mut latest_output = None;


### PR DESCRIPTION
Adds a nix pacakge to build specifically `blokli-inspector`
User can now run this command:
`nix build .#blokli-inspector`