### PR TITLE
feat(docker): align anvil-bloklid local cluster with rotsee oracle values

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -76,7 +76,7 @@ jobs:
   build-docker:
     name: Docker
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@43b03a7b5df777770d95c6524f48be34184b26fa # build-docker-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     needs: build-binaries
     permissions:
       contents: read
@@ -111,7 +111,7 @@ jobs:
   build-docker-with-anvil:
     name: Docker anvil
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@43b03a7b5df777770d95c6524f48be34184b26fa # build-docker-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     needs: build-binaries
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -199,7 +199,7 @@ jobs:
   # ── Build: Docker ───────────────────────────────────────────────────────────
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@43b03a7b5df777770d95c6524f48be34184b26fa # build-docker-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     needs: build-binaries
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@43b03a7b5df777770d95c6524f48be34184b26fa # build-docker-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@build-docker-v2
     needs: build-binaries
     permissions:
       contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -168,3 +168,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use hopr_types::{internal::prelude::WinningProbability, primitive::prelude::HoprBalance};
+
+    #[test]
+    fn ticket_price_parses_from_wxhopr_string() {
+        let balance = HoprBalance::from_str("1 wxHOPR").expect("valid balance string");
+        // 1 wxHOPR = 10^18 wei
+        assert_eq!(balance.to_string(), "1 wxHOPR");
+    }
+
+    #[test]
+    fn winning_probability_parses_from_float_string() {
+        let prob = WinningProbability::from_str("0.00000125").expect("valid probability string");
+        let roundtrip = prob.as_f64();
+        // Allow epsilon from the reduced-precision IEEE-754 encoding
+        assert!((roundtrip - 0.00000125_f64).abs() < WinningProbability::EPSILON);
+    }
+}

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -171,22 +171,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use clap::Parser;
 
-    use hopr_types::{internal::prelude::WinningProbability, primitive::prelude::HoprBalance};
+    use super::Args;
 
     #[test]
-    fn ticket_price_parses_from_wxhopr_string() {
-        let balance = HoprBalance::from_str("1 wxHOPR").expect("valid balance string");
+    fn ticket_price_arg_parses_wxhopr_string() {
+        let args = Args::try_parse_from(["blokli-contract-deployer", "--ticket-price", "1 wxHOPR"])
+            .expect("arg parse failed");
         // 1 wxHOPR = 10^18 wei
-        assert_eq!(balance.to_string(), "1 wxHOPR");
+        assert_eq!(args.ticket_price.to_string(), "1 wxHOPR");
     }
 
     #[test]
-    fn winning_probability_parses_from_float_string() {
-        let prob = WinningProbability::from_str("0.00000125").expect("valid probability string");
-        let roundtrip = prob.as_f64();
+    fn winning_probability_arg_parses_float_string() {
+        let args =
+            Args::try_parse_from(["blokli-contract-deployer", "--winning-probability", "0.00000125"])
+                .expect("arg parse failed");
+        let roundtrip = args.winning_probability.as_f64();
         // Allow epsilon from the reduced-precision IEEE-754 encoding
-        assert!((roundtrip - 0.00000125_f64).abs() < WinningProbability::EPSILON);
+        assert!(
+            (roundtrip - 0.00000125_f64).abs() < hopr_types::internal::prelude::WinningProbability::EPSILON
+        );
     }
 }

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -31,7 +31,7 @@ const DEFAULT_TICKET_PRICE_WEI: &str = "100";
 /// `cast call 0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa "currentWinProb()(uint56)" \
 ///   --rpc-url https://rpc.gnosischain.com`
 /// Override with `1.0` to restore the legacy "always wins" behaviour.
-const DEFAULT_WINNING_PROBABILITY: f64 = 0.00012499999999993072;
+const DEFAULT_WINNING_PROBABILITY: f64 = 0.000125;
 
 #[derive(Debug, Parser)]
 #[command(

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -4,17 +4,34 @@ use blokli_chain_types::ContractAddresses as BlokliContractAddresses;
 use clap::Parser;
 use hopli_lib::utils::{ContractInstances, h2a};
 use hopr_bindings::{
-    exports::alloy::{providers::ProviderBuilder, rpc::client::ClientBuilder, signers::local::PrivateKeySigner},
+    exports::alloy::{
+        primitives::{U256, aliases::U56},
+        providers::ProviderBuilder,
+        rpc::client::ClientBuilder,
+        signers::local::PrivateKeySigner,
+    },
     hopr_node_stake_factory::HoprNodeStakeFactory::HoprNetwork,
 };
 use hopr_types::{
     chain::ContractAddresses,
     crypto::keypairs::{ChainKeypair, Keypair},
+    internal::prelude::WinningProbability,
 };
 use serde::Serialize;
 use url::Url;
 
 const DEFAULT_ANVIL_PRIVATE_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+/// Live rotsee ticket price as of 2025-05 (in wei, 1e-16 wxHOPR). Read once via:
+/// `cast call 0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C "currentTicketPrice()(uint256)" \
+///   --rpc-url https://rpc.gnosischain.com`
+const DEFAULT_TICKET_PRICE_WEI: &str = "100";
+
+/// Live rotsee minimum winning probability as of 2025-05 (~1/8000). Read once via:
+/// `cast call 0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa "currentWinProb()(uint56)" \
+///   --rpc-url https://rpc.gnosischain.com`
+/// Override with `1.0` to restore the legacy "always wins" behaviour.
+const DEFAULT_WINNING_PROBABILITY: f64 = 0.00012499999999993072;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -29,6 +46,16 @@ struct Args {
     /// Private key used to deploy contracts
     #[arg(long, env = "ANVIL_DEPLOYER_PRIVATE_KEY", default_value = DEFAULT_ANVIL_PRIVATE_KEY)]
     private_key: String,
+
+    /// Minimum ticket price to set on the deployed HoprTicketPriceOracle (raw wei).
+    /// Defaults to the live rotsee value so the local cluster behaves like rotsee.
+    #[arg(long, env = "BLOKLI_DEPLOYER_TICKET_PRICE_WEI", default_value = DEFAULT_TICKET_PRICE_WEI)]
+    ticket_price_wei: String,
+
+    /// Minimum winning probability to set on the deployed HoprWinningProbabilityOracle (float in [0.0, 1.0]).
+    /// Defaults to the live rotsee value so the local cluster behaves like rotsee.
+    #[arg(long, env = "BLOKLI_DEPLOYER_WINNING_PROBABILITY", default_value_t = DEFAULT_WINNING_PROBABILITY)]
+    winning_probability: f64,
 
     /// Optional output path for TOML configuration
     #[arg(long)]
@@ -115,6 +142,32 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .watch()
         .await?;
     tracing::info!("updated stake factory contract");
+
+    let ticket_price = U256::from_str_radix(args.ticket_price_wei.trim(), 10)
+        .map_err(|e| format!("invalid --ticket-price-wei {:?}: {e}", args.ticket_price_wei))?;
+    instances
+        .price_oracle
+        .setTicketPrice(ticket_price)
+        .send()
+        .await?
+        .watch()
+        .await?;
+    tracing::info!("ticket price oracle set to {ticket_price} wei");
+
+    let win_prob = WinningProbability::try_from(args.winning_probability)
+        .map_err(|e| format!("invalid --winning-probability {}: {e}", args.winning_probability))?;
+    let win_prob_u56 = U56::from_be_slice(&win_prob.as_encoded());
+    instances
+        .win_prob_oracle
+        .setWinProb(win_prob_u56)
+        .send()
+        .await?
+        .watch()
+        .await?;
+    tracing::info!(
+        "winning probability oracle set to {} (U56 {win_prob_u56})",
+        args.winning_probability
+    );
 
     if let Some(path) = args.output {
         fs::write(path, toml_output)?;

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -171,27 +171,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
     use clap::Parser;
+    use hopr_types::{internal::prelude::WinningProbability, primitive::traits::IntoEndian};
 
     use super::Args;
 
     #[test]
-    fn ticket_price_arg_parses_wxhopr_string() {
-        let args = Args::try_parse_from(["blokli-contract-deployer", "--ticket-price", "1 wxHOPR"])
-            .expect("arg parse failed");
-        // 1 wxHOPR = 10^18 wei
-        assert_eq!(args.ticket_price.to_string(), "1 wxHOPR");
+    fn ticket_price_arg_default_parses() -> Result<()> {
+        let args = Args::try_parse_from(["blokli-contract-deployer"])?;
+        // 100 wei: amount() returns the raw U256 value
+        assert_eq!(args.ticket_price.amount().to_be_bytes(), {
+            let mut b = [0u8; 32];
+            b[31] = 100;
+            b
+        });
+        Ok(())
     }
 
     #[test]
-    fn winning_probability_arg_parses_float_string() {
-        let args =
-            Args::try_parse_from(["blokli-contract-deployer", "--winning-probability", "0.00000125"])
-                .expect("arg parse failed");
+    fn winning_probability_arg_default_parses() -> Result<()> {
+        let args = Args::try_parse_from(["blokli-contract-deployer"])?;
         let roundtrip = args.winning_probability.as_f64();
-        // Allow epsilon from the reduced-precision IEEE-754 encoding
-        assert!(
-            (roundtrip - 0.00000125_f64).abs() < hopr_types::internal::prelude::WinningProbability::EPSILON
-        );
+        assert!((roundtrip - 0.000125_f64).abs() < WinningProbability::EPSILON);
+        Ok(())
     }
 }

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -16,22 +16,12 @@ use hopr_types::{
     chain::ContractAddresses,
     crypto::keypairs::{ChainKeypair, Keypair},
     internal::prelude::WinningProbability,
+    primitive::{prelude::HoprBalance, traits::IntoEndian},
 };
 use serde::Serialize;
 use url::Url;
 
 const DEFAULT_ANVIL_PRIVATE_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-
-/// Live rotsee ticket price as of 2025-05 (in wei, 1e-16 wxHOPR). Read once via:
-/// `cast call 0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C "currentTicketPrice()(uint256)" \
-///   --rpc-url https://rpc.gnosischain.com`
-const DEFAULT_TICKET_PRICE_WEI: &str = "100";
-
-/// Live rotsee minimum winning probability as of 2025-05 (~1/8000). Read once via:
-/// `cast call 0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa "currentWinProb()(uint56)" \
-///   --rpc-url https://rpc.gnosischain.com`
-/// Override with `1.0` to restore the legacy "always wins" behaviour.
-const DEFAULT_WINNING_PROBABILITY: f64 = 0.000125;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -47,15 +37,20 @@ struct Args {
     #[arg(long, env = "ANVIL_DEPLOYER_PRIVATE_KEY", default_value = DEFAULT_ANVIL_PRIVATE_KEY)]
     private_key: String,
 
-    /// Minimum ticket price to set on the deployed HoprTicketPriceOracle (raw wei).
+    /// Minimum ticket price to set on the deployed HoprTicketPriceOracle.
     /// Defaults to the live rotsee value so the local cluster behaves like rotsee.
-    #[arg(long, env = "BLOKLI_DEPLOYER_TICKET_PRICE_WEI", default_value = DEFAULT_TICKET_PRICE_WEI)]
-    ticket_price_wei: String,
+    /// Read once via: cast call 0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C
+    ///   "currentTicketPrice()(uint256)" --rpc-url https://rpc.gnosischain.com
+    #[arg(long, env = "BLOKLI_DEPLOYER_TICKET_PRICE", default_value = "100 wei wxHOPR")]
+    ticket_price: HoprBalance,
 
-    /// Minimum winning probability to set on the deployed HoprWinningProbabilityOracle (float in [0.0, 1.0]).
+    /// Minimum winning probability to set on the deployed HoprWinningProbabilityOracle.
     /// Defaults to the live rotsee value so the local cluster behaves like rotsee.
-    #[arg(long, env = "BLOKLI_DEPLOYER_WINNING_PROBABILITY", default_value_t = DEFAULT_WINNING_PROBABILITY)]
-    winning_probability: f64,
+    /// Read once via: cast call 0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa
+    ///   "currentWinProb()(uint56)" --rpc-url https://rpc.gnosischain.com
+    /// Use 1.0 to restore the legacy "always wins" behaviour.
+    #[arg(long, env = "BLOKLI_DEPLOYER_WINNING_PROBABILITY", default_value = "0.000125")]
+    winning_probability: WinningProbability,
 
     /// Optional output path for TOML configuration
     #[arg(long)]
@@ -143,20 +138,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?;
     tracing::info!("updated stake factory contract");
 
-    let ticket_price = U256::from_str_radix(args.ticket_price_wei.trim(), 10)
-        .map_err(|e| format!("invalid --ticket-price-wei {:?}: {e}", args.ticket_price_wei))?;
     instances
         .price_oracle
-        .setTicketPrice(ticket_price)
+        .setTicketPrice(U256::from_be_bytes(args.ticket_price.amount().to_be_bytes()))
         .send()
         .await?
         .watch()
         .await?;
-    tracing::info!("ticket price oracle set to {ticket_price} wei");
+    tracing::info!("ticket price oracle set to {}", args.ticket_price);
 
-    let win_prob = WinningProbability::try_from(args.winning_probability)
-        .map_err(|e| format!("invalid --winning-probability {}: {e}", args.winning_probability))?;
-    let win_prob_u56 = U56::from_be_slice(&win_prob.as_encoded());
+    let win_prob_u56 = U56::from_be_slice(&args.winning_probability.as_encoded());
     instances
         .win_prob_oracle
         .setWinProb(win_prob_u56)
@@ -166,7 +157,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?;
     tracing::info!(
         "winning probability oracle set to {} (U56 {win_prob_u56})",
-        args.winning_probability
+        args.winning_probability.as_f64()
     );
 
     if let Some(path) = args.output {

--- a/docker/blokli-anvil-entrypoint.sh
+++ b/docker/blokli-anvil-entrypoint.sh
@@ -8,6 +8,20 @@ ANVIL_ACCOUNTS="${ANVIL_ACCOUNTS:-10}"
 ANVIL_BALANCE="${ANVIL_BALANCE:-10000}"
 ANVIL_RPC_URL="${ANVIL_RPC_URL:-http://127.0.0.1:${ANVIL_PORT}}"
 
+# Deployer key used for post-deploy oracle overrides (same default as blokli-contract-deployer).
+DEPLOYER_PRIVATE_KEY="${ANVIL_DEPLOYER_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+
+# Rotsee-aligned oracle overrides. Defaults mirror live rotsee values.
+#   To re-confirm rotsee's current values:
+#     cast call 0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C \
+#       "currentTicketPrice()(uint256)" --rpc-url https://rpc.gnosischain.com
+#     cast call 0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa \
+#       "currentWinProb()(uint56)" --rpc-url https://rpc.gnosischain.com
+BLOKLI_TICKET_PRICE_WEI="${BLOKLI_TICKET_PRICE_WEI:-100}"
+# Raw uint56 encoding of ~0.000125 winning probability (rotsee value as of 2025-05).
+# Use 72057594037927935 (U56 max) to restore the "always wins" behaviour if needed.
+BLOKLI_WIN_PROB_U56="${BLOKLI_WIN_PROB_U56:-9007199254735}"
+
 DATA_DIR="${BLOKLI_DATA_DIRECTORY:-/data}"
 CONFIG_PATH="${BLOKLI_CONFIG_PATH:-/config.toml}"
 
@@ -64,6 +78,26 @@ if ! blokli-contract-deployer \
   echo "Contract deployment failed" >&2
   exit 1
 fi
+
+TICKET_PRICE_ORACLE=$(awk -F'"' '/^ticket_price_oracle/ {print $2}' "${CONTRACTS_PATH}")
+WIN_PROB_ORACLE=$(awk -F'"' '/^winning_probability_oracle/ {print $2}' "${CONTRACTS_PATH}")
+
+if [ -z "${TICKET_PRICE_ORACLE}" ] || [ -z "${WIN_PROB_ORACLE}" ]; then
+  echo "Could not parse oracle addresses from ${CONTRACTS_PATH}" >&2
+  exit 1
+fi
+
+echo "Overriding ticket price oracle (${TICKET_PRICE_ORACLE}) -> ${BLOKLI_TICKET_PRICE_WEI} wei"
+cast send --rpc-url "${ANVIL_RPC_URL}" \
+  --private-key "${DEPLOYER_PRIVATE_KEY}" \
+  "${TICKET_PRICE_ORACLE}" "setTicketPrice(uint256)" "${BLOKLI_TICKET_PRICE_WEI}" \
+  >/dev/null
+
+echo "Overriding winning probability oracle (${WIN_PROB_ORACLE}) -> ${BLOKLI_WIN_PROB_U56} (U56)"
+cast send --rpc-url "${ANVIL_RPC_URL}" \
+  --private-key "${DEPLOYER_PRIVATE_KEY}" \
+  "${WIN_PROB_ORACLE}" "setWinProb(uint56)" "${BLOKLI_WIN_PROB_U56}" \
+  >/dev/null
 
 cat >"${CONFIG_PATH}" <<EOF
 data_directory = "${DATA_DIR}"

--- a/docker/blokli-anvil-entrypoint.sh
+++ b/docker/blokli-anvil-entrypoint.sh
@@ -8,20 +8,6 @@ ANVIL_ACCOUNTS="${ANVIL_ACCOUNTS:-10}"
 ANVIL_BALANCE="${ANVIL_BALANCE:-10000}"
 ANVIL_RPC_URL="${ANVIL_RPC_URL:-http://127.0.0.1:${ANVIL_PORT}}"
 
-# Deployer key used for post-deploy oracle overrides (same default as blokli-contract-deployer).
-DEPLOYER_PRIVATE_KEY="${ANVIL_DEPLOYER_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-
-# Rotsee-aligned oracle overrides. Defaults mirror live rotsee values.
-#   To re-confirm rotsee's current values:
-#     cast call 0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C \
-#       "currentTicketPrice()(uint256)" --rpc-url https://rpc.gnosischain.com
-#     cast call 0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa \
-#       "currentWinProb()(uint56)" --rpc-url https://rpc.gnosischain.com
-BLOKLI_TICKET_PRICE_WEI="${BLOKLI_TICKET_PRICE_WEI:-100}"
-# Raw uint56 encoding of ~0.000125 winning probability (rotsee value as of 2025-05).
-# Use 72057594037927935 (U56 max) to restore the "always wins" behaviour if needed.
-BLOKLI_WIN_PROB_U56="${BLOKLI_WIN_PROB_U56:-9007199254735}"
-
 DATA_DIR="${BLOKLI_DATA_DIRECTORY:-/data}"
 CONFIG_PATH="${BLOKLI_CONFIG_PATH:-/config.toml}"
 
@@ -78,26 +64,6 @@ if ! blokli-contract-deployer \
   echo "Contract deployment failed" >&2
   exit 1
 fi
-
-TICKET_PRICE_ORACLE=$(awk -F'"' '/^ticket_price_oracle/ {print $2}' "${CONTRACTS_PATH}")
-WIN_PROB_ORACLE=$(awk -F'"' '/^winning_probability_oracle/ {print $2}' "${CONTRACTS_PATH}")
-
-if [ -z "${TICKET_PRICE_ORACLE}" ] || [ -z "${WIN_PROB_ORACLE}" ]; then
-  echo "Could not parse oracle addresses from ${CONTRACTS_PATH}" >&2
-  exit 1
-fi
-
-echo "Overriding ticket price oracle (${TICKET_PRICE_ORACLE}) -> ${BLOKLI_TICKET_PRICE_WEI} wei"
-cast send --rpc-url "${ANVIL_RPC_URL}" \
-  --private-key "${DEPLOYER_PRIVATE_KEY}" \
-  "${TICKET_PRICE_ORACLE}" "setTicketPrice(uint256)" "${BLOKLI_TICKET_PRICE_WEI}" \
-  >/dev/null
-
-echo "Overriding winning probability oracle (${WIN_PROB_ORACLE}) -> ${BLOKLI_WIN_PROB_U56} (U56)"
-cast send --rpc-url "${ANVIL_RPC_URL}" \
-  --private-key "${DEPLOYER_PRIVATE_KEY}" \
-  "${WIN_PROB_ORACLE}" "setWinProb(uint56)" "${BLOKLI_WIN_PROB_U56}" \
-  >/dev/null
 
 cat >"${CONFIG_PATH}" <<EOF
 data_directory = "${DATA_DIR}"


### PR DESCRIPTION
## Summary

- Adds `--ticket-price` (`HoprBalance`, env `BLOKLI_DEPLOYER_TICKET_PRICE`) and `--winning-probability` (`WinningProbability`, env `BLOKLI_DEPLOYER_WINNING_PROBABILITY`) CLI args to `blokli-contract-deployer`
- After deploying contracts, the binary calls `setTicketPrice` and `setWinProb` on the freshly deployed oracles, defaulting to live rotsee values (`100 wei wxHOPR` / `0.000125`) so the local cluster behaves like rotsee out of the box
- Typed args (`HoprBalance`, `WinningProbability`) handle parsing and validation via their `FromStr` impls — no manual conversion in `main`
- Two unit tests verify clap parses the actual default values correctly
- Override with `BLOKLI_DEPLOYER_WINNING_PROBABILITY=1.0` to restore the legacy "always wins" configuration