### PR TITLE
fix: Remove build redundancy on build-library

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -56,13 +56,10 @@ jobs:
         include:
           - architecture: x86_64-linux
             runner: depot-ubuntu-24.04-4
-            build_command: nix build -L .#lib-blokli-client-x86_64-linux
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-4
-            build_command: nix build -L .#lib-blokli-client-aarch64-linux
           - architecture: aarch64-darwin
             runner: depot-macos-15
-            build_command: nix build -L .#lib-blokli-client-aarch64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read
@@ -72,7 +69,6 @@ jobs:
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: blokli
       build_file: client/Cargo.toml
-      build_command: ${{ matrix.build_command }}
       package_name: blokli-client
       runner: ${{ matrix.runner }}
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -174,15 +174,12 @@ jobs:
         include:
           - architecture: x86_64-linux
             runner: depot-ubuntu-24.04-4
-            build_command: nix build -L .#lib-blokli-client-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-4
-            build_command: nix build -L .#lib-blokli-client-aarch64-linux
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin
             runner: depot-macos-15
-            build_command: nix build -L .#lib-blokli-client-aarch64-darwin
             required_label: "binary:aarch64-darwin"
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
@@ -193,7 +190,6 @@ jobs:
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: blokli
       build_file: client/Cargo.toml
-      build_command: ${{ matrix.build_command }}
       package_name: blokli-client
       runner: ${{ matrix.runner }}
       enabled: ${{ matrix.required_label == '' || contains(github.event.pull_request.labels.*.name, matrix.required_label) }}

--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -28,7 +28,6 @@ jobs:
       architecture: x86_64-linux
       cachix_cache_name: blokli
       build_file: client/Cargo.toml
-      build_command: nix build -L .#lib-blokli-client-x86_64-linux
       package_name: blokli-client
       runner: depot-ubuntu-24.04-4
     secrets:


### PR DESCRIPTION
Following the work done in #342 here we remove the duplication step of building on the library workflow.
The workflow tag `build-library-v2` has a [breaking change](https://github.com/hoprnet/hopr-workflows/commit/823f16a80906d442ab425b81f2d0031a7d0764e8), but as it's being used only by this repo we didn't upgrade the tag. 

Other PR in this repo might fail while this PR is not merge