### PR TITLE
fix: indexed block metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-chain-indexer"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0"
 name        = "blokli-chain-indexer"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.16.1"
+version     = "0.16.2"
 
 [lib]
 crate-type = ["rlib"]

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -766,7 +766,6 @@ where
             };
             #[cfg(all(feature = "telemetry", not(test)))]
             {
-                METRIC_INDEXER_CURRENT_BLOCK.set(block.block_id as f64);
                 METRIC_INDEXER_SYNC_PROGRESS.set(&[&filter_phase.to_string()], progress / 100_f64);
             }
             info!(
@@ -872,6 +871,9 @@ where
 
         // if we made it this far, no errors occurred and we can update checksums and indexer state
         if !finalize_block {
+            #[cfg(all(feature = "telemetry", not(test)))]
+            METRIC_INDEXER_CURRENT_BLOCK.set(block_id as f64);
+
             debug!(
                 block_id,
                 "processed block logs without finalizing checksum or indexer state"
@@ -909,6 +911,8 @@ where
                 // finally update the block number in the database to the last processed block
                 match db.set_indexer_state_info(None, block_id as u32).await {
                     Ok(_) => {
+                        #[cfg(all(feature = "telemetry", not(test)))]
+                        METRIC_INDEXER_CURRENT_BLOCK.set(block_id as f64);
                         trace!(block_id, "updated indexer state info");
                     }
                     Err(error) => error!(block_id, %error, "failed to update indexer state info"),


### PR DESCRIPTION
The metric `blokli_indexer_block_number` was only increased in the indexing phase, not on continuous mode.