### PR TITLE
fix(api): query by chain-key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-db-entity"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "blokli-db-migration",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-inspector"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "blokli-client",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.22.0"
+version     = "0.22.1"
 
 [lints]
 workspace = true

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -17,7 +17,7 @@ use blokli_db_entity::{
     conversions::{
         account_aggregation::fetch_accounts_with_filters,
         channel_aggregation::{fetch_channel_stats as fetch_channel_stats_db, fetch_channels_with_state},
-        node_safe_registration::{fetch_registered_nodes_for_safe, fetch_registered_nodes_for_safes},
+        node_safe_registration::fetch_registered_nodes_for_safes,
         redemptions_aggregation::fetch_aggregated_redeemed_stats,
         safe_aggregation::{
             CurrentSafe, fetch_all_current_safes, fetch_safe_addresses as fetch_safe_addresses_db,
@@ -258,19 +258,6 @@ fn safe_from_current_row(
     })
 }
 
-async fn registered_nodes_for_safe(db: &DatabaseConnection, safe_address: Vec<u8>) -> Vec<String> {
-    match fetch_registered_nodes_for_safe(db, &safe_address).await {
-        Ok(nodes) => nodes.into_iter().map(|addr| addr.to_hex()).collect(),
-        Err(e) => {
-            warn!(
-                error = %e,
-                "Failed to fetch registered nodes for safe, returning empty list"
-            );
-            Vec::new()
-        }
-    }
-}
-
 async fn registered_nodes_by_safe(
     db: &DatabaseConnection,
     safe_addresses: &[Vec<u8>],
@@ -320,19 +307,37 @@ async fn owners_by_safe(
         .collect())
 }
 
-async fn build_safe_from_current(
+async fn build_safes_list_from_current_rows(
     db: &DatabaseConnection,
-    current: CurrentSafe,
-) -> std::result::Result<Safe, QueryFailedError> {
-    let safe_address = current.address.clone();
-    let owners = owners_for_safe(db, safe_address.clone()).await?;
-    safe_from_current_row(current, registered_nodes_for_safe(db, safe_address).await, owners)
-        .map_err(|e| errors::invalid_db_data("safe addresses", &e))
+    current_rows: Vec<CurrentSafe>,
+) -> std::result::Result<SafesList, QueryFailedError> {
+    let safe_addresses = current_rows
+        .iter()
+        .map(|current| current.address.clone())
+        .collect::<Vec<_>>();
+    let owners_by_safe = owners_by_safe(db, &safe_addresses).await?;
+    let registered_nodes_by_safe = registered_nodes_by_safe(db, &safe_addresses).await;
+    let safes = current_rows
+        .into_iter()
+        .map(|current| {
+            let registered_nodes = registered_nodes_by_safe
+                .get(&current.address)
+                .cloned()
+                .unwrap_or_default();
+            let owners = owners_by_safe.get(&current.address).cloned().unwrap_or_default();
+            safe_from_current_row(current, registered_nodes, owners)
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| errors::invalid_db_data("safe addresses", &e))?;
+    Ok(SafesList { safes })
 }
 
-async fn build_single_safe_by_result_from_current(db: &DatabaseConnection, current: CurrentSafe) -> SafeByResult {
-    match build_safe_from_current(db, current).await {
-        Ok(safe) => SafeByResult::Safes(SafesList { safes: vec![safe] }),
+async fn build_safe_by_result_from_current_rows(
+    db: &DatabaseConnection,
+    current_rows: Vec<CurrentSafe>,
+) -> SafeByResult {
+    match build_safes_list_from_current_rows(db, current_rows).await {
+        Ok(safes) => SafeByResult::Safes(safes),
         Err(e) => SafeByResult::QueryFailed(e),
     }
 }
@@ -1006,7 +1011,7 @@ impl QueryRoot {
                 };
 
                 match fetch_safe_by_address_db(db, &safe_address).await {
-                    Ok(Some(current)) => Ok(Some(build_single_safe_by_result_from_current(db, current).await)),
+                    Ok(Some(current)) => Ok(Some(build_safe_by_result_from_current_rows(db, vec![current]).await)),
                     Ok(None) => Ok(None),
                     Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed("fetch safe", e)))),
                 }
@@ -1020,44 +1025,7 @@ impl QueryRoot {
 
                 match fetch_safes_by_owner_db(db, &owner_address).await {
                     Ok(safes) if safes.is_empty() => Ok(None),
-                    Ok(safes) => {
-                        let safe_addresses = safes.iter().map(|current| current.address.clone()).collect::<Vec<_>>();
-                        let owners_by_safe = match owners_by_safe(db, &safe_addresses).await {
-                            Ok(owners_by_safe) => owners_by_safe,
-                            Err(e) => return Ok(Some(SafeByResult::QueryFailed(e))),
-                        };
-                        let registered_nodes_by_safe = registered_nodes_by_safe(db, &safe_addresses).await;
-                        let mut safe_list = Vec::with_capacity(safes.len());
-                        let mut owners_by_safe_map = HashMap::with_capacity(safes.len());
-                        for safe_address in &safe_addresses {
-                            if let Some(owners) = owners_by_safe.get(safe_address) {
-                                owners_by_safe_map.insert(safe_address.clone(), owners.clone());
-                            }
-                        }
-                        let mut registered_nodes_by_safe_map = HashMap::with_capacity(safes.len());
-                        for safe_address in &safe_addresses {
-                            if let Some(registered_nodes) = registered_nodes_by_safe.get(safe_address) {
-                                registered_nodes_by_safe_map.insert(safe_address.clone(), registered_nodes.clone());
-                            }
-                        }
-                        for current in safes {
-                            let safe_address = current.address.clone();
-                            let owners = owners_by_safe_map.remove(&safe_address).unwrap_or_default();
-                            let registered_nodes =
-                                registered_nodes_by_safe_map.remove(&safe_address).unwrap_or_default();
-                            let safe = match safe_from_current_row(current, registered_nodes, owners) {
-                                Ok(safe) => safe,
-                                Err(e) => {
-                                    return Ok(Some(SafeByResult::QueryFailed(errors::invalid_db_data(
-                                        "safe addresses",
-                                        &e,
-                                    ))));
-                                }
-                            };
-                            safe_list.push(safe);
-                        }
-                        Ok(Some(SafeByResult::Safes(SafesList { safes: safe_list })))
-                    }
+                    Ok(safes) => Ok(Some(build_safe_by_result_from_current_rows(db, safes).await)),
                     Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                         "fetch safe by owner",
                         e,
@@ -1073,44 +1041,7 @@ impl QueryRoot {
 
                 match fetch_safes_by_chain_key_db(db, &chain_key).await {
                     Ok(safes) if safes.is_empty() => Ok(None),
-                    Ok(safes) => {
-                        let safe_addresses = safes.iter().map(|current| current.address.clone()).collect::<Vec<_>>();
-                        let owners_by_safe = match owners_by_safe(db, &safe_addresses).await {
-                            Ok(owners_by_safe) => owners_by_safe,
-                            Err(e) => return Ok(Some(SafeByResult::QueryFailed(e))),
-                        };
-                        let registered_nodes_by_safe = registered_nodes_by_safe(db, &safe_addresses).await;
-                        let mut safe_list = Vec::with_capacity(safes.len());
-                        let mut owners_by_safe_map = HashMap::with_capacity(safes.len());
-                        for safe_address in &safe_addresses {
-                            if let Some(owners) = owners_by_safe.get(safe_address) {
-                                owners_by_safe_map.insert(safe_address.clone(), owners.clone());
-                            }
-                        }
-                        let mut registered_nodes_by_safe_map = HashMap::with_capacity(safes.len());
-                        for safe_address in &safe_addresses {
-                            if let Some(registered_nodes) = registered_nodes_by_safe.get(safe_address) {
-                                registered_nodes_by_safe_map.insert(safe_address.clone(), registered_nodes.clone());
-                            }
-                        }
-                        for current in safes {
-                            let safe_address = current.address.clone();
-                            let owners = owners_by_safe_map.remove(&safe_address).unwrap_or_default();
-                            let registered_nodes =
-                                registered_nodes_by_safe_map.remove(&safe_address).unwrap_or_default();
-                            let safe = match safe_from_current_row(current, registered_nodes, owners) {
-                                Ok(safe) => safe,
-                                Err(e) => {
-                                    return Ok(Some(SafeByResult::QueryFailed(errors::invalid_db_data(
-                                        "safe addresses",
-                                        &e,
-                                    ))));
-                                }
-                            };
-                            safe_list.push(safe);
-                        }
-                        Ok(Some(SafeByResult::Safes(SafesList { safes: safe_list })))
-                    }
+                    Ok(safes) => Ok(Some(build_safe_by_result_from_current_rows(db, safes).await)),
                     Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                         "fetch safe by chain key",
                         e,
@@ -1140,7 +1071,7 @@ impl QueryRoot {
                 };
 
                 match fetch_safe_by_address_db(db, &registration.safe_address).await {
-                    Ok(Some(current)) => Ok(Some(build_single_safe_by_result_from_current(db, current).await)),
+                    Ok(Some(current)) => Ok(Some(build_safe_by_result_from_current_rows(db, vec![current]).await)),
                     Ok(None) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                         "fetch safe by registered node",
                         "Safe not found for registered node",
@@ -1193,23 +1124,23 @@ impl QueryRoot {
         }
     }
 
-    /// Finds a Safe by owner address using the deprecated `CHAIN_KEY` selector alias.
+    /// Finds a Safe by chain key using the deprecated `safeByChainKey` resolver.
     ///
     /// The function validates the provided `chain_key` as an Ethereum-style hex address and returns one of the GraphQL
     /// union variants describing the outcome:
     /// - `Some(SafeResult::Safe(...))` when a matching safe is found,
-    /// - `None` when no safe exists for the given owner address,
+    /// - `None` when no safe exists for the given chain key,
     /// - `Some(SafeResult::InvalidAddress(...))` when the `chain_key` is not a valid hex address,
     /// - `Some(SafeResult::QueryFailed(...))` when the database query fails.
     ///
     /// # Parameters
     ///
-    /// - `chain_key`: Owner address to query (hexadecimal format).
+    /// - `chain_key`: Chain key to query (hexadecimal format).
     ///
     /// # Returns
     ///
     /// `Some(SafeResult::Safe)` with the found `Safe` if a record exists; `None` if no record exists;
-    /// `Some(SafeResult::InvalidAddress)` if the owner address format is invalid; `Some(SafeResult::QueryFailed)` if
+    /// `Some(SafeResult::InvalidAddress)` if the chain key format is invalid; `Some(SafeResult::QueryFailed)` if
     /// the database query fails.
     ///
     /// # Examples
@@ -1219,17 +1150,16 @@ impl QueryRoot {
     /// let res = futures::executor::block_on(query_root.safe_by_chain_key(&ctx, "0x0123...".to_string())).unwrap();
     /// match res {
     ///     Some(SafeResult::Safe(s)) => println!("Found safe: {}", s.address),
-    ///     Some(SafeResult::InvalidAddress(_)) => println!("Invalid owner address"),
+    ///     Some(SafeResult::InvalidAddress(_)) => println!("Invalid chain key"),
     ///     Some(SafeResult::QueryFailed(_)) => println!("Query failed"),
-    ///     None => println!("No safe for that owner address"),
+    ///     None => println!("No safe for that chain key"),
     /// }
     /// ```
     #[graphql(name = "safeByChainKey", deprecation = "Use safeBy(selector: ...)")]
     async fn safe_by_chain_key(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "Owner address to query via the deprecated CHAIN_KEY alias (hexadecimal format)")]
-        chain_key: String,
+        #[graphql(desc = "Chain key to query (hexadecimal format)")] chain_key: String,
     ) -> Result<Option<SafeResult>> {
         match self.safe_by(ctx, SafeSelectorInput::ChainKey, chain_key).await? {
             Some(SafeByResult::Safes(mut safes)) => Ok(safes.safes.drain(..).next().map(SafeResult::Safe)),
@@ -1323,52 +1253,9 @@ impl QueryRoot {
             Err(e) => return Ok(SafesResult::QueryFailed(errors::query_failed("fetch safes", e))),
         };
 
-        // Fetch all registrations in a single query to avoid N+1
-        let all_registrations = match hopr_node_safe_registration::Entity::find().all(db).await {
-            Ok(registrations) => registrations,
-            Err(e) => {
-                return Ok(SafesResult::QueryFailed(errors::query_failed(
-                    "fetch safe registrations",
-                    e,
-                )));
-            }
-        };
-
-        // Group registrations by safe address
-        let mut registrations_by_safe: HashMap<Vec<u8>, Vec<String>> = HashMap::new();
-        for reg in all_registrations {
-            if let Ok(node_addr) = Address::try_from(reg.node_address.as_slice()) {
-                registrations_by_safe
-                    .entry(reg.safe_address.clone())
-                    .or_default()
-                    .push(node_addr.to_hex());
-            }
-        }
-
-        let safe_addresses = current_rows
-            .iter()
-            .map(|current| current.address.clone())
-            .collect::<Vec<_>>();
-        let owners_by_safe = match owners_by_safe(db, &safe_addresses).await {
-            Ok(owners_by_safe) => owners_by_safe,
-            Err(e) => return Ok(SafesResult::QueryFailed(e)),
-        };
-
-        let safe_results: Result<Vec<Safe>, String> = current_rows
-            .into_iter()
-            .map(|current| {
-                let registered_nodes = registrations_by_safe
-                    .get(&current.address)
-                    .cloned()
-                    .unwrap_or_else(Vec::new);
-                let owners = owners_by_safe.get(&current.address).cloned().unwrap_or_else(Vec::new);
-                safe_from_current_row(current, registered_nodes, owners)
-            })
-            .collect();
-
-        match safe_results {
-            Ok(safe_list) => Ok(SafesResult::Safes(SafesList { safes: safe_list })),
-            Err(e) => Ok(SafesResult::QueryFailed(errors::invalid_db_data("safe addresses", &e))),
+        match build_safes_list_from_current_rows(db, current_rows).await {
+            Ok(safes) => Ok(SafesResult::Safes(safes)),
+            Err(e) => Ok(SafesResult::QueryFailed(e)),
         }
     }
 

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -261,26 +261,18 @@ fn safe_from_current_row(
 async fn registered_nodes_by_safe(
     db: &DatabaseConnection,
     safe_addresses: &[Vec<u8>],
-) -> HashMap<Vec<u8>, Vec<String>> {
-    match fetch_registered_nodes_for_safes(db, safe_addresses).await {
-        Ok(by_safe) => {
-            let mut registered_nodes_by_safe = HashMap::with_capacity(safe_addresses.len());
-            for (safe_address, nodes) in by_safe {
-                registered_nodes_by_safe.insert(
-                    safe_address,
-                    nodes.into_iter().map(|node_address| node_address.to_hex()).collect(),
-                );
-            }
-            registered_nodes_by_safe
-        }
-        Err(e) => {
-            warn!(
-                error = %e,
-                "Failed to batch-fetch registered nodes for safes, returning empty lists"
-            );
-            HashMap::with_capacity(safe_addresses.len())
-        }
-    }
+) -> std::result::Result<HashMap<Vec<u8>, Vec<String>>, QueryFailedError> {
+    Ok(fetch_registered_nodes_for_safes(db, safe_addresses)
+        .await
+        .map_err(|e| errors::query_failed("fetch registered nodes for list query", e))?
+        .into_iter()
+        .map(|(safe_address, nodes)| {
+            (
+                safe_address,
+                nodes.into_iter().map(|node_address| node_address.to_hex()).collect(),
+            )
+        })
+        .collect())
 }
 
 pub(crate) async fn owners_for_safe(
@@ -316,7 +308,7 @@ async fn build_safes_list_from_current_rows(
         .map(|current| current.address.clone())
         .collect::<Vec<_>>();
     let owners_by_safe = owners_by_safe(db, &safe_addresses).await?;
-    let registered_nodes_by_safe = registered_nodes_by_safe(db, &safe_addresses).await;
+    let registered_nodes_by_safe = registered_nodes_by_safe(db, &safe_addresses).await?;
     let safes = current_rows
         .into_iter()
         .map(|current| {

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -1804,7 +1804,8 @@ mod tests {
         safe_history::{BlokliDbSafeHistoryOperations, SafeActivityKind},
     };
     use blokli_db_entity::conversions::safe_aggregation::{
-        CurrentSafe, fetch_safe_addresses, fetch_safe_threshold_by_address, fetch_safes_by_owner,
+        CurrentSafe, fetch_safe_addresses, fetch_safe_threshold_by_address, fetch_safes_by_chain_key,
+        fetch_safes_by_owner,
     };
     use hopr_types::{
         crypto::types::Hash,
@@ -2129,6 +2130,69 @@ mod tests {
         assert_eq!(
             safe_two_result["registeredNodes"].as_array(),
             Some(&vec![serde_json::Value::String(node_two_hex)])
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_safe_by_chain_key_uses_chain_key_lookup() -> anyhow::Result<()> {
+        let db = BlokliDb::new_in_memory().await?;
+
+        let safe = random_address();
+        let module = random_address();
+        let chain_key = random_address();
+        let owner = random_address();
+        let node = random_address();
+
+        db.create_safe_contract(None, safe, module, chain_key, 100, 0, 0)
+            .await?;
+        db.upsert_safe_owner_state(None, safe, owner, true, 101, 0, 0).await?;
+        db.register_node_to_safe(None, safe, node, 102, 0, 0).await?;
+
+        let conn = db.conn(TargetDb::Index);
+        let fetched = fetch_safes_by_chain_key(conn, chain_key.as_ref()).await?;
+        assert_eq!(fetched.len(), 1, "chain-key lookup should match one safe");
+        assert_eq!(fetched[0].address, safe.as_ref().to_vec());
+
+        let schema = build_test_schema(&db);
+        let query = format!(
+            r#"
+            query {{
+              safeBy(selector: CHAIN_KEY, address: "{}") {{
+                ... on SafesList {{
+                  safes {{
+                    address
+                    chainKey
+                    owners
+                    registeredNodes
+                  }}
+                }}
+              }}
+            }}
+            "#,
+            chain_key.to_hex()
+        );
+
+        let response = schema.execute(query).await;
+        let body = response.data.into_json()?;
+        let safes = body["safeBy"]["safes"]
+            .as_array()
+            .ok_or_else(|| anyhow!("expected safeBy.safes array"))?;
+        assert_eq!(safes.len(), 1);
+
+        let safe_item = &safes[0];
+        assert_eq!(safe_item["address"], safe.to_hex());
+        assert_eq!(safe_item["chainKey"], chain_key.to_hex());
+        assert!(
+            safe_item["owners"].as_array().is_some_and(|owners| owners
+                .iter()
+                .any(|value| value == &serde_json::Value::String(owner.to_hex()))),
+            "owners should include current owner"
+        );
+        assert_eq!(
+            safe_item["registeredNodes"].as_array(),
+            Some(&vec![serde_json::Value::String(node.to_hex())])
         );
 
         Ok(())

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -22,7 +22,7 @@ use blokli_db_entity::{
         safe_aggregation::{
             CurrentSafe, fetch_all_current_safes, fetch_safe_addresses as fetch_safe_addresses_db,
             fetch_safe_by_address as fetch_safe_by_address_db, fetch_safe_owners, fetch_safe_owners_for_safes,
-            fetch_safes_by_owner as fetch_safes_by_owner_db,
+            fetch_safes_by_chain_key as fetch_safes_by_chain_key_db, fetch_safes_by_owner as fetch_safes_by_owner_db,
         },
     },
     hopr_node_safe_registration,
@@ -1012,7 +1012,7 @@ impl QueryRoot {
                 }
             }
 
-            SafeSelectorInput::Owner | SafeSelectorInput::ChainKey => {
+            SafeSelectorInput::Owner => {
                 let owner_address = match parse_eth_address(address) {
                     Ok(addr) => addr.as_ref().to_vec(),
                     Err(e) => return Ok(Some(SafeByResult::InvalidAddress(e))),
@@ -1060,6 +1060,59 @@ impl QueryRoot {
                     }
                     Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
                         "fetch safe by owner",
+                        e,
+                    )))),
+                }
+            }
+
+            SafeSelectorInput::ChainKey => {
+                let chain_key = match parse_eth_address(address) {
+                    Ok(addr) => addr.as_ref().to_vec(),
+                    Err(e) => return Ok(Some(SafeByResult::InvalidAddress(e))),
+                };
+
+                match fetch_safes_by_chain_key_db(db, &chain_key).await {
+                    Ok(safes) if safes.is_empty() => Ok(None),
+                    Ok(safes) => {
+                        let safe_addresses = safes.iter().map(|current| current.address.clone()).collect::<Vec<_>>();
+                        let owners_by_safe = match owners_by_safe(db, &safe_addresses).await {
+                            Ok(owners_by_safe) => owners_by_safe,
+                            Err(e) => return Ok(Some(SafeByResult::QueryFailed(e))),
+                        };
+                        let registered_nodes_by_safe = registered_nodes_by_safe(db, &safe_addresses).await;
+                        let mut safe_list = Vec::with_capacity(safes.len());
+                        let mut owners_by_safe_map = HashMap::with_capacity(safes.len());
+                        for safe_address in &safe_addresses {
+                            if let Some(owners) = owners_by_safe.get(safe_address) {
+                                owners_by_safe_map.insert(safe_address.clone(), owners.clone());
+                            }
+                        }
+                        let mut registered_nodes_by_safe_map = HashMap::with_capacity(safes.len());
+                        for safe_address in &safe_addresses {
+                            if let Some(registered_nodes) = registered_nodes_by_safe.get(safe_address) {
+                                registered_nodes_by_safe_map.insert(safe_address.clone(), registered_nodes.clone());
+                            }
+                        }
+                        for current in safes {
+                            let safe_address = current.address.clone();
+                            let owners = owners_by_safe_map.remove(&safe_address).unwrap_or_default();
+                            let registered_nodes =
+                                registered_nodes_by_safe_map.remove(&safe_address).unwrap_or_default();
+                            let safe = match safe_from_current_row(current, registered_nodes, owners) {
+                                Ok(safe) => safe,
+                                Err(e) => {
+                                    return Ok(Some(SafeByResult::QueryFailed(errors::invalid_db_data(
+                                        "safe addresses",
+                                        &e,
+                                    ))));
+                                }
+                            };
+                            safe_list.push(safe);
+                        }
+                        Ok(Some(SafeByResult::Safes(SafesList { safes: safe_list })))
+                    }
+                    Err(e) => Ok(Some(SafeByResult::QueryFailed(errors::query_failed(
+                        "fetch safe by chain key",
                         e,
                     )))),
                 }

--- a/api/tests/safe_api_integration_test.rs
+++ b/api/tests/safe_api_integration_test.rs
@@ -240,7 +240,7 @@ async fn test_safe_by_chain_key_query() -> anyhow::Result<()> {
             }}
         }}
         "#,
-        owner_address.to_hex()
+        chain_key.to_hex()
     );
 
     let response = schema.execute(query).await;
@@ -285,7 +285,7 @@ async fn test_safe_by_chain_key_query_returns_single_safe_for_deprecated_field()
             }}
         }}
         "#,
-        owner.to_hex()
+        chain_key_0.to_hex()
     );
 
     let response = schema.execute(query).await;
@@ -323,7 +323,7 @@ async fn test_safe_by_selector_chain_key_returns_safes_list_for_single_match() -
             }}
         }}
         "#,
-        owner.to_hex()
+        chain_key.to_hex()
     );
 
     let response = schema.execute(query).await;
@@ -539,6 +539,54 @@ async fn test_safe_by_registered_node_query() -> anyhow::Result<()> {
         }}
         "#,
         registered_node.to_hex()
+    );
+
+    let response = schema.execute(query).await;
+    insta::assert_yaml_snapshot!(response);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_safe_by_registered_node_invalid_address() -> anyhow::Result<()> {
+    let db = BlokliDb::new_in_memory().await?;
+    let schema = build_test_schema(&db);
+
+    let query = r#"
+        query {
+            safeByRegisteredNode(chainKey: "invalid_key") {
+                ... on InvalidAddressError {
+                    code
+                    message
+                    address
+                }
+            }
+        }
+    "#;
+
+    let response = schema.execute(query).await;
+    insta::assert_yaml_snapshot!(response);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_safe_by_registered_node_not_found() -> anyhow::Result<()> {
+    let db = BlokliDb::new_in_memory().await?;
+    let schema = build_test_schema(&db);
+
+    let nonexistent_node = Address::new(&[0x99; 20]).to_hex();
+    let query = format!(
+        r#"
+        query {{
+            safeByRegisteredNode(chainKey: "{}") {{
+                ... on Safe {{
+                    address
+                }}
+            }}
+        }}
+        "#,
+        nonexistent_node
     );
 
     let response = schema.execute(query).await;

--- a/api/tests/snapshots/safe_api_integration_test__safe_by_registered_node_invalid_address.snap
+++ b/api/tests/snapshots/safe_api_integration_test__safe_by_registered_node_invalid_address.snap
@@ -1,0 +1,9 @@
+---
+source: api/tests/safe_api_integration_test.rs
+expression: response
+---
+data:
+  safeByRegisteredNode:
+    code: INVALID_ADDRESS
+    message: "Invalid address: must be 40 hex characters (20 bytes), got 11 characters"
+    address: invalid_key

--- a/api/tests/snapshots/safe_api_integration_test__safe_by_registered_node_not_found.snap
+++ b/api/tests/snapshots/safe_api_integration_test__safe_by_registered_node_not_found.snap
@@ -1,0 +1,6 @@
+---
+source: api/tests/safe_api_integration_test.rs
+expression: response
+---
+data:
+  safeByRegisteredNode: ~

--- a/db/entity/Cargo.toml
+++ b/db/entity/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-db-entity"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.6.0"
+version     = "0.6.1"
 
 [lints]
 workspace = true

--- a/db/entity/src/conversions/safe_aggregation.rs
+++ b/db/entity/src/conversions/safe_aggregation.rs
@@ -80,6 +80,21 @@ where
         .collect())
 }
 
+pub async fn fetch_safes_by_chain_key<C>(conn: &C, chain_key: &[u8]) -> Result<Vec<CurrentSafe>, sea_orm::DbErr>
+where
+    C: ConnectionTrait,
+{
+    let thresholds_by_address = fetch_thresholds_by_safe_address(conn).await?;
+    Ok(safe_contract_current::Entity::find()
+        .filter(safe_contract_current::Column::ChainKey.eq(chain_key.to_vec()))
+        .order_by_asc(safe_contract_current::Column::Address)
+        .all(conn)
+        .await?
+        .into_iter()
+        .map(|safe| current_safe_from_model(safe, &thresholds_by_address))
+        .collect())
+}
+
 pub async fn fetch_safe_addresses<C>(conn: &C, owner_address: Option<&[u8]>) -> Result<Vec<Vec<u8>>, sea_orm::DbErr>
 where
     C: ConnectionTrait,

--- a/inspector/Cargo.toml
+++ b/inspector/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-inspector"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.11.1"
+version     = "0.11.2"
 
 
 [dependencies]

--- a/inspector/src/queries.rs
+++ b/inspector/src/queries.rs
@@ -43,6 +43,9 @@ pub(crate) enum QueryTarget {
         /// Safe owner address.
         #[arg(short, long, value_parser = clap::value_parser!(Address), group = "selector")]
         owner: Option<Address>,
+        /// Safe chain key address.
+        #[arg(long, value_parser = clap::value_parser!(Address), group = "selector")]
+        chain_key: Option<Address>,
         /// Registered node address.
         #[arg(short, long, value_parser = clap::value_parser!(Address), group = "selector")]
         registered_node: Option<Address>,
@@ -92,16 +95,21 @@ impl QueryTarget {
             QueryTarget::Safe {
                 address,
                 owner,
+                chain_key,
                 registered_node,
             } => format.serialize(
                 client
-                    .query_safe(match (address, owner, registered_node) {
-                        (Some(address), None, None) => SafeSelector::SafeAddress(address.into()),
-                        (None, Some(owner), None) => SafeSelector::Owner(owner.into()),
-                        (None, None, Some(registered_node)) => SafeSelector::RegisteredNode(registered_node.into()),
+                    .query_safe(match (address, owner, chain_key, registered_node) {
+                        (Some(address), None, None, None) => SafeSelector::SafeAddress(address.into()),
+                        (None, Some(owner), None, None) => SafeSelector::Owner(owner.into()),
+                        (None, None, Some(chain_key), None) => SafeSelector::ChainKey(chain_key.into()),
+                        (None, None, None, Some(registered_node)) => {
+                            SafeSelector::RegisteredNode(registered_node.into())
+                        }
                         _ => {
                             return Err(anyhow::anyhow!(
-                                "Exactly one of --address, --owner or --registered-node must be specified."
+                                "Exactly one of --address, --owner, --chain-key or --registered-node must be \
+                                 specified."
                             ));
                         }
                     })


### PR DESCRIPTION
The `safeByChainKey` query (deprecated) uses the `safeBy` query under the hood.
The `safeBy` match on the selector assumed the owner and chain-key to be the same kind of data, except named differently, applying the same look up logic. Basically, when querying by chain-key, blokli was looking for owners with this value, where it should have been chain-keys.

In this PR, the chain-key lookup has its own logic, looking for the provided value in the chain-key column of the db.

_Tested on a test blokli instance. Clients can see their safes again when doing safeByChainKey queries._

Closes #350 