### PR TITLE
fix: add missing xhopr_token contract in api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "async-graphql",
  "blokli-chain-types",

--- a/api/tests/contract_address_scalar_test.rs
+++ b/api/tests/contract_address_scalar_test.rs
@@ -71,43 +71,33 @@ fn test_contract_address_map_roundtrip_serialization() {
 
 #[test]
 fn test_contract_address_map_from_chain_types() {
-    // Create a ContractAddresses instance
     let chain_addresses = ContractAddresses::default();
-
-    // Convert to ContractAddressMap
     let map: ContractAddressMap = (&chain_addresses).into();
-
-    // Serialize it
     let serialized = map.to_value();
 
-    // Verify it's a string
     assert!(
         matches!(serialized, async_graphql::Value::String(_)),
         "Should serialize to string"
     );
 
-    // Extract and validate the JSON string
     if let async_graphql::Value::String(json_str) = serialized {
         let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("Should be valid JSON");
-
         let obj = parsed.as_object().expect("Should be an object");
+        let expected = serde_json::to_value(chain_addresses)
+            .expect("ContractAddresses should serialize")
+            .as_object()
+            .expect("ContractAddresses should serialize to object")
+            .keys()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        let actual = obj.keys().cloned().collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            actual, expected,
+            "contractAddresses keys should match ContractAddresses fields"
+        );
 
-        // Verify all required keys are present
-        let expected_keys = vec![
-            "token",
-            "channels",
-            "announcements",
-            "module_implementation",
-            "node_safe_migration",
-            "node_safe_registry",
-            "ticket_price_oracle",
-            "winning_probability_oracle",
-            "node_stake_factory",
-        ];
-
-        for key in expected_keys {
-            assert!(obj.contains_key(key), "contractAddresses should contain key: {}", key);
-            let value = obj.get(key).and_then(|v| v.as_str());
+        for key in actual {
+            let value = obj.get(&key).and_then(|v| v.as_str());
             assert!(
                 !value.unwrap_or("").is_empty(),
                 "contractAddresses[{}] should not be empty",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api-types"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.12.0"
+version     = "0.13.0"
 
 [dependencies]
 # GraphQL

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -790,6 +790,7 @@ impl From<&blokli_chain_types::ContractAddresses> for ContractAddressMap {
             ("ticket_price_oracle", &addresses.ticket_price_oracle),
             ("winning_probability_oracle", &addresses.winning_probability_oracle),
             ("node_stake_factory", &addresses.node_stake_factory),
+            ("xhopr_token", &addresses.xhopr_token),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))


### PR DESCRIPTION
Exposes the `xhopr_token` contract in the chain_info query.

It was missing in PR #352. The contract addresses returned by the API are manually serialized from the `ContractAddresses` object, and the chain_info test was also manually checking the field. So the issue didn't surface.