### PR TITLE
feat: Enable telemetry only if defined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/bloklid/Cargo.toml
+++ b/bloklid/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "bloklid"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.10.1"
+version     = "0.10.2"
 
 [features]
 default = ["runtime-tokio"]

--- a/charts/blokli/Chart.yaml
+++ b/charts/blokli/Chart.yaml
@@ -4,7 +4,7 @@ name: blokli
 description: Helm chart for Blokli - HOPR on-chain indexer with GraphQL API
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 keywords:
   - blokli

--- a/charts/blokli/Chart.yaml
+++ b/charts/blokli/Chart.yaml
@@ -5,7 +5,7 @@ description: Helm chart for Blokli - HOPR on-chain indexer with GraphQL API
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"
 version: 0.1.5
-appVersion: "0.1.0"
+appVersion: "0.10.1"
 keywords:
   - blokli
   - hopr

--- a/charts/blokli/Chart.yaml
+++ b/charts/blokli/Chart.yaml
@@ -4,7 +4,7 @@ name: blokli
 description: Helm chart for Blokli - HOPR on-chain indexer with GraphQL API
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.1.0"
 keywords:
   - blokli

--- a/charts/blokli/templates/configmap.yaml
+++ b/charts/blokli/templates/configmap.yaml
@@ -54,8 +54,10 @@ data:
     timeout = {{ .Values.config.api.health.timeout | quote }}
     readiness_check_interval = {{ .Values.config.api.health.readinessCheckInterval | quote }}
 
+{{- if not (empty .Values.config.telemetry.otlpEndpoint) }}
     # Telemetry configuration
     [telemetry]
     otlp_endpoint = {{ .Values.config.telemetry.otlpEndpoint | quote }}
     otlp_signals = {{ .Values.config.telemetry.otlpSignals | quote }}
     metric_export_interval = {{ .Values.config.telemetry.metricExportInterval | quote }}
+{{- end }}

--- a/charts/blokli/templates/configmap.yaml
+++ b/charts/blokli/templates/configmap.yaml
@@ -29,7 +29,9 @@ data:
     [indexer]
     fast_sync = {{ .Values.config.indexer.fastSync }}
     enable_logs_snapshot = {{ .Values.config.indexer.enableLogsSnapshot }}
+    {{- if .Values.config.indexer.enableSafeIndexing }}
     enable_safe_indexing = {{ .Values.config.indexer.enableSafeIndexing }}
+    {{- end }}
     {{- if .Values.config.indexer.enableLogsSnapshot }}
     logs_snapshot_url = "{{ required "config.indexer.logsSnapshotUrl is required" .Values.config.indexer.logsSnapshotUrl }}"
     {{- end }}
@@ -54,10 +56,10 @@ data:
     timeout = {{ .Values.config.api.health.timeout | quote }}
     readiness_check_interval = {{ .Values.config.api.health.readinessCheckInterval | quote }}
 
-{{- if not (empty .Values.config.telemetry.otlpEndpoint) }}
+    {{- if not (empty .Values.config.telemetry.otlpEndpoint) }}
     # Telemetry configuration
     [telemetry]
     otlp_endpoint = {{ .Values.config.telemetry.otlpEndpoint | quote }}
     otlp_signals = {{ .Values.config.telemetry.otlpSignals | quote }}
     metric_export_interval = {{ .Values.config.telemetry.metricExportInterval | quote }}
-{{- end }}
+    {{- end }}

--- a/charts/blokli/templates/configmap.yaml
+++ b/charts/blokli/templates/configmap.yaml
@@ -56,7 +56,7 @@ data:
     timeout = {{ .Values.config.api.health.timeout | quote }}
     readiness_check_interval = {{ .Values.config.api.health.readinessCheckInterval | quote }}
 
-    {{- if not (empty .Values.config.telemetry.otlpEndpoint) }}
+    {{- if not (empty (.Values.config.telemetry.otlpEndpoint | default "" | trim)) }}
     # Telemetry configuration
     [telemetry]
     otlp_endpoint = {{ .Values.config.telemetry.otlpEndpoint | quote }}


### PR DESCRIPTION
- Make telemetry config optional
- Bump version as it was not bumped in the previous release process due to a bug https://github.com/hoprnet/hopr-workflows/pull/56
- Make `enableSafeIndexing` config optional