### PR TITLE
feat: Build blokli-inspector as part of the default build command

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -27,31 +27,16 @@ jobs:
             build_command: nix build -L .#binary-blokli-x86_64-linux
             build_file: bloklid/Cargo.toml
             binary: bloklid
-          - architecture: x86_64-linux
-            runner: depot-ubuntu-22.04-4
-            build_command: nix build -L .#binary-blokli-inspector-x86_64-linux
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
           - architecture: aarch64-linux
             runner: depot-ubuntu-22.04-arm-4
             build_command: nix build -L .#binary-blokli-aarch64-linux
             build_file: bloklid/Cargo.toml
             binary: bloklid
-          - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-arm-4
-            build_command: nix build -L .#binary-blokli-inspector-aarch64-linux
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
           - architecture: aarch64-darwin
             runner: depot-macos-15
             build_command: nix build -L .#binary-blokli-aarch64-darwin
             build_file: bloklid/Cargo.toml
             binary: bloklid
-          - architecture: aarch64-darwin
-            runner: depot-macos-15
-            build_command: nix build -L .#binary-blokli-inspector-aarch64-darwin
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -154,24 +154,6 @@ jobs:
             build_file: bloklid/Cargo.toml
             binary: bloklid
             required_label: "binary:aarch64-darwin"
-          - architecture: x86_64-linux
-            runner: depot-ubuntu-22.04-4
-            build_command: nix build -L .#binary-blokli-inspector-x86_64-linux
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
-            required_label: ""
-          - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-arm-4
-            build_command: nix build -L .#binary-blokli-inspector-aarch64-linux
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
-            required_label: "binary:aarch64-linux"
-          - architecture: aarch64-darwin
-            runner: depot-macos-15
-            build_command: nix build -L .#binary-blokli-inspector-aarch64-darwin
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
-            required_label: "binary:aarch64-darwin"
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -190,11 +190,6 @@ jobs:
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-blokli-x86_64-linux",
             "smoke_test_command": "nix develop -c just smoke-test"
-          },
-          {
-            "runner": "depot-ubuntu-22.04-arm-4",
-            "architecture": "aarch64-linux",
-            "build_command": "nix build -L .#docker-blokli-aarch64-linux"
           }
         ]
       cachix_cache_name: blokli

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,31 +28,16 @@ jobs:
             build_command: nix build -L .#binary-blokli-x86_64-linux
             build_file: bloklid/Cargo.toml
             binary: bloklid
-          - architecture: x86_64-linux
-            runner: depot-ubuntu-22.04-4
-            build_command: nix build -L .#binary-blokli-inspector-x86_64-linux
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
           - architecture: aarch64-linux
             runner: depot-ubuntu-22.04-arm-4
             build_command: nix build -L .#binary-blokli-aarch64-linux
             build_file: bloklid/Cargo.toml
             binary: bloklid
-          - architecture: aarch64-linux
-            runner: depot-ubuntu-22.04-arm-4
-            build_command: nix build -L .#binary-blokli-inspector-aarch64-linux
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
           - architecture: aarch64-darwin
             runner: depot-macos-15
             build_command: nix build -L .#binary-blokli-aarch64-darwin
             build_file: bloklid/Cargo.toml
             binary: bloklid
-          - architecture: aarch64-darwin
-            runner: depot-macos-15
-            build_command: nix build -L .#binary-blokli-inspector-aarch64-darwin
-            build_file: inspector/Cargo.toml
-            binary: blokli-inspector
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
       contents: read
@@ -114,12 +99,11 @@ jobs:
       contents: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@0d6e82b5bfb948c58ac2f850a331443054486565 # release-version-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v3
         with:
           source_branch: ${{ github.ref_name }}
           file: bloklid/Cargo.toml
           release_type: ${{ inputs.release_type }}
-          package_name: bloklid
           cachix_cache_name: blokli
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
@@ -127,6 +111,7 @@ jobs:
           zulip_channel: Blokli
           zulip_topic: Releases
           gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+          gcp_artifact_package: bloklid
           github_token: ${{ secrets.GH_RUNNER_TOKEN }}
   deploy-staging:
     name: Deploy Gnosis Staging

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -22,30 +22,17 @@ let
       cargoToml = ./../../bloklid/Cargo.toml;
     };
 
-  inspectorBuildArgs = {
-    inherit rev;
-    src = sources.main;
-    depsSrc = sources.deps;
-    cargoToml = ./../../inspector/Cargo.toml;
-    cargoExtraArgs = "--bins";
-  };
-
-  # Production builds for blokli-inspector across all supported platforms
-  inspectorPackages = builtins.listToAttrs (
-    map (platform: {
-      name = "binary-blokli-inspector-${platform}";
-      value = builders.${platform}.callPackage nixLib.mkRustPackage inspectorBuildArgs;
-    }) [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
-  );
-
-  # Production builds for bloklid across all supported platforms
-  # Linux platforms additionally include a dev variant
+  # Production builds include blokli-inspector alongside bloklid in each platform derivation.
+  # prependPackageName = false lets us specify both packages explicitly via cargoExtraArgs.
   mkBloklidPlatformPackages =
     platform:
     let
-      args = mkbloklidBuildArgs {
+      args = (mkbloklidBuildArgs {
         src = sources.main;
         depsSrc = sources.deps;
+      }) // {
+        prependPackageName = false;
+        cargoExtraArgs = "-p bloklid -p blokli-inspector --bins";
       };
       name = "binary-blokli-${platform}";
     in
@@ -80,7 +67,6 @@ in
     }
   );
 }
-// inspectorPackages
 // bloklidPackages
 // {
   # Test and quality assurance builds


### PR DESCRIPTION
The previous PR #317 created the binary blokli-inspector but didn't use the default build command and created a separate command. 
The build commands needs to generate as many binaries as needed, instead of invoking different build commands to generate specific binaries. The release process, only takes the binaries from a single `package`, that's why we need to embed both binaries in the same build command.