### PR TITLE
chore(ci): integrate nix pre-commit simplification and Renovate

### DIFF
--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -14,6 +14,20 @@
 let
   lib = pkgs.lib;
 
+  # pre-commit in nixpkgs bundles heavyweight test-only dependencies
+  # (dotnet-sdk, nodejs, go, coursier, …) into nativeBuildInputs via
+  # its preCheck string interpolation, even though doCheck is already
+  # false on Darwin. Filter them out so `direnv allow` / `nix develop`
+  # doesn't have to build dotnet from source.
+  pre-commit-lightweight = pkgs.pre-commit.overridePythonAttrs {
+    nativeCheckInputs = [ ];
+    doCheck = false;
+    doInstallCheck = false;
+    dontUsePytestCheck = true;
+    preCheck = "";
+    postCheck = "";
+  };
+
   # Wrapper script that provides cargo and other tools to the export-db-schema hook.
   # Pre-commit system hooks run outside the devshell, so tools must be explicitly
   # added to PATH.
@@ -38,6 +52,7 @@ in
 
 pre-commit.lib.${system}.run {
   src = ./../..; # Root of the project
+  package = pre-commit-lightweight;
 
   # Configure the pre-commit hooks to run
   hooks = {
@@ -86,9 +101,6 @@ pre-commit.lib.${system}.run {
       language = "system";
     };
   };
-
-  # Tools available to the pre-commit environment
-  tools = pkgs;
 
   # Exclude certain paths from pre-commit checks
   excludes = [

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,6 @@
     {
       "description": "Expedite nix security updates — bypass weekly schedule",
       "matchManagers": ["nix"],
-      "matchUpdateTypes": ["patch"],
       "matchCategories": ["security"],
       "schedule": ["at any time"],
       "automerge": true,

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:earlyMondays"],
+  "extends": [
+    "config:recommended",
+    "schedule:earlyMondays",
+    "group:allNonMajor",
+    "group:allDigest",
+    ":disableDependencyDashboard"
+  ],
+  "prCreation": "not-pending",
+  "semanticCommits": "enabled",
+  "rangeStrategy": "bump",
   "pinDigests": true,
   "nix": { "enabled": true },
   "vulnerabilityAlerts": {
@@ -13,6 +22,7 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
+      "pinDigests": true,
       "commitMessageTopic": "GitHub Actions"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,22 @@
       "labels": ["security"],
       "groupName": "nix security updates",
       "commitMessageTopic": "Nix security updates"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "cargo dependencies",
+      "commitMessageTopic": "Cargo dependencies"
+    },
+    {
+      "description": "Expedite cargo security updates — bypass weekly schedule",
+      "matchManagers": ["cargo"],
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
+      "automerge": true,
+      "labels": ["security"],
+      "groupName": "cargo security updates",
+      "commitMessageTopic": "Cargo security updates"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "schedule:earlyMondays"],
+  "pinDigests": true,
+  "nix": { "enabled": true },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "schedule": ["at any time"],
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "commitMessageTopic": "GitHub Actions"
+    },
+    {
+      "matchManagers": ["nix"],
+      "groupName": "nix flake updates",
+      "commitMessageTopic": "Nix flake inputs"
+    },
+    {
+      "description": "Expedite nix security updates — bypass weekly schedule",
+      "matchManagers": ["nix"],
+      "matchUpdateTypes": ["patch"],
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
+      "automerge": true,
+      "labels": ["security"],
+      "groupName": "nix security updates",
+      "commitMessageTopic": "Nix security updates"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `pre-commit-lightweight` override in `nix/packages/pre-commit-check.nix` to strip heavyweight test-only deps (dotnet-sdk, nodejs, go, coursier) from the pre-commit derivation, reducing devShell build plan from ~10 to ~3 derivations
- Remove `tools = pkgs` from pre-commit configuration (unnecessary)
- Add `renovate.json` with nix and cargo managers enabled for dependency management

Security vulnerability updates (nix and cargo) bypass the weekly schedule and automerge when CI passes.