### PR TITLE
feat: Create a static entrypoint to be able to override

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -175,8 +175,6 @@ jobs:
       version_type: commit
       build_matrix: >-
         [
-
-
           {
             "runner": "self-hosted-hoprnet-bigger",
             "architecture": "x86_64-linux",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3996,8 +3996,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus-text-exporter",
  "opentelemetry_sdk",
- "generic-array 1.3.5",
- "rand 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6605,9 +6605,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7771,7 +7771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/flake.nix
+++ b/flake.nix
@@ -214,13 +214,13 @@
             builtins.readFile ./docker/blokli-anvil-entrypoint.sh
           );
 
-          # Helper: create a /usr/local/bin symlink to a Nix store binary.
+          # Helper: create a /bin symlink to a Nix store binary.
           # The store path is part of the image closure so the symlink resolves inside the container.
           mkStaticEntrypoint =
             { pkgs, binary, name }:
             pkgs.runCommand "${name}-entrypoint" { } ''
-              mkdir -p $out/usr/local/bin
-              ln -s ${binary}/bin/${name} $out/usr/local/bin/${name}
+              mkdir -p $out/bin
+              ln -s ${binary}/bin/${name} $out/bin/${name}
             '';
 
           # Docker images using nix-lib
@@ -228,12 +228,13 @@
             # x86_64-linux Docker images
             docker-blokli-x86_64-linux = nixLib.mkDockerImage {
               name = "bloklid";
-              Entrypoint = [ "/usr/local/bin/bloklid" ];
+              Entrypoint = [ "/bin/bloklid" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
               extraContents = [
+                bloklidPackages.binary-blokli-x86_64-linux
                 (mkStaticEntrypoint {
                   pkgs = pkgsLinux;
                   binary = bloklidPackages.binary-blokli-x86_64-linux;
@@ -243,12 +244,13 @@
             };
             docker-blokli-x86_64-linux-dev = nixLib.mkDockerImage {
               name = "bloklid-dev";
-              Entrypoint = [ "/usr/local/bin/bloklid" ];
+              Entrypoint = [ "/bin/bloklid" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
               extraContents = [
+                bloklidPackages.binary-blokli-x86_64-linux-dev
                 (mkStaticEntrypoint {
                   pkgs = pkgsLinux;
                   binary = bloklidPackages.binary-blokli-x86_64-linux-dev;
@@ -258,12 +260,13 @@
             };
             docker-blokli-x86_64-linux-profile = nixLib.mkDockerImage {
               name = "bloklid-profile";
-              Entrypoint = [ "/usr/local/bin/bloklid" ];
+              Entrypoint = [ "/bin/bloklid" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
               extraContents = [
+                bloklidPackages.binary-blokli-x86_64-linux-profile
                 (mkStaticEntrypoint {
                   pkgs = pkgsLinux;
                   binary = bloklidPackages.binary-blokli-x86_64-linux-profile;
@@ -273,7 +276,7 @@
             };
             docker-blokli-anvil-x86_64-linux = nixLib.mkDockerImage {
               name = "bloklid-anvil";
-              Entrypoint = [ "/usr/local/bin/blokli-anvil-entrypoint" ];
+              Entrypoint = [ "/bin/blokli-anvil-entrypoint" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -293,12 +296,13 @@
             # aarch64-linux Docker images
             docker-blokli-aarch64-linux = nixLib.mkDockerImage {
               name = "bloklid";
-              Entrypoint = [ "/usr/local/bin/bloklid" ];
+              Entrypoint = [ "/bin/bloklid" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
               extraContents = [
+                bloklidPackages.binary-blokli-aarch64-linux
                 (mkStaticEntrypoint {
                   pkgs = pkgsLinuxAarch64;
                   binary = bloklidPackages.binary-blokli-aarch64-linux;
@@ -308,12 +312,13 @@
             };
             docker-blokli-aarch64-linux-dev = nixLib.mkDockerImage {
               name = "bloklid-dev";
-              Entrypoint = [ "/usr/local/bin/bloklid" ];
+              Entrypoint = [ "/bin/bloklid" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
               extraContents = [
+                bloklidPackages.binary-blokli-aarch64-linux-dev
                 (mkStaticEntrypoint {
                   pkgs = pkgsLinuxAarch64;
                   binary = bloklidPackages.binary-blokli-aarch64-linux-dev;
@@ -323,12 +328,13 @@
             };
             docker-blokli-aarch64-linux-profile = nixLib.mkDockerImage {
               name = "bloklid-profile";
-              Entrypoint = [ "/usr/local/bin/bloklid" ];
+              Entrypoint = [ "/bin/bloklid" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
               extraContents = [
+                bloklidPackages.binary-blokli-aarch64-linux-profile
                 (mkStaticEntrypoint {
                   pkgs = pkgsLinuxAarch64;
                   binary = bloklidPackages.binary-blokli-aarch64-linux-profile;
@@ -338,7 +344,7 @@
             };
             docker-blokli-anvil-aarch64-linux = nixLib.mkDockerImage {
               name = "bloklid-anvil";
-              Entrypoint = [ "/usr/local/bin/blokli-anvil-entrypoint" ];
+              Entrypoint = [ "/bin/blokli-anvil-entrypoint" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"

--- a/flake.nix
+++ b/flake.nix
@@ -214,36 +214,66 @@
             builtins.readFile ./docker/blokli-anvil-entrypoint.sh
           );
 
+          # Helper: create a /usr/local/bin symlink to a Nix store binary.
+          # The store path is part of the image closure so the symlink resolves inside the container.
+          mkStaticEntrypoint =
+            { pkgs, binary, name }:
+            pkgs.runCommand "${name}-entrypoint" { } ''
+              mkdir -p $out/usr/local/bin
+              ln -s ${binary}/bin/${name} $out/usr/local/bin/${name}
+            '';
+
           # Docker images using nix-lib
           bloklidDocker = {
             # x86_64-linux Docker images
             docker-blokli-x86_64-linux = nixLib.mkDockerImage {
               name = "bloklid";
-              Entrypoint = [ "${bloklidPackages.binary-blokli-x86_64-linux}/bin/bloklid" ];
+              Entrypoint = [ "/usr/local/bin/bloklid" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+              extraContents = [
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinux;
+                  binary = bloklidPackages.binary-blokli-x86_64-linux;
+                  name = "bloklid";
+                })
               ];
             };
             docker-blokli-x86_64-linux-dev = nixLib.mkDockerImage {
               name = "bloklid-dev";
-              Entrypoint = [ "${bloklidPackages.binary-blokli-x86_64-linux-dev}/bin/bloklid" ];
+              Entrypoint = [ "/usr/local/bin/bloklid" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+              extraContents = [
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinux;
+                  binary = bloklidPackages.binary-blokli-x86_64-linux-dev;
+                  name = "bloklid";
+                })
               ];
             };
             docker-blokli-x86_64-linux-profile = nixLib.mkDockerImage {
               name = "bloklid-profile";
-              Entrypoint = [ "${bloklidPackages.binary-blokli-x86_64-linux-profile}/bin/bloklid" ];
+              Entrypoint = [ "/usr/local/bin/bloklid" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
+              extraContents = [
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinux;
+                  binary = bloklidPackages.binary-blokli-x86_64-linux-profile;
+                  name = "bloklid";
+                })
+              ];
             };
             docker-blokli-anvil-x86_64-linux = nixLib.mkDockerImage {
               name = "bloklid-anvil";
-              Entrypoint = [ "${blokliAnvilEntrypointX86_64}/bin/blokli-anvil-entrypoint" ];
+              Entrypoint = [ "/usr/local/bin/blokli-anvil-entrypoint" ];
               pkgsLinux = pkgsLinux;
               env = [
                 "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -252,38 +282,63 @@
                 bloklidPackages.binary-blokli-x86_64-linux
                 pkgsLinux.curl
                 pkgsLinux.foundry
-                blokliAnvilEntrypointX86_64
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinux;
+                  binary = blokliAnvilEntrypointX86_64;
+                  name = "blokli-anvil-entrypoint";
+                })
               ];
             };
 
             # aarch64-linux Docker images
             docker-blokli-aarch64-linux = nixLib.mkDockerImage {
               name = "bloklid";
-              Entrypoint = [ "${bloklidPackages.binary-blokli-aarch64-linux}/bin/bloklid" ];
+              Entrypoint = [ "/usr/local/bin/bloklid" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+              extraContents = [
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinuxAarch64;
+                  binary = bloklidPackages.binary-blokli-aarch64-linux;
+                  name = "bloklid";
+                })
               ];
             };
             docker-blokli-aarch64-linux-dev = nixLib.mkDockerImage {
               name = "bloklid-dev";
-              Entrypoint = [ "${bloklidPackages.binary-blokli-aarch64-linux-dev}/bin/bloklid" ];
+              Entrypoint = [ "/usr/local/bin/bloklid" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+              extraContents = [
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinuxAarch64;
+                  binary = bloklidPackages.binary-blokli-aarch64-linux-dev;
+                  name = "bloklid";
+                })
               ];
             };
             docker-blokli-aarch64-linux-profile = nixLib.mkDockerImage {
               name = "bloklid-profile";
-              Entrypoint = [ "${bloklidPackages.binary-blokli-aarch64-linux-profile}/bin/bloklid" ];
+              Entrypoint = [ "/usr/local/bin/bloklid" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
               ];
+              extraContents = [
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinuxAarch64;
+                  binary = bloklidPackages.binary-blokli-aarch64-linux-profile;
+                  name = "bloklid";
+                })
+              ];
             };
             docker-blokli-anvil-aarch64-linux = nixLib.mkDockerImage {
               name = "bloklid-anvil";
-              Entrypoint = [ "${blokliAnvilEntrypointAarch64}/bin/blokli-anvil-entrypoint" ];
+              Entrypoint = [ "/usr/local/bin/blokli-anvil-entrypoint" ];
               pkgsLinux = pkgsLinuxAarch64;
               env = [
                 "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
@@ -292,7 +347,11 @@
                 bloklidPackages.binary-blokli-aarch64-linux
                 pkgsLinuxAarch64.curl
                 pkgsLinuxAarch64.foundry
-                blokliAnvilEntrypointAarch64
+                (mkStaticEntrypoint {
+                  pkgs = pkgsLinuxAarch64;
+                  binary = blokliAnvilEntrypointAarch64;
+                  name = "blokli-anvil-entrypoint";
+                })
               ];
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -206,13 +206,11 @@
             inherit overlays;
           };
 
-          blokliAnvilEntrypointX86_64 = pkgsLinux.writeShellScriptBin "blokli-anvil-entrypoint" (
-            builtins.readFile ./docker/blokli-anvil-entrypoint.sh
-          );
-
-          blokliAnvilEntrypointAarch64 = pkgsLinuxAarch64.writeShellScriptBin "blokli-anvil-entrypoint" (
-            builtins.readFile ./docker/blokli-anvil-entrypoint.sh
-          );
+          # Map target platform string to the matching Linux nixpkgs instance.
+          platformPkgsMap = {
+            "x86_64-linux" = pkgsLinux;
+            "aarch64-linux" = pkgsLinuxAarch64;
+          };
 
           # Helper: create a /bin symlink to a Nix store binary.
           # The store path is part of the image closure so the symlink resolves inside the container.
@@ -223,143 +221,73 @@
               ln -s ${binary}/bin/${name} $out/bin/${name}
             '';
 
-          # Docker images using nix-lib
-          bloklidDocker = {
-            # x86_64-linux Docker images
-            docker-blokli-x86_64-linux = nixLib.mkDockerImage {
-              name = "bloklid";
+          # Helper: build the anvil shell-script entrypoint for a given target platform.
+          mkBlokliAnvilEntrypoint =
+            targetPlatform:
+            platformPkgsMap.${targetPlatform}.writeShellScriptBin "blokli-anvil-entrypoint" (
+              builtins.readFile ./docker/blokli-anvil-entrypoint.sh
+            );
+
+          # Helper: build a standard bloklid Docker image for a target platform.
+          # variant is null (release), "dev", or "profile".
+          mkBloklidDocker =
+            targetPlatform: variant:
+            let
+              platformPkgs = platformPkgsMap.${targetPlatform};
+              binarySuffix = if variant == null then "" else "-${variant}";
+              dockerName = "bloklid${if variant == null then "" else "-${variant}"}";
+              binary = bloklidPackages."binary-blokli-${targetPlatform}${binarySuffix}";
+            in
+            nixLib.mkDockerImage {
+              name = dockerName;
               Entrypoint = [ "/bin/bloklid" ];
-              pkgsLinux = pkgsLinux;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
+              pkgsLinux = platformPkgs;
+              env = [ "SSL_CERT_FILE=${platformPkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
               extraContents = [
-                bloklidPackages.binary-blokli-x86_64-linux
+                binary
                 (mkStaticEntrypoint {
-                  pkgs = pkgsLinux;
-                  binary = bloklidPackages.binary-blokli-x86_64-linux;
+                  pkgs = platformPkgs;
+                  inherit binary;
                   name = "bloklid";
                 })
               ];
             };
-            docker-blokli-x86_64-linux-dev = nixLib.mkDockerImage {
-              name = "bloklid-dev";
-              Entrypoint = [ "/bin/bloklid" ];
-              pkgsLinux = pkgsLinux;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
-              extraContents = [
-                bloklidPackages.binary-blokli-x86_64-linux-dev
-                (mkStaticEntrypoint {
-                  pkgs = pkgsLinux;
-                  binary = bloklidPackages.binary-blokli-x86_64-linux-dev;
-                  name = "bloklid";
-                })
-              ];
-            };
-            docker-blokli-x86_64-linux-profile = nixLib.mkDockerImage {
-              name = "bloklid-profile";
-              Entrypoint = [ "/bin/bloklid" ];
-              pkgsLinux = pkgsLinux;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
-              extraContents = [
-                bloklidPackages.binary-blokli-x86_64-linux-profile
-                (mkStaticEntrypoint {
-                  pkgs = pkgsLinux;
-                  binary = bloklidPackages.binary-blokli-x86_64-linux-profile;
-                  name = "bloklid";
-                })
-              ];
-            };
-            docker-blokli-anvil-x86_64-linux = nixLib.mkDockerImage {
+
+          # Helper: build the bloklid-anvil Docker image for a target platform.
+          mkBloklidAnvilDocker =
+            targetPlatform:
+            let
+              platformPkgs = platformPkgsMap.${targetPlatform};
+              binary = bloklidPackages."binary-blokli-${targetPlatform}";
+              anvilEntrypoint = mkBlokliAnvilEntrypoint targetPlatform;
+            in
+            nixLib.mkDockerImage {
               name = "bloklid-anvil";
               Entrypoint = [ "/bin/blokli-anvil-entrypoint" ];
-              pkgsLinux = pkgsLinux;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinux.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
+              pkgsLinux = platformPkgs;
+              env = [ "SSL_CERT_FILE=${platformPkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
               extraContents = [
-                bloklidPackages.binary-blokli-x86_64-linux
-                pkgsLinux.curl
-                pkgsLinux.foundry
+                binary
+                platformPkgs.curl
+                platformPkgs.foundry
                 (mkStaticEntrypoint {
-                  pkgs = pkgsLinux;
-                  binary = blokliAnvilEntrypointX86_64;
+                  pkgs = platformPkgs;
+                  binary = anvilEntrypoint;
                   name = "blokli-anvil-entrypoint";
                 })
               ];
             };
 
-            # aarch64-linux Docker images
-            docker-blokli-aarch64-linux = nixLib.mkDockerImage {
-              name = "bloklid";
-              Entrypoint = [ "/bin/bloklid" ];
-              pkgsLinux = pkgsLinuxAarch64;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
-              extraContents = [
-                bloklidPackages.binary-blokli-aarch64-linux
-                (mkStaticEntrypoint {
-                  pkgs = pkgsLinuxAarch64;
-                  binary = bloklidPackages.binary-blokli-aarch64-linux;
-                  name = "bloklid";
-                })
-              ];
-            };
-            docker-blokli-aarch64-linux-dev = nixLib.mkDockerImage {
-              name = "bloklid-dev";
-              Entrypoint = [ "/bin/bloklid" ];
-              pkgsLinux = pkgsLinuxAarch64;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
-              extraContents = [
-                bloklidPackages.binary-blokli-aarch64-linux-dev
-                (mkStaticEntrypoint {
-                  pkgs = pkgsLinuxAarch64;
-                  binary = bloklidPackages.binary-blokli-aarch64-linux-dev;
-                  name = "bloklid";
-                })
-              ];
-            };
-            docker-blokli-aarch64-linux-profile = nixLib.mkDockerImage {
-              name = "bloklid-profile";
-              Entrypoint = [ "/bin/bloklid" ];
-              pkgsLinux = pkgsLinuxAarch64;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
-              extraContents = [
-                bloklidPackages.binary-blokli-aarch64-linux-profile
-                (mkStaticEntrypoint {
-                  pkgs = pkgsLinuxAarch64;
-                  binary = bloklidPackages.binary-blokli-aarch64-linux-profile;
-                  name = "bloklid";
-                })
-              ];
-            };
-            docker-blokli-anvil-aarch64-linux = nixLib.mkDockerImage {
-              name = "bloklid-anvil";
-              Entrypoint = [ "/bin/blokli-anvil-entrypoint" ];
-              pkgsLinux = pkgsLinuxAarch64;
-              env = [
-                "SSL_CERT_FILE=${pkgsLinuxAarch64.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
-              extraContents = [
-                bloklidPackages.binary-blokli-aarch64-linux
-                pkgsLinuxAarch64.curl
-                pkgsLinuxAarch64.foundry
-                (mkStaticEntrypoint {
-                  pkgs = pkgsLinuxAarch64;
-                  binary = blokliAnvilEntrypointAarch64;
-                  name = "blokli-anvil-entrypoint";
-                })
-              ];
-            };
+          # Docker images using nix-lib
+          bloklidDocker = {
+            docker-blokli-x86_64-linux = mkBloklidDocker "x86_64-linux" null;
+            docker-blokli-x86_64-linux-dev = mkBloklidDocker "x86_64-linux" "dev";
+            docker-blokli-x86_64-linux-profile = mkBloklidDocker "x86_64-linux" "profile";
+            docker-blokli-anvil-x86_64-linux = mkBloklidAnvilDocker "x86_64-linux";
+            docker-blokli-aarch64-linux = mkBloklidDocker "aarch64-linux" null;
+            docker-blokli-aarch64-linux-dev = mkBloklidDocker "aarch64-linux" "dev";
+            docker-blokli-aarch64-linux-profile = mkBloklidDocker "aarch64-linux" "profile";
+            docker-blokli-anvil-aarch64-linux = mkBloklidAnvilDocker "aarch64-linux";
           };
 
           # Combine all packages


### PR DESCRIPTION
The deployment in Gnosis Infra requires overriding the entrypoint to add some delay until the volume with the config file is mounted.
The current setup had a dynamic entrypoint which a nix path including a hash.
With this change, the entrypoint of the docker image is pointing to symbolic link `/bin/bloklid` which points to the nix store of the binary.