### PR TITLE
feat: return all safe matching the selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-db-entity"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blokli-db-migration",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-integration-tests"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "blokli-client",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.21.1"
+version     = "0.22.0"
 
 [lints]
 workspace = true

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -21,8 +21,8 @@ use blokli_db_entity::{
         redemptions_aggregation::fetch_aggregated_redeemed_stats,
         safe_aggregation::{
             CurrentSafe, fetch_all_current_safes, fetch_safe_addresses as fetch_safe_addresses_db,
-            fetch_safe_by_address as fetch_safe_by_address_db, fetch_safe_by_owner as fetch_safe_by_owner_db,
-            fetch_safe_owners, fetch_safe_owners_by_safe,
+            fetch_safe_by_address as fetch_safe_by_address_db, fetch_safe_owners, fetch_safe_owners_by_safe,
+            fetch_safes_by_owner as fetch_safes_by_owner_db,
         },
     },
     hopr_node_safe_registration,
@@ -87,10 +87,18 @@ pub enum TransactionCountResult {
     QueryFailed(QueryFailedError),
 }
 
-/// Result type for single safe queries
+/// Result type for deprecated single-safe queries (`safe`, `safeByChainKey`, `safeByRegisteredNode`).
 #[derive(Union)]
 pub enum SafeResult {
     Safe(Safe),
+    InvalidAddress(InvalidAddressError),
+    QueryFailed(QueryFailedError),
+}
+
+/// Result type for safe-by-selector query
+#[derive(Union)]
+pub enum SafeByResult {
+    Safes(SafesList),
     InvalidAddress(InvalidAddressError),
     QueryFailed(QueryFailedError),
 }
@@ -264,10 +272,20 @@ async fn owners_by_safe(
         .collect())
 }
 
-fn safe_result_from_row(current: CurrentSafe, registered_nodes: Vec<String>, owners: Vec<String>) -> SafeResult {
-    match safe_from_current_row(current, registered_nodes, owners) {
-        Ok(safe_data) => SafeResult::Safe(safe_data),
-        Err(e) => SafeResult::QueryFailed(errors::invalid_db_data("safe addresses", &e)),
+async fn build_safe_from_current(
+    db: &DatabaseConnection,
+    current: CurrentSafe,
+) -> std::result::Result<Safe, QueryFailedError> {
+    let safe_address = current.address.clone();
+    let owners = owners_for_safe(db, safe_address.clone()).await?;
+    safe_from_current_row(current, registered_nodes_for_safe(db, safe_address).await, owners)
+        .map_err(|e| errors::invalid_db_data("safe addresses", &e))
+}
+
+async fn build_single_safe_by_result_from_current(db: &DatabaseConnection, current: CurrentSafe) -> SafeByResult {
+    match build_safe_from_current(db, current).await {
+        Ok(safe) => SafeByResult::Safes(SafesList { safes: vec![safe] }),
+        Err(e) => SafeByResult::QueryFailed(e),
     }
 }
 
@@ -929,50 +947,57 @@ impl QueryRoot {
         ctx: &Context<'_>,
         #[graphql(desc = "Selector type for safe lookup")] selector: SafeSelectorInput,
         #[graphql(desc = "Address value for the selector (hexadecimal format)")] address: String,
-    ) -> Result<Option<SafeResult>> {
+    ) -> Result<Option<SafeByResult>> {
         let db = ctx.data::<DatabaseConnection>()?;
 
         match selector {
             SafeSelectorInput::Address => {
                 let safe_address = match parse_eth_address(address) {
                     Ok(addr) => addr.as_ref().to_vec(),
-                    Err(e) => return Ok(Some(SafeResult::InvalidAddress(e))),
+                    Err(e) => return Ok(Some(SafeByResult::InvalidAddress(e))),
                 };
 
                 match fetch_safe_by_address_db(db, &safe_address).await {
-                    Ok(Some(current)) => match owners_for_safe(db, safe_address.clone()).await {
-                        Ok(owners) => Ok(Some(safe_result_from_row(
-                            current,
-                            registered_nodes_for_safe(db, safe_address).await,
-                            owners,
-                        ))),
-                        Err(e) => Ok(Some(SafeResult::QueryFailed(e))),
-                    },
+                    Ok(Some(current)) => Ok(Some(build_single_safe_by_result_from_current(db, current).await)),
                     Ok(None) => Ok(None),
-                    Err(e) => Ok(Some(SafeResult::QueryFailed(errors::query_failed("fetch safe", e)))),
+                    Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed("fetch safe", e)))),
                 }
             }
 
             SafeSelectorInput::Owner | SafeSelectorInput::ChainKey => {
                 let owner_address = match parse_eth_address(address) {
                     Ok(addr) => addr.as_ref().to_vec(),
-                    Err(e) => return Ok(Some(SafeResult::InvalidAddress(e))),
+                    Err(e) => return Ok(Some(SafeByResult::InvalidAddress(e))),
                 };
 
-                match fetch_safe_by_owner_db(db, &owner_address).await {
-                    Ok(Some(current)) => {
-                        let safe_address = current.address.clone();
-                        match owners_for_safe(db, safe_address.clone()).await {
-                            Ok(owners) => Ok(Some(safe_result_from_row(
+                match fetch_safes_by_owner_db(db, &owner_address).await {
+                    Ok(safes) if safes.is_empty() => Ok(None),
+                    Ok(safes) => {
+                        let mut safe_list = Vec::with_capacity(safes.len());
+                        for current in safes {
+                            let safe_address = current.address.clone();
+                            let owners = match owners_for_safe(db, safe_address.clone()).await {
+                                Ok(owners) => owners,
+                                Err(e) => return Ok(Some(SafeByResult::QueryFailed(e))),
+                            };
+                            let safe = match safe_from_current_row(
                                 current,
                                 registered_nodes_for_safe(db, safe_address).await,
                                 owners,
-                            ))),
-                            Err(e) => Ok(Some(SafeResult::QueryFailed(e))),
+                            ) {
+                                Ok(safe) => safe,
+                                Err(e) => {
+                                    return Ok(Some(SafeByResult::QueryFailed(errors::invalid_db_data(
+                                        "safe addresses",
+                                        &e,
+                                    ))));
+                                }
+                            };
+                            safe_list.push(safe);
                         }
+                        Ok(Some(SafeByResult::Safes(SafesList { safes: safe_list })))
                     }
-                    Ok(None) => Ok(None),
-                    Err(e) => Ok(Some(SafeResult::QueryFailed(errors::query_failed(
+                    Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                         "fetch safe by owner",
                         e,
                     )))),
@@ -982,7 +1007,7 @@ impl QueryRoot {
             SafeSelectorInput::RegisteredNode => {
                 let node_address = match parse_eth_address(address) {
                     Ok(addr) => addr.as_ref().to_vec(),
-                    Err(e) => return Ok(Some(SafeResult::InvalidAddress(e))),
+                    Err(e) => return Ok(Some(SafeByResult::InvalidAddress(e))),
                 };
 
                 let registration = match hopr_node_safe_registration::Entity::find()
@@ -993,7 +1018,7 @@ impl QueryRoot {
                     Ok(Some(reg)) => reg,
                     Ok(None) => return Ok(None),
                     Err(e) => {
-                        return Ok(Some(SafeResult::QueryFailed(errors::query_failed(
+                        return Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                             "fetch safe by registered node",
                             e,
                         ))));
@@ -1001,19 +1026,12 @@ impl QueryRoot {
                 };
 
                 match fetch_safe_by_address_db(db, &registration.safe_address).await {
-                    Ok(Some(current)) => match owners_for_safe(db, registration.safe_address.clone()).await {
-                        Ok(owners) => Ok(Some(safe_result_from_row(
-                            current,
-                            registered_nodes_for_safe(db, registration.safe_address).await,
-                            owners,
-                        ))),
-                        Err(e) => Ok(Some(SafeResult::QueryFailed(e))),
-                    },
-                    Ok(None) => Ok(Some(SafeResult::QueryFailed(errors::query_failed(
+                    Ok(Some(current)) => Ok(Some(build_single_safe_by_result_from_current(db, current).await)),
+                    Ok(None) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                         "fetch safe by registered node",
                         "Safe not found for registered node",
                     )))),
-                    Err(e) => Ok(Some(SafeResult::QueryFailed(errors::query_failed(
+                    Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                         "fetch safe by registered node",
                         e,
                     )))),
@@ -1053,7 +1071,12 @@ impl QueryRoot {
         ctx: &Context<'_>,
         #[graphql(desc = "Safe contract address to query (hexadecimal format)")] address: String,
     ) -> Result<Option<SafeResult>> {
-        self.safe_by(ctx, SafeSelectorInput::Address, address).await
+        match self.safe_by(ctx, SafeSelectorInput::Address, address).await? {
+            Some(SafeByResult::Safes(mut safes)) => Ok(safes.safes.drain(..).next().map(SafeResult::Safe)),
+            Some(SafeByResult::InvalidAddress(e)) => Ok(Some(SafeResult::InvalidAddress(e))),
+            Some(SafeByResult::QueryFailed(e)) => Ok(Some(SafeResult::QueryFailed(e))),
+            None => Ok(None),
+        }
     }
 
     /// Finds a Safe by owner address using the deprecated `CHAIN_KEY` selector alias.
@@ -1094,7 +1117,12 @@ impl QueryRoot {
         #[graphql(desc = "Owner address to query via the deprecated CHAIN_KEY alias (hexadecimal format)")]
         chain_key: String,
     ) -> Result<Option<SafeResult>> {
-        self.safe_by(ctx, SafeSelectorInput::ChainKey, chain_key).await
+        match self.safe_by(ctx, SafeSelectorInput::ChainKey, chain_key).await? {
+            Some(SafeByResult::Safes(mut safes)) => Ok(safes.safes.drain(..).next().map(SafeResult::Safe)),
+            Some(SafeByResult::InvalidAddress(e)) => Ok(Some(SafeResult::InvalidAddress(e))),
+            Some(SafeByResult::QueryFailed(e)) => Ok(Some(SafeResult::QueryFailed(e))),
+            None => Ok(None),
+        }
     }
 
     /// Fetches a Safe contract by registered node address.
@@ -1139,7 +1167,12 @@ impl QueryRoot {
         ctx: &Context<'_>,
         #[graphql(name = "chainKey")] chain_key: String,
     ) -> Result<Option<SafeResult>> {
-        self.safe_by(ctx, SafeSelectorInput::RegisteredNode, chain_key).await
+        match self.safe_by(ctx, SafeSelectorInput::RegisteredNode, chain_key).await? {
+            Some(SafeByResult::Safes(mut safes)) => Ok(safes.safes.drain(..).next().map(SafeResult::Safe)),
+            Some(SafeByResult::InvalidAddress(e)) => Ok(Some(SafeResult::InvalidAddress(e))),
+            Some(SafeByResult::QueryFailed(e)) => Ok(Some(SafeResult::QueryFailed(e))),
+            None => Ok(None),
+        }
     }
 
     /// Fetches all indexed Safe contracts.
@@ -1643,7 +1676,7 @@ mod tests {
         safe_history::{BlokliDbSafeHistoryOperations, SafeActivityKind},
     };
     use blokli_db_entity::conversions::safe_aggregation::{
-        CurrentSafe, fetch_safe_addresses, fetch_safe_by_owner, fetch_safe_threshold_by_address,
+        CurrentSafe, fetch_safe_addresses, fetch_safe_threshold_by_address, fetch_safes_by_owner,
     };
     use hopr_types::{
         crypto::types::Hash,
@@ -1852,15 +1885,20 @@ mod tests {
             .map_err(|error| anyhow!("fetch_safe_addresses failed: {}", error))?;
         assert_eq!(safe_addresses, vec![safe_address.as_ref().to_vec()]);
 
-        let current_safe = fetch_safe_by_owner(conn, owner.as_ref())
+        let current_safe = fetch_safes_by_owner(conn, owner.as_ref())
             .await?
+            .into_iter()
+            .next()
             .expect("safe should exist for current owner");
         assert_eq!(current_safe.address, safe_address.as_ref().to_vec());
         assert_eq!(current_safe.module_address, module_address.as_ref().to_vec());
         assert_eq!(current_safe.chain_key, chain_key.as_ref().to_vec());
 
-        let no_safe = fetch_safe_by_owner(conn, unrelated_owner.as_ref()).await?;
-        assert!(no_safe.is_none(), "former owners should not match current-owner lookup");
+        let no_safe = fetch_safes_by_owner(conn, unrelated_owner.as_ref()).await?;
+        assert!(
+            no_safe.is_empty(),
+            "former owners should not match current-owner lookup"
+        );
 
         Ok(())
     }

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -21,7 +21,7 @@ use blokli_db_entity::{
         redemptions_aggregation::fetch_aggregated_redeemed_stats,
         safe_aggregation::{
             CurrentSafe, fetch_all_current_safes, fetch_safe_addresses as fetch_safe_addresses_db,
-            fetch_safe_by_address as fetch_safe_by_address_db, fetch_safe_owners, fetch_safe_owners_by_safe,
+            fetch_safe_by_address as fetch_safe_by_address_db, fetch_safe_owners, fetch_safe_owners_for_safes,
             fetch_safes_by_owner as fetch_safes_by_owner_db,
         },
     },
@@ -288,8 +288,9 @@ pub(crate) async fn owners_for_safe(
 
 async fn owners_by_safe(
     db: &DatabaseConnection,
+    safe_addresses: &[Vec<u8>],
 ) -> std::result::Result<HashMap<Vec<u8>, Vec<String>>, QueryFailedError> {
-    Ok(fetch_safe_owners_by_safe(db)
+    Ok(fetch_safe_owners_for_safes(db, safe_addresses)
         .await
         .map_err(|e| errors::query_failed("fetch safe owners for list query", e))?
         .into_iter()
@@ -999,7 +1000,7 @@ impl QueryRoot {
                     Ok(safes) if safes.is_empty() => Ok(None),
                     Ok(safes) => {
                         let safe_addresses = safes.iter().map(|current| current.address.clone()).collect::<Vec<_>>();
-                        let owners_by_safe = match owners_by_safe(db).await {
+                        let owners_by_safe = match owners_by_safe(db, &safe_addresses).await {
                             Ok(owners_by_safe) => owners_by_safe,
                             Err(e) => return Ok(Some(SafeByResult::QueryFailed(e))),
                         };
@@ -1269,7 +1270,11 @@ impl QueryRoot {
             }
         }
 
-        let owners_by_safe = match owners_by_safe(db).await {
+        let safe_addresses = current_rows
+            .iter()
+            .map(|current| current.address.clone())
+            .collect::<Vec<_>>();
+        let owners_by_safe = match owners_by_safe(db, &safe_addresses).await {
             Ok(owners_by_safe) => owners_by_safe,
             Err(e) => return Ok(SafesResult::QueryFailed(e)),
         };

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -17,7 +17,7 @@ use blokli_db_entity::{
     conversions::{
         account_aggregation::fetch_accounts_with_filters,
         channel_aggregation::{fetch_channel_stats as fetch_channel_stats_db, fetch_channels_with_state},
-        node_safe_registration::fetch_registered_nodes_for_safe,
+        node_safe_registration::{fetch_registered_nodes_for_safe, fetch_registered_nodes_for_safes},
         redemptions_aggregation::fetch_aggregated_redeemed_stats,
         safe_aggregation::{
             CurrentSafe, fetch_all_current_safes, fetch_safe_addresses as fetch_safe_addresses_db,
@@ -245,6 +245,31 @@ async fn registered_nodes_for_safe(db: &DatabaseConnection, safe_address: Vec<u8
                 "Failed to fetch registered nodes for safe, returning empty list"
             );
             Vec::new()
+        }
+    }
+}
+
+async fn registered_nodes_by_safe(
+    db: &DatabaseConnection,
+    safe_addresses: &[Vec<u8>],
+) -> HashMap<Vec<u8>, Vec<String>> {
+    match fetch_registered_nodes_for_safes(db, safe_addresses).await {
+        Ok(by_safe) => {
+            let mut registered_nodes_by_safe = HashMap::with_capacity(safe_addresses.len());
+            for (safe_address, nodes) in by_safe {
+                registered_nodes_by_safe.insert(
+                    safe_address,
+                    nodes.into_iter().map(|node_address| node_address.to_hex()).collect(),
+                );
+            }
+            registered_nodes_by_safe
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                "Failed to batch-fetch registered nodes for safes, returning empty lists"
+            );
+            HashMap::with_capacity(safe_addresses.len())
         }
     }
 }
@@ -973,18 +998,31 @@ impl QueryRoot {
                 match fetch_safes_by_owner_db(db, &owner_address).await {
                     Ok(safes) if safes.is_empty() => Ok(None),
                     Ok(safes) => {
+                        let safe_addresses = safes.iter().map(|current| current.address.clone()).collect::<Vec<_>>();
+                        let owners_by_safe = match owners_by_safe(db).await {
+                            Ok(owners_by_safe) => owners_by_safe,
+                            Err(e) => return Ok(Some(SafeByResult::QueryFailed(e))),
+                        };
+                        let registered_nodes_by_safe = registered_nodes_by_safe(db, &safe_addresses).await;
                         let mut safe_list = Vec::with_capacity(safes.len());
+                        let mut owners_by_safe_map = HashMap::with_capacity(safes.len());
+                        for safe_address in &safe_addresses {
+                            if let Some(owners) = owners_by_safe.get(safe_address) {
+                                owners_by_safe_map.insert(safe_address.clone(), owners.clone());
+                            }
+                        }
+                        let mut registered_nodes_by_safe_map = HashMap::with_capacity(safes.len());
+                        for safe_address in &safe_addresses {
+                            if let Some(registered_nodes) = registered_nodes_by_safe.get(safe_address) {
+                                registered_nodes_by_safe_map.insert(safe_address.clone(), registered_nodes.clone());
+                            }
+                        }
                         for current in safes {
                             let safe_address = current.address.clone();
-                            let owners = match owners_for_safe(db, safe_address.clone()).await {
-                                Ok(owners) => owners,
-                                Err(e) => return Ok(Some(SafeByResult::QueryFailed(e))),
-                            };
-                            let safe = match safe_from_current_row(
-                                current,
-                                registered_nodes_for_safe(db, safe_address).await,
-                                owners,
-                            ) {
+                            let owners = owners_by_safe_map.remove(&safe_address).unwrap_or_default();
+                            let registered_nodes =
+                                registered_nodes_by_safe_map.remove(&safe_address).unwrap_or_default();
+                            let safe = match safe_from_current_row(current, registered_nodes, owners) {
                                 Ok(safe) => safe,
                                 Err(e) => {
                                     return Ok(Some(SafeByResult::QueryFailed(errors::invalid_db_data(

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -44,7 +44,7 @@ use crate::{
     conversions::transaction_from_record, errors, mutation::TransactionResult, validation::validate_eth_address,
 };
 
-const SUPPORTED_CLIENT_VERSIONS: &str = "^0.26";
+const SUPPORTED_CLIENT_VERSIONS: &str = "^0.27";
 
 /// Result type for HOPR balance queries
 #[derive(Union)]
@@ -1707,9 +1707,12 @@ impl QueryRoot {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
+    use async_graphql::Schema;
+    use blokli_chain_types::ContractAddresses;
     use blokli_db::{
         BlokliDbGeneralModelOperations, TargetDb,
         db::BlokliDb,
+        node_safe_registrations::BlokliDbNodeSafeRegistrationOperations,
         safe_contracts::BlokliDbSafeContractOperations,
         safe_history::{BlokliDbSafeHistoryOperations, SafeActivityKind},
     };
@@ -1721,7 +1724,8 @@ mod tests {
         primitive::{prelude::Address, traits::ToHex},
     };
 
-    use super::{owners_for_safe, safe_from_current_row, scale_wei_by_multiplier};
+    use super::{QueryRoot, owners_for_safe, safe_from_current_row, scale_wei_by_multiplier};
+    use crate::schema::{ChainId, GasMultiplier, NetworkName};
 
     fn random_address() -> Address {
         Address::from(rand::random::<[u8; 20]>())
@@ -1729,6 +1733,22 @@ mod tests {
 
     fn random_hash() -> Hash {
         Hash::from(rand::random::<[u8; 32]>())
+    }
+
+    fn build_test_schema(
+        db: &BlokliDb,
+    ) -> Schema<QueryRoot, async_graphql::EmptyMutation, async_graphql::EmptySubscription> {
+        Schema::build(
+            QueryRoot,
+            async_graphql::EmptyMutation,
+            async_graphql::EmptySubscription,
+        )
+        .data(db.conn(TargetDb::Index).clone())
+        .data(ContractAddresses::default())
+        .data(ChainId(100))
+        .data(NetworkName("test".to_string()))
+        .data(GasMultiplier(1.0))
+        .finish()
     }
 
     #[test]
@@ -1936,6 +1956,92 @@ mod tests {
         assert!(
             no_safe.is_empty(),
             "former owners should not match current-owner lookup"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_safe_by_owner_returns_prefetched_owners_and_registered_nodes() -> anyhow::Result<()> {
+        let db = BlokliDb::new_in_memory().await?;
+
+        let safe_one = random_address();
+        let safe_two = random_address();
+        let module_one = random_address();
+        let module_two = random_address();
+        let chain_key_one = random_address();
+        let chain_key_two = random_address();
+        let owner = random_address();
+        let extra_owner = random_address();
+        let node_one = random_address();
+        let node_two = random_address();
+
+        db.create_safe_contract(None, safe_one, module_one, chain_key_one, 100, 0, 0)
+            .await?;
+        db.create_safe_contract(None, safe_two, module_two, chain_key_two, 101, 0, 1)
+            .await?;
+        db.upsert_safe_owner_state(None, safe_one, owner, true, 102, 0, 0)
+            .await?;
+        db.upsert_safe_owner_state(None, safe_one, extra_owner, true, 103, 0, 0)
+            .await?;
+        db.upsert_safe_owner_state(None, safe_two, owner, true, 104, 0, 1)
+            .await?;
+        db.register_node_to_safe(None, safe_one, node_one, 105, 0, 0).await?;
+        db.register_node_to_safe(None, safe_two, node_two, 106, 0, 1).await?;
+
+        let schema = build_test_schema(&db);
+        let query = format!(
+            r#"
+            query {{
+              safeBy(selector: OWNER, address: "{}") {{
+                ... on SafesList {{
+                  safes {{
+                    address
+                    owners
+                    registeredNodes
+                  }}
+                }}
+              }}
+            }}
+            "#,
+            owner.to_hex()
+        );
+
+        let response = schema.execute(query).await;
+        let body = response.data.into_json()?;
+        let safes = body["safeBy"]["safes"]
+            .as_array()
+            .ok_or_else(|| anyhow!("expected safeBy.safes array"))?;
+        assert_eq!(safes.len(), 2);
+
+        let safe_one_hex = safe_one.to_hex();
+        let safe_two_hex = safe_two.to_hex();
+        let node_one_hex = node_one.to_hex();
+        let node_two_hex = node_two.to_hex();
+        let owner_hex = owner.to_hex();
+
+        let safe_one_result = safes
+            .iter()
+            .find(|safe| safe["address"] == safe_one_hex)
+            .ok_or_else(|| anyhow!("safe one not found in response"))?;
+        let safe_two_result = safes
+            .iter()
+            .find(|safe| safe["address"] == safe_two_hex)
+            .ok_or_else(|| anyhow!("safe two not found in response"))?;
+
+        assert!(
+            safe_one_result["owners"]
+                .as_array()
+                .is_some_and(|owners| owners.iter().any(|value| value == &owner_hex)),
+            "safe one should include owner in owners list"
+        );
+        assert_eq!(
+            safe_one_result["registeredNodes"].as_array(),
+            Some(&vec![serde_json::Value::String(node_one_hex)])
+        );
+        assert_eq!(
+            safe_two_result["registeredNodes"].as_array(),
+            Some(&vec![serde_json::Value::String(node_two_hex)])
         );
 
         Ok(())

--- a/api/tests/safe_api_integration_test.rs
+++ b/api/tests/safe_api_integration_test.rs
@@ -248,6 +248,89 @@ async fn test_safe_by_chain_key_query() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_safe_by_chain_key_query_returns_multiple_safes_for_same_owner() -> anyhow::Result<()> {
+    let db = BlokliDb::new_in_memory().await?;
+
+    let safe_address_0 = safe_address();
+    let module_address_0 = module_address();
+    let chain_key_0 = chain_key_address();
+
+    let safe_address_1 = secondary_safe_address();
+    let module_address_1 = secondary_module_address();
+    let chain_key_1 = secondary_chain_key_address();
+
+    let owner = owner_address();
+
+    db.create_safe_contract(None, safe_address_0, module_address_0, chain_key_0, 100, 0, 0)
+        .await?;
+    db.create_safe_contract(None, safe_address_1, module_address_1, chain_key_1, 101, 0, 1)
+        .await?;
+    db.upsert_safe_owner_state(None, safe_address_0, owner, true, 102, 0, 0)
+        .await?;
+    db.upsert_safe_owner_state(None, safe_address_1, owner, true, 103, 0, 1)
+        .await?;
+
+    let schema = build_test_schema(&db);
+    let query = format!(
+        r#"
+        query {{
+            safeByChainKey(chainKey: "{}") {{
+                ... on Safe {{
+                    address
+                }}
+                ... on QueryFailedError {{
+                    message
+                }}
+            }}
+        }}
+        "#,
+        owner.to_hex()
+    );
+
+    let response = schema.execute(query).await;
+    insta::assert_yaml_snapshot!(response);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_safe_by_selector_chain_key_returns_safes_list_for_single_match() -> anyhow::Result<()> {
+    let db = BlokliDb::new_in_memory().await?;
+
+    let safe_address = safe_address();
+    let module_address = module_address();
+    let chain_key = chain_key_address();
+    let owner = owner_address();
+
+    db.create_safe_contract(None, safe_address, module_address, chain_key, 100, 0, 0)
+        .await?;
+    db.upsert_safe_owner_state(None, safe_address, owner, true, 101, 0, 0)
+        .await?;
+
+    let schema = build_test_schema(&db);
+    let query = format!(
+        r#"
+        query {{
+            safeBy(selector: CHAIN_KEY, address: "{}") {{
+                ... on SafesList {{
+                    safes {{
+                        address
+                    }}
+                }}
+                ... on QueryFailedError {{
+                    message
+                }}
+            }}
+        }}
+        "#,
+        owner.to_hex()
+    );
+
+    let response = schema.execute(query).await;
+    insta::assert_yaml_snapshot!(response);
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_safes_list_query() -> anyhow::Result<()> {
     let db = BlokliDb::new_in_memory().await?;
 

--- a/api/tests/safe_api_integration_test.rs
+++ b/api/tests/safe_api_integration_test.rs
@@ -6,6 +6,7 @@ use blokli_chain_types::ContractAddresses;
 use blokli_db::{
     BlokliDbGeneralModelOperations,
     db::BlokliDb,
+    node_safe_registrations::BlokliDbNodeSafeRegistrationOperations,
     safe_contracts::BlokliDbSafeContractOperations,
     safe_history::{BlokliDbSafeHistoryOperations, SafeActivityKind},
     safe_redeemed_stats::BlokliDbSafeRedeemedStatsOperations,
@@ -248,7 +249,7 @@ async fn test_safe_by_chain_key_query() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_safe_by_chain_key_query_returns_multiple_safes_for_same_owner() -> anyhow::Result<()> {
+async fn test_safe_by_chain_key_query_returns_single_safe_for_deprecated_field() -> anyhow::Result<()> {
     let db = BlokliDb::new_in_memory().await?;
 
     let safe_address_0 = safe_address();
@@ -499,6 +500,45 @@ async fn test_safe_by_chain_key_not_found() -> anyhow::Result<()> {
         }}
         "#,
         nonexistent_key
+    );
+
+    let response = schema.execute(query).await;
+    insta::assert_yaml_snapshot!(response);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_safe_by_registered_node_query() -> anyhow::Result<()> {
+    let db = BlokliDb::new_in_memory().await?;
+
+    let safe_address = safe_address();
+    let module_address = module_address();
+    let chain_key = chain_key_address();
+    let owner = owner_address();
+    let registered_node = Address::new(&[0x88; 20]);
+
+    db.create_safe_contract(None, safe_address, module_address, chain_key, 100, 0, 0)
+        .await?;
+    db.upsert_safe_owner_state(None, safe_address, owner, true, 101, 0, 0)
+        .await?;
+    db.register_node_to_safe(None, safe_address, registered_node, 102, 0, 0)
+        .await?;
+
+    let schema = build_test_schema(&db);
+    let query = format!(
+        r#"
+        query {{
+            safeByRegisteredNode(chainKey: "{}") {{
+                ... on Safe {{
+                    address
+                    owners
+                    registeredNodes
+                }}
+            }}
+        }}
+        "#,
+        registered_node.to_hex()
     );
 
     let response = schema.execute(query).await;

--- a/api/tests/snapshots/safe_api_integration_test__safe_by_chain_key_query_returns_multiple_safes_for_same_owner.snap
+++ b/api/tests/snapshots/safe_api_integration_test__safe_by_chain_key_query_returns_multiple_safes_for_same_owner.snap
@@ -1,0 +1,8 @@
+---
+source: api/tests/safe_api_integration_test.rs
+assertion_line: 291
+expression: response
+---
+data:
+  safeByChainKey:
+    address: "0x1111111111111111111111111111111111111111"

--- a/api/tests/snapshots/safe_api_integration_test__safe_by_chain_key_query_returns_single_safe_for_deprecated_field.snap
+++ b/api/tests/snapshots/safe_api_integration_test__safe_by_chain_key_query_returns_single_safe_for_deprecated_field.snap
@@ -1,6 +1,6 @@
 ---
 source: api/tests/safe_api_integration_test.rs
-assertion_line: 291
+assertion_line: 292
 expression: response
 ---
 data:

--- a/api/tests/snapshots/safe_api_integration_test__safe_by_registered_node_query.snap
+++ b/api/tests/snapshots/safe_api_integration_test__safe_by_registered_node_query.snap
@@ -1,0 +1,12 @@
+---
+source: api/tests/safe_api_integration_test.rs
+assertion_line: 545
+expression: response
+---
+data:
+  safeByRegisteredNode:
+    address: "0x1111111111111111111111111111111111111111"
+    owners:
+      - "0x7777777777777777777777777777777777777777"
+    registeredNodes:
+      - "0x8888888888888888888888888888888888888888"

--- a/api/tests/snapshots/safe_api_integration_test__safe_by_selector_chain_key_returns_safes_list_for_single_match.snap
+++ b/api/tests/snapshots/safe_api_integration_test__safe_by_selector_chain_key_returns_safes_list_for_single_match.snap
@@ -1,0 +1,9 @@
+---
+source: api/tests/safe_api_integration_test.rs
+assertion_line: 329
+expression: response
+---
+data:
+  safeBy:
+    safes:
+      - address: "0x1111111111111111111111111111111111111111"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-client"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.26.0"
+version     = "0.27.0"
 
 [dependencies]
 anyhow          = { workspace = true }

--- a/client/src/api/v1/graphql/safe.rs
+++ b/client/src/api/v1/graphql/safe.rs
@@ -37,7 +37,7 @@ pub struct Safe {
 #[cynic(graphql_type = "QueryRoot", variables = "SafeByVariables")]
 pub struct QuerySafeBy {
     #[arguments(selector: $selector, address: $address)]
-    pub safe_by: Option<SafeResult>,
+    pub safe_by: Option<SafeByResult>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -66,6 +66,7 @@ pub struct QueryModuleAddress {
     pub calculate_module_address: CalculateModuleAddressResult,
 }
 
+/// Result union for deprecated single-safe GraphQL fields (`safe`, `safeByChainKey`, `safeByRegisteredNode`).
 #[derive(cynic::InlineFragments, Debug)]
 pub enum SafeResult {
     Safe(Safe),
@@ -82,6 +83,31 @@ impl From<SafeResult> for Result<Option<Safe>, BlokliClientError> {
             SafeResult::InvalidAddressError(e) => Err(e.into()),
             SafeResult::QueryFailedError(e) => Err(e.into()),
             SafeResult::Unknown => Err(ErrorKind::NoData.into()),
+        }
+    }
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone, PartialEq, Eq)]
+pub struct SafesList {
+    pub safes: Vec<Safe>,
+}
+
+#[derive(cynic::InlineFragments, Debug)]
+pub enum SafeByResult {
+    SafesList(SafesList),
+    InvalidAddressError(InvalidAddressError),
+    QueryFailedError(QueryFailedError),
+    #[cynic(fallback)]
+    Unknown,
+}
+
+impl From<SafeByResult> for Result<Vec<Safe>, BlokliClientError> {
+    fn from(value: SafeByResult) -> Self {
+        match value {
+            SafeByResult::SafesList(safes) => Ok(safes.safes),
+            SafeByResult::InvalidAddressError(e) => Err(e.into()),
+            SafeByResult::QueryFailedError(e) => Err(e.into()),
+            SafeByResult::Unknown => Err(ErrorKind::NoData.into()),
         }
     }
 }

--- a/client/src/api/v1/mod.rs
+++ b/client/src/api/v1/mod.rs
@@ -216,8 +216,8 @@ pub trait BlokliQueryClient {
     async fn query_safe_allowance(&self, address: &ChainAddress) -> Result<types::SafeHoprAllowance>;
     /// Queries redeemed ticket stats filtered by safe, node, or both.
     async fn query_redeemed_stats(&self, selector: RedeemedStatsSelector) -> Result<types::RedeemedStats>;
-    /// Queries the deployed Safe by the given [`selector`](SafeSelector).
-    async fn query_safe(&self, selector: SafeSelector) -> Result<Option<types::Safe>>;
+    /// Queries deployed Safes matching the given [`selector`](SafeSelector).
+    async fn query_safe(&self, selector: SafeSelector) -> Result<Vec<types::Safe>>;
     /// Queries the module address prediction of the given [Safe deployment data](ModulePredictionInput).
     async fn query_module_address_prediction(&self, input: ModulePredictionInput) -> Result<ChainAddress>;
     /// Counts the number of channels matching the given [`selector`](ChannelSelector).

--- a/client/src/client/queries.rs
+++ b/client/src/client/queries.rs
@@ -22,8 +22,8 @@ impl BlokliClient {
 
         let safe: Option<Safe> = match response_to_data(safe_response)?.safe_by {
             Some(safe_result) => {
-                let parsed_safe: Result<Option<Safe>> = safe_result.into();
-                parsed_safe?
+                let parsed_safes: Result<Vec<Safe>> = safe_result.into();
+                parsed_safes?.into_iter().next()
             }
             None => None,
         };
@@ -269,7 +269,7 @@ impl BlokliQueryClient for BlokliClient {
     }
 
     #[tracing::instrument(level = "debug", skip(self), fields(?selector))]
-    async fn query_safe(&self, selector: SafeSelector) -> Result<Option<Safe>> {
+    async fn query_safe(&self, selector: SafeSelector) -> Result<Vec<Safe>> {
         let (gql_selector, addr) = match selector {
             SafeSelector::SafeAddress(addr) => (SafeSelectorInput::Address, addr),
             SafeSelector::Owner(addr) => (SafeSelectorInput::Owner, addr),
@@ -283,7 +283,7 @@ impl BlokliQueryClient for BlokliClient {
 
         match response_to_data(res)?.safe_by {
             Some(result) => result.into(),
-            None => Ok(None),
+            None => Ok(Vec::new()),
         }
     }
 

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -199,20 +199,22 @@ impl BlokliTestState {
         self.safe_redeem_stats.get_mut(&hex::encode(chain_address))
     }
 
-    /// Convenience method to return a reference to an [`Safe`] with the given owner's [`ChainAddress`].
-    pub fn get_safe_by_owner(&self, owner: &ChainAddress) -> Option<&Safe> {
+    /// Convenience method to return references to [`Safe`]s with the given owner's [`ChainAddress`].
+    pub fn get_safe_by_owner(&self, owner: &ChainAddress) -> Vec<&Safe> {
         let owner_hex = hex::encode(owner);
         self.deployed_safes
             .values()
-            .find(|safe| Self::safe_matches_owner(safe, &owner_hex))
+            .filter(|safe| Self::safe_matches_owner(safe, &owner_hex))
+            .collect()
     }
 
-    /// Convenience method to return a mutable reference to an [`Safe`] with the given owner's [`ChainAddress`].
-    pub fn get_safe_by_owner_mut(&mut self, owner: &ChainAddress) -> Option<&mut Safe> {
+    /// Convenience method to return mutable references to [`Safe`]s with the given owner's [`ChainAddress`].
+    pub fn get_safe_by_owner_mut(&mut self, owner: &ChainAddress) -> Vec<&mut Safe> {
         let owner_hex = hex::encode(owner);
         self.deployed_safes
             .values_mut()
-            .find(|safe| Self::safe_matches_owner(safe, &owner_hex))
+            .filter(|safe| Self::safe_matches_owner(safe, &owner_hex))
+            .collect()
     }
 }
 
@@ -567,20 +569,27 @@ impl<M: BlokliTestStateMutator + Send + Sync> BlokliQueryClient for BlokliTestCl
         }
     }
 
-    async fn query_safe(&self, selector: SafeSelector) -> Result<Option<Safe>> {
+    async fn query_safe(&self, selector: SafeSelector) -> Result<Vec<Safe>> {
         let state = self.state.read();
         match selector {
-            SafeSelector::SafeAddress(addr) => Ok(state.deployed_safes.get(&hex::encode(addr)).cloned()),
+            SafeSelector::SafeAddress(addr) => Ok(state
+                .deployed_safes
+                .get(&hex::encode(addr))
+                .cloned()
+                .into_iter()
+                .collect()),
             SafeSelector::Owner(owner_address) | SafeSelector::ChainKey(owner_address) => Ok(state
                 .deployed_safes
                 .values()
-                .find(|s| BlokliTestState::safe_matches_owner(s, &hex::encode(owner_address)))
-                .cloned()),
+                .filter(|s| BlokliTestState::safe_matches_owner(s, &hex::encode(owner_address)))
+                .cloned()
+                .collect()),
             SafeSelector::RegisteredNode(node_address) => Ok(state
                 .deployed_safes
                 .values()
-                .find(|s| s.registered_nodes.contains(&hex::encode(node_address)))
-                .cloned()),
+                .filter(|s| s.registered_nodes.contains(&hex::encode(node_address)))
+                .cloned()
+                .collect()),
         }
     }
 

--- a/client/tests/query_tests.rs
+++ b/client/tests/query_tests.rs
@@ -1,4 +1,7 @@
-use blokli_client::{BlokliClient, api::BlokliQueryClient};
+use blokli_client::{
+    BlokliClient,
+    api::{BlokliQueryClient, SafeSelector},
+};
 use serde_json::json;
 
 use crate::common::{Body, RequestRecorder};
@@ -125,5 +128,71 @@ async fn query_compatibility() -> anyhow::Result<()> {
         })))
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_safe_returns_safes_list() -> anyhow::Result<()> {
+    let mut server = mockito::Server::new_async().await;
+    let cli = BlokliClient::new(server.url().parse()?, Default::default());
+
+    let mock = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+              "data": {
+                "safeBy": {
+                  "__typename": "SafesList",
+                  "safes": [
+                    {
+                      "address": "0x1111111111111111111111111111111111111111",
+                      "chainKey": "0x3333333333333333333333333333333333333333",
+                      "owners": ["0x7777777777777777777777777777777777777777"],
+                      "moduleAddress": "0x2222222222222222222222222222222222222222",
+                      "registeredNodes": ["0x8888888888888888888888888888888888888888"],
+                      "threshold": "2"
+                    }
+                  ]
+                }
+              }
+            }"#,
+        )
+        .create_async()
+        .await;
+
+    let safes = cli.query_safe(SafeSelector::Owner([0x77; 20])).await?;
+    assert_eq!(safes.len(), 1);
+    assert_eq!(safes[0].address, "0x1111111111111111111111111111111111111111");
+    assert_eq!(safes[0].owners, vec!["0x7777777777777777777777777777777777777777"]);
+
+    mock.assert_async().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_safe_returns_empty_vec_when_safe_by_is_null() -> anyhow::Result<()> {
+    let mut server = mockito::Server::new_async().await;
+    let cli = BlokliClient::new(server.url().parse()?, Default::default());
+
+    let mock = server
+        .mock("POST", "/graphql")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{
+              "data": {
+                "safeBy": null
+              }
+            }"#,
+        )
+        .create_async()
+        .await;
+
+    let safes = cli.query_safe(SafeSelector::Owner([0x77; 20])).await?;
+    assert!(safes.is_empty());
+
+    mock.assert_async().await;
     Ok(())
 }

--- a/db/core/src/node_safe_registrations.rs
+++ b/db/core/src/node_safe_registrations.rs
@@ -279,6 +279,7 @@ impl BlokliDbNodeSafeRegistrationOperations for BlokliDb {
 
 #[cfg(test)]
 mod tests {
+    use blokli_db_entity::conversions::node_safe_registration::fetch_registered_nodes_for_safes;
     use hopr_types::crypto_random::random_bytes;
     use sea_orm::PaginatorTrait;
 
@@ -442,6 +443,51 @@ mod tests {
         // Try to register same node to safe2 (should fail due to unique constraint on node_address)
         let result = db.register_node_to_safe(None, safe2, node, 100, 1, 0).await;
         assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fetch_registered_nodes_for_safes_batches_and_filters_invalid_nodes() -> anyhow::Result<()> {
+        let db = BlokliDb::new_in_memory().await?;
+        let conn = db.conn(crate::TargetDb::Index);
+
+        let empty = fetch_registered_nodes_for_safes(conn, &[]).await?;
+        assert!(empty.is_empty());
+
+        let safe1 = random_address();
+        let safe2 = random_address();
+        let safe3 = random_address();
+        let node1 = random_address();
+        let node2 = random_address();
+
+        db.register_node_to_safe(None, safe1, node1, 100, 0, 0).await?;
+        db.register_node_to_safe(None, safe2, node2, 101, 0, 0).await?;
+
+        HoprNodeSafeRegistration::insert(hopr_node_safe_registration::ActiveModel {
+            safe_address: Set(safe1.as_ref().to_vec()),
+            node_address: Set(vec![0xAB; 19]),
+            registered_block: Set(102),
+            registered_tx_index: Set(0),
+            registered_log_index: Set(0),
+            ..Default::default()
+        })
+        .exec(conn)
+        .await?;
+
+        let result = fetch_registered_nodes_for_safes(
+            conn,
+            &[
+                safe1.as_ref().to_vec(),
+                safe2.as_ref().to_vec(),
+                safe3.as_ref().to_vec(),
+            ],
+        )
+        .await?;
+
+        assert_eq!(result.get(safe1.as_ref()), Some(&vec![node1]));
+        assert_eq!(result.get(safe2.as_ref()), Some(&vec![node2]));
+        assert!(!result.contains_key(safe3.as_ref()));
 
         Ok(())
     }

--- a/db/entity/Cargo.toml
+++ b/db/entity/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-db-entity"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.5.1"
+version     = "0.6.0"
 
 [lints]
 workspace = true

--- a/db/entity/src/conversions/node_safe_registration.rs
+++ b/db/entity/src/conversions/node_safe_registration.rs
@@ -1,5 +1,7 @@
 //! Query helpers for node-safe registration lookups
 
+use std::collections::HashMap;
+
 use hopr_types::primitive::primitives::Address;
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 
@@ -22,4 +24,33 @@ where
         .into_iter()
         .filter_map(|reg| Address::try_from(reg.node_address.as_slice()).ok())
         .collect())
+}
+
+pub async fn fetch_registered_nodes_for_safes<C>(
+    conn: &C,
+    safe_addresses: &[Vec<u8>],
+) -> Result<HashMap<Vec<u8>, Vec<Address>>, sea_orm::DbErr>
+where
+    C: ConnectionTrait,
+{
+    if safe_addresses.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let registrations = hopr_node_safe_registration::Entity::find()
+        .filter(hopr_node_safe_registration::Column::SafeAddress.is_in(safe_addresses.to_vec()))
+        .all(conn)
+        .await?;
+
+    let mut nodes_by_safe = HashMap::new();
+    for registration in registrations {
+        if let Ok(node_address) = Address::try_from(registration.node_address.as_slice()) {
+            nodes_by_safe
+                .entry(registration.safe_address)
+                .or_insert_with(Vec::new)
+                .push(node_address);
+        }
+    }
+
+    Ok(nodes_by_safe)
 }

--- a/db/entity/src/conversions/safe_aggregation.rs
+++ b/db/entity/src/conversions/safe_aggregation.rs
@@ -52,20 +52,32 @@ where
     Ok(current_safe.map(|safe| current_safe_from_model(safe, &thresholds_by_address)))
 }
 
-pub async fn fetch_safe_by_owner<C>(conn: &C, owner_address: &[u8]) -> Result<Option<CurrentSafe>, sea_orm::DbErr>
+pub async fn fetch_safes_by_owner<C>(conn: &C, owner_address: &[u8]) -> Result<Vec<CurrentSafe>, sea_orm::DbErr>
 where
     C: ConnectionTrait,
 {
-    let safe_owner = safe_owner_current::Entity::find()
+    let thresholds_by_address = fetch_thresholds_by_safe_address(conn).await?;
+    let safe_addresses = safe_owner_current::Entity::find()
         .filter(safe_owner_current::Column::OwnerAddress.eq(owner_address.to_vec()))
         .order_by_asc(safe_owner_current::Column::SafeAddress)
-        .one(conn)
-        .await?;
+        .all(conn)
+        .await?
+        .into_iter()
+        .map(|row| row.safe_address)
+        .collect::<Vec<_>>();
 
-    match safe_owner {
-        Some(safe_owner) => fetch_safe_by_address(conn, &safe_owner.safe_address).await,
-        None => Ok(None),
+    if safe_addresses.is_empty() {
+        return Ok(Vec::new());
     }
+
+    Ok(safe_contract_current::Entity::find()
+        .filter(safe_contract_current::Column::Address.is_in(safe_addresses))
+        .order_by_asc(safe_contract_current::Column::Address)
+        .all(conn)
+        .await?
+        .into_iter()
+        .map(|safe| current_safe_from_model(safe, &thresholds_by_address))
+        .collect())
 }
 
 pub async fn fetch_safe_addresses<C>(conn: &C, owner_address: Option<&[u8]>) -> Result<Vec<Vec<u8>>, sea_orm::DbErr>

--- a/db/entity/src/conversions/safe_aggregation.rs
+++ b/db/entity/src/conversions/safe_aggregation.rs
@@ -148,6 +148,34 @@ where
     Ok(owners_by_safe)
 }
 
+pub async fn fetch_safe_owners_for_safes<C>(
+    conn: &C,
+    safe_addresses: &[Vec<u8>],
+) -> Result<HashMap<Vec<u8>, Vec<Address>>, sea_orm::DbErr>
+where
+    C: ConnectionTrait,
+{
+    if safe_addresses.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = safe_owner_current::Entity::find()
+        .filter(safe_owner_current::Column::SafeAddress.is_in(safe_addresses.to_vec()))
+        .order_by_asc(safe_owner_current::Column::SafeAddress)
+        .order_by_asc(safe_owner_current::Column::OwnerAddress)
+        .all(conn)
+        .await?;
+
+    let mut owners_by_safe: HashMap<Vec<u8>, Vec<Address>> = HashMap::new();
+    for row in rows {
+        if let Ok(owner_address) = Address::try_from(row.owner_address.as_slice()) {
+            owners_by_safe.entry(row.safe_address).or_default().push(owner_address);
+        }
+    }
+
+    Ok(owners_by_safe)
+}
+
 pub async fn fetch_all_current_safes<C>(conn: &C) -> Result<Vec<CurrentSafe>, sea_orm::DbErr>
 where
     C: ConnectionTrait,

--- a/design/target-api-schema.graphql
+++ b/design/target-api-schema.graphql
@@ -594,7 +594,7 @@ type QueryRoot {
     address: String!
     "Selector type for safe lookup"
     selector: SafeSelectorInput!
-  ): SafeResult
+  ): SafeByResult
   """
   Retrieve safe by chain key (owner address)
 
@@ -799,6 +799,10 @@ union SafeHoprAllowanceResult =
 Result type for single safe queries
 """
 union SafeResult = Safe | InvalidAddressError | QueryFailedError
+"""
+Result union for selector-based safe lookups that always return safe vectors on success.
+"""
+union SafeByResult = SafesList | InvalidAddressError | QueryFailedError
 
 """
 Aggregated wxHOPR holdings across all indexed safe contracts

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name    = "blokli-integration-tests"
 publish = false
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/tests/integration/src/fixtures.rs
+++ b/tests/integration/src/fixtures.rs
@@ -257,7 +257,9 @@ impl IntegrationFixture {
         let maybe_safe = self
             .client()
             .query_safe(SafeSelector::ChainKey(owner.to_alloy_address().into()))
-            .await?;
+            .await?
+            .into_iter()
+            .next();
 
         match maybe_safe {
             Some(s) => Ok(s),
@@ -273,7 +275,7 @@ impl IntegrationFixture {
                     || {
                         let client = client.clone();
                         let selector = selector.clone();
-                        async move { Ok(client.query_safe(selector).await?) }
+                        async move { Ok(client.query_safe(selector).await?.into_iter().next()) }
                     },
                 )
                 .await?;

--- a/tests/integration/tests/blokli_load.rs
+++ b/tests/integration/tests/blokli_load.rs
@@ -40,7 +40,7 @@ async fn open_multiple_channels_simultaneously(#[future(awt)] fixture: Integrati
                 || {
                     let client = client.clone();
                     let selector = selector.clone();
-                    async move { Ok(client.query_safe(selector).await?) }
+                    async move { Ok(client.query_safe(selector).await?.into_iter().next()) }
                 },
             )
             .await
@@ -58,7 +58,7 @@ async fn open_multiple_channels_simultaneously(#[future(awt)] fixture: Integrati
     let modules_by_chain_key = futures::future::try_join_all(safes_futures)
         .await?
         .iter()
-        .flatten()
+        .flat_map(|safes| safes.iter())
         .map(|safe| (safe.chain_key.clone(), safe.module_address.clone()))
         .collect::<HashMap<String, String>>();
 

--- a/tests/integration/tests/blokli_query_client.rs
+++ b/tests/integration/tests/blokli_query_client.rs
@@ -127,7 +127,9 @@ async fn query_token_balance_and_allowance_of_safe(#[future(awt)] fixture: Integ
     let maybe_safe = fixture
         .client()
         .query_safe(SafeSelector::ChainKey(account.to_alloy_address().into()))
-        .await?;
+        .await?
+        .into_iter()
+        .next();
 
     let safe = match maybe_safe {
         Some(safe) => safe,
@@ -142,7 +144,7 @@ async fn query_token_balance_and_allowance_of_safe(#[future(awt)] fixture: Integ
                 || {
                     let client = client.clone();
                     let selector = selector.clone();
-                    async move { Ok(client.query_safe(selector).await?) }
+                    async move { Ok(client.query_safe(selector).await?.into_iter().next()) }
                 },
             )
             .await?
@@ -185,6 +187,8 @@ async fn query_safe_returns_indexed_owners(#[future(awt)] fixture: IntegrationFi
         .client()
         .query_safe(SafeSelector::Owner(account.to_alloy_address().into()))
         .await?
+        .into_iter()
+        .next()
         .context("deployed safe not found")?;
 
     assert_eq!(safe.address.to_lowercase(), deployed_safe.address.to_lowercase());

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -382,7 +382,7 @@ async fn subscribe_safe_deployments(#[future(awt)] fixture: IntegrationFixture) 
             .client()
             .query_safe(SafeSelector::ChainKey(maybe_account.to_alloy_address().into()))
             .await?;
-        if safe.is_none() {
+        if safe.is_empty() {
             break maybe_account;
         }
     };


### PR DESCRIPTION
Ensures all safes matching the SafeSelector by owner returns all safes matching the criteria.
Now instead of returning an `Option<Safe>` the safe query returns a `Vec<Safe>`, and it applies for all filters. The downstream crates have to update the result parsing. 

Closes #340 