### PR TITLE
fix: retrieve only latest multiaddress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -397,7 +397,7 @@ dependencies = [
  "alloy-signer-local",
  "k256",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -424,7 +424,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -612,7 +612,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
 ]
 
@@ -1028,7 +1028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1048,7 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1828,7 +1828,7 @@ dependencies = [
  "insta",
  "multiaddr",
  "pem-rfc7468 1.0.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "rustls",
  "sea-orm",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api-types"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-graphql",
  "blokli-chain-types",
@@ -1880,7 +1880,7 @@ dependencies = [
  "hopr-bindings",
  "hopr-types",
  "insta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2007,7 +2007,7 @@ dependencies = [
  "launchdarkly-sdk-transport",
  "mockito",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2034,7 +2034,7 @@ dependencies = [
  "hopr-types",
  "lazy_static",
  "multiaddr",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sea-orm",
  "sea-query",
  "semver 1.0.27",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-db-entity"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "blokli-db-migration",
@@ -2122,7 +2122,7 @@ dependencies = [
  "hopr-types",
  "insta",
  "libc",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "rstest",
  "semver 1.0.27",
@@ -2603,15 +2603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,7 +2950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3333,7 +3324,7 @@ dependencies = [
  "launchdarkly-sdk-transport",
  "log",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -3414,7 +3405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -4000,7 +3991,7 @@ version = "1.2.0"
 source = "git+https://github.com/hoprnet/hopr-types?branch=main#c5a65c8c020748718e1b74d930ec21fe6dfd5f2e"
 dependencies = [
  "generic-array 1.3.5",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -4797,7 +4788,7 @@ dependencies = [
  "hkdf",
  "multihash",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "thiserror 2.0.18",
@@ -5055,7 +5046,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -5133,11 +5124,11 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "core2",
+ "no_std_io2",
  "unsigned-varint",
 ]
 
@@ -5169,6 +5160,15 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5210,7 +5210,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -5913,7 +5913,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -6006,9 +6006,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6018,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6029,9 +6029,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -6452,8 +6452,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -6497,7 +6497,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -6571,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6898,7 +6898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -6910,7 +6910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -7436,7 +7436,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -7478,7 +7478,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -7726,7 +7726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8213,7 +8213,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.19.0"
+version     = "0.19.1"
 
 [lints]
 workspace = true

--- a/api/tests/account_api_integration_test.rs
+++ b/api/tests/account_api_integration_test.rs
@@ -474,6 +474,68 @@ async fn test_accounts_query_with_multiaddresses() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_accounts_query_returns_only_latest_multiaddress() -> anyhow::Result<()> {
+    let db = BlokliDb::new_in_memory().await?;
+
+    let keypair = random_keypair();
+    let offchain = random_offchain_keypair();
+    let chain_key = keypair.public().to_address();
+    let packet_key = offchain.public();
+
+    db.upsert_account(None, 1, chain_key, *packet_key, None, 100, 0, 0)
+        .await?;
+
+    let first_multiaddr_str = "/ip4/127.0.0.1/tcp/9091";
+    let second_multiaddr_str = "/ip4/127.0.0.1/tcp/9092";
+    let first_multiaddr: Multiaddr = first_multiaddr_str.parse().unwrap();
+    let second_multiaddr: Multiaddr = second_multiaddr_str.parse().unwrap();
+
+    db.insert_announcement(None, chain_key, first_multiaddr, 101).await?;
+    db.insert_announcement(None, chain_key, second_multiaddr, 102).await?;
+
+    let schema = async_graphql::Schema::build(
+        QueryRoot,
+        async_graphql::EmptyMutation,
+        async_graphql::EmptySubscription,
+    )
+    .data(db.conn(TargetDb::Index).clone())
+    .data(ContractAddresses::default())
+    .data(ChainId(100))
+    .data(NetworkName("test".to_string()))
+    .data(blokli_api::schema::GasMultiplier(1.0))
+    .finish();
+
+    let query = r#"
+        query {
+            accounts(keyid: 1) {
+                __typename
+                ... on AccountsList {
+                    accounts {
+                        keyid
+                        multiAddresses
+                    }
+                }
+                ... on MissingFilterError { code message }
+                ... on QueryFailedError { code message }
+            }
+        }
+    "#;
+
+    let response = execute_graphql_query(&schema, query).await;
+    assert!(response.errors.is_empty());
+
+    let data = response.data.into_json()?;
+    let accounts = extract_accounts_from_result(&data)?;
+    assert_eq!(accounts.len(), 1);
+
+    let multi_addresses = accounts[0]["multiAddresses"].as_array().unwrap();
+    assert_eq!(multi_addresses.len(), 1);
+    assert_eq!(multi_addresses[0].as_str().unwrap(), second_multiaddr_str);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_account_count_no_filters() -> anyhow::Result<()> {
     let db = BlokliDb::new_in_memory().await?;
 

--- a/api/tests/account_api_integration_test.rs
+++ b/api/tests/account_api_integration_test.rs
@@ -5,6 +5,7 @@
 //! - Executing GraphQL queries against the schema
 //! - Verifying filtering, validation, and type conversions
 
+use anyhow::Context;
 use blokli_api::{
     query::QueryRoot,
     schema::{ChainId, NetworkName},
@@ -487,8 +488,10 @@ async fn test_accounts_query_returns_only_latest_multiaddress() -> anyhow::Resul
 
     let first_multiaddr_str = "/ip4/127.0.0.1/tcp/9091";
     let second_multiaddr_str = "/ip4/127.0.0.1/tcp/9092";
-    let first_multiaddr: Multiaddr = first_multiaddr_str.parse().unwrap();
-    let second_multiaddr: Multiaddr = second_multiaddr_str.parse().unwrap();
+    let first_multiaddr: Multiaddr = first_multiaddr_str.parse().context("must be able to parse multiaddr")?;
+    let second_multiaddr: Multiaddr = second_multiaddr_str
+        .parse()
+        .context("must be able to parse multiaddr")?;
 
     db.insert_announcement(None, chain_key, first_multiaddr, 101).await?;
     db.insert_announcement(None, chain_key, second_multiaddr, 102).await?;
@@ -528,10 +531,11 @@ async fn test_accounts_query_returns_only_latest_multiaddress() -> anyhow::Resul
     let accounts = extract_accounts_from_result(&data)?;
     assert_eq!(accounts.len(), 1);
 
-    let multi_addresses = accounts[0]["multiAddresses"].as_array().unwrap();
-    assert_eq!(multi_addresses.len(), 1);
-    assert_eq!(multi_addresses[0].as_str().unwrap(), second_multiaddr_str);
-
+    let received_multiaddrs = accounts[0]["multiAddresses"]
+        .as_array()
+        .context("should be available")?;
+    assert_eq!(received_multiaddrs.len(), 1);
+    assert_eq!(received_multiaddrs[0].as_str().unwrap(), second_multiaddr_str);
     Ok(())
 }
 

--- a/api/tests/account_subscription_test.rs
+++ b/api/tests/account_subscription_test.rs
@@ -9,6 +9,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use anyhow::Context;
 use async_graphql::Schema;
 use blokli_api::{mutation::MutationRoot, query::QueryRoot, schema::build_schema, subscription::SubscriptionRoot};
 use blokli_api_types::Account;
@@ -744,8 +745,12 @@ async fn test_account_subscription_handles_account_with_multiple_announcements()
     // Add multiple announcements
     let multiaddr1: Multiaddr = "/ip4/127.0.0.1/tcp/9091".parse().unwrap();
     let multiaddr2: Multiaddr = "/ip4/127.0.0.1/tcp/9092".parse().unwrap();
-    db.insert_announcement(None, chain_key, multiaddr1, 101).await.unwrap();
-    db.insert_announcement(None, chain_key, multiaddr2.clone(), 102).await.unwrap();
+    db.insert_announcement(None, chain_key, multiaddr1, 101)
+        .await
+        .context("should be able to insert a multiaddress");
+    db.insert_announcement(None, chain_key, multiaddr2.clone(), 102)
+        .await
+        .context("should be able to insert a multiaddress");
 
     let (schema, _indexer_state) = create_test_schema(&db);
 

--- a/api/tests/account_subscription_test.rs
+++ b/api/tests/account_subscription_test.rs
@@ -745,7 +745,7 @@ async fn test_account_subscription_handles_account_with_multiple_announcements()
     let multiaddr1: Multiaddr = "/ip4/127.0.0.1/tcp/9091".parse().unwrap();
     let multiaddr2: Multiaddr = "/ip4/127.0.0.1/tcp/9092".parse().unwrap();
     db.insert_announcement(None, chain_key, multiaddr1, 101).await.unwrap();
-    db.insert_announcement(None, chain_key, multiaddr2, 102).await.unwrap();
+    db.insert_announcement(None, chain_key, multiaddr2.clone(), 102).await.unwrap();
 
     let (schema, _indexer_state) = create_test_schema(&db);
 
@@ -760,7 +760,7 @@ async fn test_account_subscription_handles_account_with_multiple_announcements()
 
     let mut stream = schema.execute_stream(query).boxed();
 
-    // Should receive account with multiple announcements
+    // Should receive only the latest announced multiaddress
     let result = tokio::time::timeout(Duration::from_secs(2), stream.next())
         .await
         .unwrap()
@@ -769,7 +769,8 @@ async fn test_account_subscription_handles_account_with_multiple_announcements()
     assert!(result.errors.is_empty());
     let data = result.data.into_json().unwrap();
     let multi_addresses = data["accountUpdated"]["multiAddresses"].as_array().unwrap();
-    assert_eq!(multi_addresses.len(), 2);
+    assert_eq!(multi_addresses.len(), 1);
+    assert_eq!(multi_addresses[0].as_str().unwrap(), multiaddr2.to_string());
 }
 
 #[tokio::test]

--- a/db/entity/Cargo.toml
+++ b/db/entity/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-db-entity"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.5.0"
+version     = "0.5.1"
 
 [lints]
 workspace = true

--- a/db/entity/src/conversions/account_aggregation.rs
+++ b/db/entity/src/conversions/account_aggregation.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use hopr_types::primitive::{primitives::Address, traits::ToHex};
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder};
 
 use crate::{codegen::announcement, views::account_current};
 
@@ -46,26 +46,29 @@ where
     // Batch fetch all announcements
     let announcements = announcement::Entity::find()
         .filter(announcement::Column::AccountId.is_in(account_ids))
+        .order_by_desc(announcement::Column::PublishedBlock)
+        .order_by_desc(announcement::Column::PublishedTxIndex)
+        .order_by_desc(announcement::Column::PublishedLogIndex)
+        .order_by_desc(announcement::Column::Id)
         .all(conn)
         .await?;
 
-    // Group announcements by account_id
-    let mut announcements_by_account: HashMap<i64, Vec<String>> = HashMap::new();
+    let mut latest_announcement_by_account: HashMap<i64, String> = HashMap::new();
     for ann in announcements {
-        announcements_by_account
+        latest_announcement_by_account
             .entry(ann.account_id)
-            .or_default()
-            .push(ann.multiaddress);
+            .or_insert(ann.multiaddress);
     }
 
     // Aggregate all data
     current_accounts
         .into_iter()
         .map(|row| {
-            let multi_addresses = announcements_by_account
+            let multi_addresses = latest_announcement_by_account
                 .get(&row.account_id)
                 .cloned()
-                .unwrap_or_default();
+                .into_iter()
+                .collect();
 
             let chain_key_str = bytes_to_address_hex(&row.chain_key)?;
 

--- a/design/target-api-schema.graphql
+++ b/design/target-api-schema.graphql
@@ -16,7 +16,7 @@ type Account {
   chainKey: String!
   "Unique identifier for the account"
   keyid: Int!
-  "List of multiaddresses associated with the packet key"
+  "Latest announced multiaddress for the packet key, returned as an empty or single-element list"
   multiAddresses: [String!]!
   "Unique account packet key in peer id format"
   packetKey: String!

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api-types"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.11.0"
+version     = "0.11.1"
 
 [dependencies]
 # GraphQL

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -288,7 +288,7 @@ pub struct Account {
     /// HOPR Safe contract address to which the account is linked
     #[graphql(name = "safeAddress")]
     pub safe_address: Option<String>,
-    /// List of multiaddresses associated with the packet key
+    /// Latest announced multiaddress for the packet key, returned as an empty or single-element list
     #[graphql(name = "multiAddresses")]
     pub multi_addresses: Vec<String>,
 }


### PR DESCRIPTION
Returns only the latest multiaddress, as only this one should be valid. Any historical data is not necessary.

Data is still returned as a list, containing up to a single element, to not break the compatibility with the clients of blokli. Could be improved in the future.

Fixes #309 