### PR TITLE
feat: added subscription for redeemed tickets

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # 0.6.0
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup GCP
         uses: hoprnet/hopr-workflows/actions/setup-gcp@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
         with:
-          google-credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+          google_credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           login-artifact-registry: 'true'
           install-sdk: 'false'
       - name: Run Integration tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,7 +96,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # 0.6.0
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,11 +99,11 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      unit_tests: true
+      enable_unit_tests: true
       unit_test_command: "nix run -L .#test"
-      unit_coverage: true
+      enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
       test_timeout: 30
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,6 +1809,7 @@ dependencies = [
  "pem-rfc7468 1.0.0",
  "rand 0.10.1",
  "regex",
+ "rstest",
  "rustls",
  "sea-orm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,11 @@ opt-level     = 3
 panic         = "abort"
 strip         = true
 
+# humantime-serde used only via #[serde(with = "humantime_serde")] string attrs,
+# which cargo-shear cannot detect through static analysis.
+[workspace.metadata.cargo-shear]
+ignored = ["humantime-serde"]
+
 # Workspace-level lints to prevent common issues
 [workspace.lints.clippy]
 # Prevent lossy numeric casts that can cause data corruption

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Blokli implements a temporal database system for tracking blockchain state chang
 ## Repository Layout
 
 - `bloklid/`: Indexer daemon and chain operations
-- `blokli-api/`: GraphQL API server
+- `api/`: GraphQL API server
 - `db/`: Database abstractions, entities, and migrations
 - `design/`: Architecture and target schema references
 - `tests/`: Integration and smoke tests

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,9 +29,45 @@ just test-debug
 # Run specific test by name
 cargo test test_get_channel_state_at -F runtime-tokio -- --nocapture
 
-# Run integration tests
+# Run integration tests (requires Docker — see below)
 just test-indexer
 ```
+
+### Manual API Testing (no Docker required)
+
+For interactive exploration — GraphQL playground, manual subscription testing via curl, quick
+iteration on API behaviour — you can run a local stack without building a Docker image.
+
+**Terminal 1 — Anvil:**
+```bash
+anvil --host 0.0.0.0 --port 8545 --block-time 1
+```
+
+**Terminal 2 — Deploy contracts, then start bloklid:**
+```bash
+# Deploy HOPR contracts and write their addresses to a TOML fragment
+cargo run --bin blokli-contract-deployer -- --output /tmp/contracts-deploy.toml
+
+# Append the [contracts] section to the SQLite config
+cat /tmp/contracts-deploy.toml >> config-sqlite.toml
+
+# Start bloklid with SQLite backend
+just run-sqlite
+```
+
+The GraphQL playground is available at `http://localhost:8080/graphiql` once bloklid is running.
+
+> **Note:** This approach does NOT run the automated integration tests.
+> Those always require Docker (`just test-indexer`) because the test fixture
+> manages its own Anvil + PostgreSQL stack and deploys contracts internally.
+
+**Clean up between runs:**
+```bash
+just clean-sqlite   # removes data/bloklid-index.db and data/bloklid-logs.db
+```
+
+Also remove the `[contracts]` block appended to `config-sqlite.toml` before redeploying,
+or the file will accumulate duplicate sections.
 
 ### Post-Test Workflow
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -35,15 +35,17 @@ just test-indexer
 
 ### Manual API Testing (no Docker required)
 
-For interactive exploration — GraphQL playground, manual subscription testing via curl, quick
-iteration on API behaviour — you can run a local stack without building a Docker image.
+For interactive exploration — GraphQL playground, manual subscription testing via curl, quick iteration on API behaviour — you can run a
+local stack without building a Docker image.
 
 **Terminal 1 — Anvil:**
+
 ```bash
 anvil --host 0.0.0.0 --port 8545 --block-time 1
 ```
 
 **Terminal 2 — Deploy contracts, then start bloklid:**
+
 ```bash
 # Deploy HOPR contracts and write their addresses to a TOML fragment
 cargo run --bin blokli-contract-deployer -- --output /tmp/contracts-deploy.toml
@@ -57,17 +59,16 @@ just run-sqlite
 
 The GraphQL playground is available at `http://localhost:8080/graphiql` once bloklid is running.
 
-> **Note:** This approach does NOT run the automated integration tests.
-> Those always require Docker (`just test-indexer`) because the test fixture
-> manages its own Anvil + PostgreSQL stack and deploys contracts internally.
+> **Note:** This approach does NOT run the automated integration tests. Those always require Docker (`just test-indexer`) because the test
+> fixture manages its own Anvil + PostgreSQL stack and deploys contracts internally.
 
 **Clean up between runs:**
+
 ```bash
 just clean-sqlite   # removes data/bloklid-index.db and data/bloklid-logs.db
 ```
 
-Also remove the `[contracts]` block appended to `config-sqlite.toml` before redeploying,
-or the file will accumulate duplicate sections.
+Also remove the `[contracts]` block appended to `config-sqlite.toml` before redeploying, or the file will accumulate duplicate sections.
 
 ### Post-Test Workflow
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -94,6 +94,7 @@ insta               = { workspace = true, features = ["redactions", "yaml"] }
 multiaddr           = { workspace = true }
 rand                = { workspace = true }
 regex               = { workspace = true }
+rstest              = { workspace = true }
 temp-env            = { workspace = true }
 tempfile            = { workspace = true }
 test-log            = { workspace = true }

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -6,8 +6,8 @@ use async_broadcast::Receiver;
 use async_graphql::{Context, ID, Result, Subscription};
 use async_stream::stream;
 use blokli_api_types::{
-    Account, Channel, ChannelUpdate, Hex32, OpenedChannelsGraphEntry, Safe, TicketParameters, TokenValueString,
-    Transaction, UInt64,
+    Account, Channel, ChannelUpdate, Hex32, OpenedChannelsGraphEntry, RedeemTicketDetails, RedeemTicketDetailsInfo,
+    Safe, TicketParameters, TokenValueString, Transaction, UInt64,
 };
 use blokli_chain_api::transaction_store::{
     TransactionEvent, TransactionStatus as StoreTransactionStatus, TransactionStore,
@@ -25,6 +25,7 @@ use blokli_db_entity::{
 };
 use chrono::Utc;
 use futures::Stream;
+use hopr_bindings::exports::alloy::hex;
 use hopr_types::primitive::{
     prelude::HoprBalance as PrimitiveHoprBalance,
     primitives::Address,
@@ -528,6 +529,9 @@ impl SubscriptionRoot {
                             Ok(IndexerEvent::TicketParametersUpdated(_)) => {
                                 // Ticket parameter updates don't affect this subscription
                             }
+                            Ok(IndexerEvent::TicketRedeemed(_)) => {
+                                // Ticket redeemed don't affect this subscription
+                            }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending channelUpdated subscription");
                                 return;
@@ -651,6 +655,9 @@ impl SubscriptionRoot {
                             }
                             Ok(IndexerEvent::TicketParametersUpdated(_)) => {
                                 // Ticket parameter updates don't affect this subscription
+                            }
+                            Ok(IndexerEvent::TicketRedeemed(_)) => {
+                                // Ticket redeemed don't affect this subscription
                             }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending subscription");
@@ -840,6 +847,9 @@ impl SubscriptionRoot {
                             Ok(IndexerEvent::SafeDeployed(_)) => {
                                 // Irrelevant for this subscription
                             }
+                            Ok(IndexerEvent::TicketRedeemed(_)) => {
+                                // Ticket redeemed don't affect this subscription
+                            }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending ticketParametersUpdated subscription");
                                 return;
@@ -944,6 +954,9 @@ impl SubscriptionRoot {
                             }
                             Ok(IndexerEvent::TicketParametersUpdated(_)) => {
                                 // Irrelevant for this subscription
+                            }
+                            Ok(IndexerEvent::TicketRedeemed(_)) => {
+                                // Ticket redeemed don't affect this subscription
                             }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending keyBindingFeeUpdated subscription");
@@ -1201,6 +1214,85 @@ impl SubscriptionRoot {
             }
         })
     }
+
+    #[graphql(name = "ticketRedeemed")]
+    async fn ticket_redeemed(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "Filter by channel ID (hexadecimal format)")] channel_id: Option<ID>,
+        #[graphql(desc = "Filter by ticket issuesr (hexadecimal format)")] issuer_address: Option<ID>,
+        #[graphql(desc = "Filter by ticket recepient (hexadecimal format)")] recepient_address: Option<ID>,
+    ) -> Result<impl Stream<Item = RedeemTicketDetails>> {
+        // Validate correctnes of input parameters
+        if let Some(channel_id) = &channel_id {
+            hex::check(channel_id.as_bytes()).map_err(|e| {
+                async_graphql::Error::new(format!("Invalid channel ID format: {}. Expected hex format.", e))
+            })?
+        }
+        if let Some(issuer_address) = &issuer_address {
+            hex::check(issuer_address.as_bytes()).map_err(|e| {
+                async_graphql::Error::new(format!("Invalid issuer address format: {}. expected hex format.", e))
+            })?
+        }
+        if let Some(recepient_address) = &recepient_address {
+            hex::check(recepient_address.as_bytes()).map_err(|e| {
+                async_graphql::Error::new(format!("Invalid recepient address format: {}. Expected hex format.", e))
+            })?
+        }
+
+        let indexer_state = ctx
+            .data::<IndexerState>()
+            .map_err(|e| async_graphql::Error::new(errors::messages::context_error("IndexerState", e.message)))?
+            .clone();
+
+        Ok(stream! {
+            // Subscribe to events and shutdown first to avoid missing events
+            let mut event_receiver = indexer_state.subscribe_to_events();
+            let mut shutdown_receiver = indexer_state.subscribe_to_shutdown();
+
+            // Stream updates from event bus
+            loop {
+                tokio::select! {
+                    biased;
+
+                    shutdown_result = shutdown_receiver.recv() => {
+                        match shutdown_result {
+                            Ok(_) => {
+                                info!("ticketRedeemed subscription shutting down due to reorg");
+                                return;
+                            }
+                            Err(async_broadcast::RecvError::Closed) => {
+                                warn!("Shutdown channel closed for ticketRedeemed");
+                                return;
+                            }
+                            Err(async_broadcast::RecvError::Overflowed(n)) => {
+                                warn!("Shutdown signal overflowed ({}), continuing", n);
+                            }
+                        }
+                    }
+                    event_result = event_receiver.recv() => {
+                        match event_result {
+                            Ok(IndexerEvent::TicketRedeemed(ticket_redeemed)) => {
+                                if match_ticket_filters(&ticket_redeemed, &channel_id, &issuer_address, &recepient_address) {
+                                yield ticket_redeemed.into();
+                                }
+                            }
+                            Ok(_) => {
+                                // Other events (ChannelUpdated, etc.) - ignore
+                            }
+                            Err(async_broadcast::RecvError::Closed) => {
+                                info!("Event bus closed, ending ticketRedeemed subscription");
+                                return;
+                            }
+                            Err(async_broadcast::RecvError::Overflowed(n)) => {
+                                warn!("Event bus overflowed ({}); ticketRedeemed may miss events", n);
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
 }
 
 /// Convert ChannelUpdate (from events) to OpenedChannelsGraphEntry (for GraphQL)
@@ -1254,6 +1346,61 @@ impl SubscriptionRoot {
 
         Ok(result)
     }
+}
+
+fn match_ticket_filters(
+    info: &RedeemTicketDetailsInfo,
+    channel_id: &Option<ID>,
+    issuer_address: &Option<ID>,
+    recepient_address: &Option<ID>,
+) -> bool {
+    if let Some(channel_id) = channel_id {
+        let channel_id_normalized = channel_id.strip_prefix("0x").unwrap_or(&channel_id);
+        if info.channel_id != channel_id_normalized {
+            return false;
+        }
+    }
+
+    if let Some(iss_addr) = issuer_address {
+        let iss = match Address::from_hex(&iss_addr) {
+            Ok(iss) => iss,
+            Err(_) => {
+                // Invalid address - this should never happen due to early validation of inputs
+                return false;
+            }
+        };
+        let iss_info = match Address::from_hex(&info.issuer_address) {
+            Ok(iss) => iss,
+            Err(_) => {
+                // Invalid address
+                return false;
+            }
+        };
+        if iss != iss_info {
+            return false;
+        }
+    }
+
+    if let Some(rec_addr) = recepient_address {
+        let rec = match Address::from_hex(&rec_addr) {
+            Ok(rec) => rec,
+            Err(_) => {
+                // Invalid address - this should never happen due to early validation of inputs
+                return false;
+            }
+        };
+        let rec_info = match Address::from_hex(&info.recepient_address) {
+            Ok(rec) => rec,
+            Err(_) => {
+                // Invalid address
+                return false;
+            }
+        };
+        if rec != rec_info {
+            return false;
+        }
+    }
+    true
 }
 
 /// Helper to check if an account matches the subscription filters

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -2843,8 +2843,8 @@ mod tests {
                 "ticketRedeemed": {
                     "issuerAddress": TEST_ISSUER_ADDR,
                     "recipientAddress": TEST_RECIPIENT_ADDR,
-                    "epoch": 1,
-                    "index": 42,
+                    "epoch": "1",
+                    "index": "42",
                     "result": "REDEEMED"
                 }
             }))

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -1230,23 +1230,29 @@ impl SubscriptionRoot {
         ctx: &Context<'_>,
         #[graphql(desc = "Filter by channel ID (hexadecimal format)")] channel_id: Option<ID>,
         #[graphql(desc = "Filter by ticket issuer (hexadecimal format)")] issuer_address: Option<ID>,
-        #[graphql(desc = "Filter by ticket recipient (hexadecimal format)")] recepient_address: Option<ID>,
+        #[graphql(desc = "Filter by ticket recipient (hexadecimal format)")] recipient_address: Option<ID>,
     ) -> Result<impl Stream<Item = RedeemTicketDetails>> {
         // Validate correctness of input parameters
         if let Some(channel_id) = &channel_id {
-            hex::check(channel_id.as_bytes()).map_err(|e| {
+            let stripped = channel_id.strip_prefix("0x").unwrap_or(channel_id.as_str());
+            if stripped.len() != 64 {
+                return Err(async_graphql::Error::new(
+                    "Invalid channel ID format: must be a 32-byte hex value (64 hex chars, optional 0x prefix)",
+                ));
+            }
+            hex::decode(stripped).map_err(|e| {
                 async_graphql::Error::new(format!("Invalid channel ID format: {}. Expected hex format.", e))
-            })?
+            })?;
         }
         if let Some(issuer_address) = &issuer_address {
-            hex::check(issuer_address.as_bytes()).map_err(|e| {
-                async_graphql::Error::new(format!("Invalid issuer address format: {}. expected hex format.", e))
-            })?
+            Address::from_hex(issuer_address.as_str()).map_err(|e| {
+                async_graphql::Error::new(format!("Invalid issuer address format: {}. Expected hex format.", e))
+            })?;
         }
-        if let Some(recepient_address) = &recepient_address {
-            hex::check(recepient_address.as_bytes()).map_err(|e| {
-                async_graphql::Error::new(format!("Invalid recepient address format: {}. Expected hex format.", e))
-            })?
+        if let Some(recipient_address) = &recipient_address {
+            Address::from_hex(recipient_address.as_str()).map_err(|e| {
+                async_graphql::Error::new(format!("Invalid recipient address format: {}. Expected hex format.", e))
+            })?;
         }
 
         let indexer_state = ctx
@@ -1282,7 +1288,7 @@ impl SubscriptionRoot {
                     event_result = event_receiver.recv() => {
                         match event_result {
                             Ok(IndexerEvent::TicketRedeemed(ticket_redeemed)) => {
-                                if match_ticket_filters(&ticket_redeemed, &channel_id, &issuer_address, &recepient_address) {
+                                if match_ticket_filters(&ticket_redeemed, &channel_id, &issuer_address, &recipient_address) {
                                 yield ticket_redeemed.into();
                                 }
                             }
@@ -1373,10 +1379,13 @@ fn match_ticket_filters(
     info: &RedeemTicketDetailsInfo,
     channel_id: &Option<ID>,
     issuer_address: &Option<ID>,
-    recepient_address: &Option<ID>,
+    recipient_address: &Option<ID>,
 ) -> bool {
     if let Some(channel_id) = channel_id {
-        let channel_id_normalized = channel_id.strip_prefix("0x").unwrap_or(channel_id);
+        let channel_id_normalized = channel_id
+            .strip_prefix("0x")
+            .unwrap_or(channel_id.as_str())
+            .to_lowercase();
         if info.channel_id != channel_id_normalized {
             return false;
         }
@@ -1402,7 +1411,7 @@ fn match_ticket_filters(
         }
     }
 
-    if let Some(rec_addr) = recepient_address {
+    if let Some(rec_addr) = recipient_address {
         let rec = match Address::from_hex(rec_addr) {
             Ok(rec) => rec,
             Err(_) => {
@@ -1410,7 +1419,7 @@ fn match_ticket_filters(
                 return false;
             }
         };
-        let rec_info = match Address::from_hex(&info.recepient_address) {
+        let rec_info = match Address::from_hex(&info.recipient_address) {
             Ok(rec) => rec,
             Err(_) => {
                 // Invalid address
@@ -2750,7 +2759,7 @@ mod tests {
     fn make_test_ticket_info() -> RedeemTicketDetailsInfo {
         RedeemTicketDetailsInfo {
             issuer_address: TEST_ISSUER_ADDR.to_string(),
-            recepient_address: TEST_RECIPIENT_ADDR.to_string(),
+            recipient_address: TEST_RECIPIENT_ADDR.to_string(),
             epoch: 1,
             index: 42,
             channel_id: TEST_CHANNEL_ID.to_string(),
@@ -2808,7 +2817,7 @@ mod tests {
         let indexer_state = IndexerState::new(10, 100);
         let schema = make_subscription_schema(db.conn(blokli_db::TargetDb::Index), &indexer_state);
 
-        let query = r#"subscription { ticketRedeemed { issuerAddress recepientAddress epoch index result } }"#;
+        let query = r#"subscription { ticketRedeemed { issuerAddress recipientAddress epoch index result } }"#;
         let mut stream = schema.execute_stream(query).boxed();
 
         let ticket_info = make_test_ticket_info();
@@ -2830,7 +2839,7 @@ mod tests {
             async_graphql::Value::from_json(serde_json::json!({
                 "ticketRedeemed": {
                     "issuerAddress": TEST_ISSUER_ADDR,
-                    "recepientAddress": TEST_RECIPIENT_ADDR,
+                    "recipientAddress": TEST_RECIPIENT_ADDR,
                     "epoch": 1,
                     "index": 42,
                     "result": "REDEEMED"

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -6,13 +6,16 @@ use async_broadcast::Receiver;
 use async_graphql::{Context, ID, Result, Subscription};
 use async_stream::stream;
 use blokli_api_types::{
-    Account, Channel, ChannelUpdate, Hex32, OpenedChannelsGraphEntry, RedeemTicketDetails, RedeemTicketDetailsInfo,
-    Safe, TicketParameters, TokenValueString, Transaction, UInt64,
+    Account, Channel, ChannelUpdate, Hex32, OpenedChannelsGraphEntry, RedeemTicketDetails, Safe, TicketParameters,
+    TokenValueString, Transaction, UInt64,
 };
 use blokli_chain_api::transaction_store::{
     TransactionEvent, TransactionStatus as StoreTransactionStatus, TransactionStore,
 };
-use blokli_chain_indexer::{IndexerState, state::IndexerEvent};
+use blokli_chain_indexer::{
+    IndexerState,
+    state::{IndexerEvent, RedeemTicketDetailsInfo},
+};
 use blokli_db_entity::{
     chain_info,
     chain_info::Entity as ChainInfoEntity,
@@ -1530,7 +1533,7 @@ mod tests {
 
     use async_graphql::{EmptyMutation, Object, Schema};
     use blokli_api_types::RedemptionResult;
-    use blokli_chain_indexer::state::IndexerEvent;
+    use blokli_chain_indexer::state::{IndexerEvent, RedeemTicketDetailsInfo};
     use blokli_db::{BlokliDbGeneralModelOperations, db::BlokliDb};
     use blokli_db_entity::{hopr_safe_contract, hopr_safe_contract_state};
     use futures::StreamExt;

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -1215,15 +1215,24 @@ impl SubscriptionRoot {
         })
     }
 
+    /// Subscribe to real-time updates of ticket redemptions.
+    ///
+    /// Streams a [`RedeemTicketDetails`] item each time a ticket redemption event
+    /// is observed on-chain. Covers both successful redemptions and inner Safe
+    /// transaction rejections (see [`RedemptionResult`]).
+    ///
+    /// At most one of the three filter arguments is typically supplied. When none
+    /// are given, all ticket redemption events are emitted. Input addresses and
+    /// channel IDs are validated as hex before the stream is established.
     #[graphql(name = "ticketRedeemed")]
     async fn ticket_redeemed(
         &self,
         ctx: &Context<'_>,
         #[graphql(desc = "Filter by channel ID (hexadecimal format)")] channel_id: Option<ID>,
-        #[graphql(desc = "Filter by ticket issuesr (hexadecimal format)")] issuer_address: Option<ID>,
-        #[graphql(desc = "Filter by ticket recepient (hexadecimal format)")] recepient_address: Option<ID>,
+        #[graphql(desc = "Filter by ticket issuer (hexadecimal format)")] issuer_address: Option<ID>,
+        #[graphql(desc = "Filter by ticket recipient (hexadecimal format)")] recepient_address: Option<ID>,
     ) -> Result<impl Stream<Item = RedeemTicketDetails>> {
-        // Validate correctnes of input parameters
+        // Validate correctness of input parameters
         if let Some(channel_id) = &channel_id {
             hex::check(channel_id.as_bytes()).map_err(|e| {
                 async_graphql::Error::new(format!("Invalid channel ID format: {}. Expected hex format.", e))
@@ -1348,6 +1357,18 @@ impl SubscriptionRoot {
     }
 }
 
+/// Check whether a ticket redemption event matches the subscription filters.
+///
+/// Filters are ANDed — all non-`None` arguments must match. An absent filter
+/// matches everything.
+///
+/// * Channel ID comparison strips the `0x` prefix from the filter value if present, then compares against the lowercase
+///   hex stored in [`RedeemTicketDetailsInfo::channel_id`].
+/// * Address comparisons normalise both the filter value and the stored address via [`Address::from_hex`], giving
+///   case-insensitive, prefix-agnostic matching.
+///
+/// Returns `false` and silently drops the event if either address is unparseable
+/// (this is a defensive fallback — inputs are validated before the stream starts).
 fn match_ticket_filters(
     info: &RedeemTicketDetailsInfo,
     channel_id: &Option<ID>,
@@ -1355,14 +1376,14 @@ fn match_ticket_filters(
     recepient_address: &Option<ID>,
 ) -> bool {
     if let Some(channel_id) = channel_id {
-        let channel_id_normalized = channel_id.strip_prefix("0x").unwrap_or(&channel_id);
+        let channel_id_normalized = channel_id.strip_prefix("0x").unwrap_or(channel_id);
         if info.channel_id != channel_id_normalized {
             return false;
         }
     }
 
     if let Some(iss_addr) = issuer_address {
-        let iss = match Address::from_hex(&iss_addr) {
+        let iss = match Address::from_hex(iss_addr) {
             Ok(iss) => iss,
             Err(_) => {
                 // Invalid address - this should never happen due to early validation of inputs
@@ -1382,7 +1403,7 @@ fn match_ticket_filters(
     }
 
     if let Some(rec_addr) = recepient_address {
-        let rec = match Address::from_hex(&rec_addr) {
+        let rec = match Address::from_hex(rec_addr) {
             Ok(rec) => rec,
             Err(_) => {
                 // Invalid address - this should never happen due to early validation of inputs
@@ -1504,6 +1525,8 @@ mod tests {
     use blokli_db_entity::{hopr_safe_contract, hopr_safe_contract_state};
     use futures::StreamExt;
     use sea_orm::{ActiveModelTrait, Set};
+
+    use blokli_api_types::RedemptionResult;
 
     use super::*;
     use crate::schema::GasMultiplier;
@@ -2712,6 +2735,171 @@ mod tests {
         assert!(
             seen_different,
             "5 subscription runs of 10 accounts should produce at least one different Phase 1 ordering"
+        );
+    }
+
+    // ── match_ticket_filters ──────────────────────────────────────────────────
+
+    const TEST_ISSUER_ADDR: &str = "0x1111111111111111111111111111111111111111";
+    const TEST_RECIPIENT_ADDR: &str = "0x2222222222222222222222222222222222222222";
+    const TEST_OTHER_ADDR: &str = "0x3333333333333333333333333333333333333333";
+    /// Lowercase hex without 0x prefix — matches how `hex::encode` stores channel IDs.
+    const TEST_CHANNEL_ID: &str = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234";
+    const TEST_CHANNEL_ID_0X: &str = "0xabcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234";
+    const TEST_CHANNEL_ID_OTHER: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    fn make_test_ticket_info() -> RedeemTicketDetailsInfo {
+        RedeemTicketDetailsInfo {
+            issuer_address: TEST_ISSUER_ADDR.to_string(),
+            recepient_address: TEST_RECIPIENT_ADDR.to_string(),
+            epoch: 1,
+            index: 42,
+            channel_id: TEST_CHANNEL_ID.to_string(),
+            result: RedemptionResult::Redeemed,
+        }
+    }
+
+    #[rstest::rstest]
+    #[case(None, None, None, true)]
+    #[case(Some(ID::from(TEST_CHANNEL_ID)), None, None, true)]
+    #[case(Some(ID::from(TEST_CHANNEL_ID_0X)), None, None, true)]
+    #[case(Some(ID::from(TEST_CHANNEL_ID_OTHER)), None, None, false)]
+    #[case(None, Some(ID::from(TEST_ISSUER_ADDR)), None, true)]
+    #[case(None, Some(ID::from(TEST_OTHER_ADDR)), None, false)]
+    #[case(None, None, Some(ID::from(TEST_RECIPIENT_ADDR)), true)]
+    #[case(None, None, Some(ID::from(TEST_OTHER_ADDR)), false)]
+    #[case(
+        Some(ID::from(TEST_CHANNEL_ID)),
+        Some(ID::from(TEST_ISSUER_ADDR)),
+        Some(ID::from(TEST_RECIPIENT_ADDR)),
+        true
+    )]
+    #[case(
+        Some(ID::from(TEST_CHANNEL_ID)),
+        Some(ID::from(TEST_OTHER_ADDR)),
+        Some(ID::from(TEST_RECIPIENT_ADDR)),
+        false
+    )]
+    fn test_match_ticket_filters(
+        #[case] channel_id: Option<ID>,
+        #[case] issuer: Option<ID>,
+        #[case] recipient: Option<ID>,
+        #[case] expected: bool,
+    ) {
+        let info = make_test_ticket_info();
+        assert_eq!(match_ticket_filters(&info, &channel_id, &issuer, &recipient), expected);
+    }
+
+    // ── ticketRedeemed subscription ───────────────────────────────────────────
+
+    fn make_subscription_schema(
+        conn: &DatabaseConnection,
+        indexer_state: &IndexerState,
+    ) -> Schema<DummyQuery, EmptyMutation, SubscriptionRoot> {
+        Schema::build(DummyQuery, EmptyMutation, SubscriptionRoot)
+            .data(conn.clone())
+            .data(indexer_state.clone())
+            .data(GasMultiplier(1.0))
+            .finish()
+    }
+
+    #[tokio::test]
+    async fn test_ticket_redeemed_subscription_yields_on_event() {
+        let db = BlokliDb::new_in_memory().await.unwrap();
+        let indexer_state = IndexerState::new(10, 100);
+        let schema = make_subscription_schema(db.conn(blokli_db::TargetDb::Index), &indexer_state);
+
+        let query = r#"subscription { ticketRedeemed { issuerAddress recepientAddress epoch index result } }"#;
+        let mut stream = schema.execute_stream(query).boxed();
+
+        let ticket_info = make_test_ticket_info();
+        let indexer_clone = indexer_state.clone();
+        let info_clone = ticket_info.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            indexer_clone.publish_event(IndexerEvent::TicketRedeemed(info_clone));
+        });
+
+        let response = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("timeout waiting for ticketRedeemed event")
+            .expect("stream ended early");
+        let data = response.into_result().expect("response error").data;
+
+        assert_eq!(
+            data,
+            async_graphql::Value::from_json(serde_json::json!({
+                "ticketRedeemed": {
+                    "issuerAddress": TEST_ISSUER_ADDR,
+                    "recepientAddress": TEST_RECIPIENT_ADDR,
+                    "epoch": 1,
+                    "index": 42,
+                    "result": "REDEEMED"
+                }
+            }))
+            .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ticket_redeemed_subscription_filters_by_channel_id() {
+        let db = BlokliDb::new_in_memory().await.unwrap();
+        let indexer_state = IndexerState::new(10, 100);
+        let schema = make_subscription_schema(db.conn(blokli_db::TargetDb::Index), &indexer_state);
+
+        let query = format!(
+            r#"subscription {{ ticketRedeemed(channelId: "{}") {{ issuerAddress }} }}"#,
+            TEST_CHANNEL_ID
+        );
+        let mut stream = schema.execute_stream(query.as_str()).boxed();
+
+        let matching = make_test_ticket_info();
+        let non_matching = RedeemTicketDetailsInfo {
+            channel_id: TEST_CHANNEL_ID_OTHER.to_string(),
+            ..make_test_ticket_info()
+        };
+
+        let indexer_clone = indexer_state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            indexer_clone.publish_event(IndexerEvent::TicketRedeemed(non_matching));
+            indexer_clone.publish_event(IndexerEvent::TicketRedeemed(matching));
+        });
+
+        let response = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("timeout waiting for matching ticketRedeemed event")
+            .expect("stream ended early");
+        let data = response.into_result().expect("response error").data;
+
+        assert_eq!(
+            data,
+            async_graphql::Value::from_json(serde_json::json!({
+                "ticketRedeemed": { "issuerAddress": TEST_ISSUER_ADDR }
+            }))
+            .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ticket_redeemed_subscription_ignores_other_indexer_events() {
+        let db = BlokliDb::new_in_memory().await.unwrap();
+        let indexer_state = IndexerState::new(10, 100);
+        let schema = make_subscription_schema(db.conn(blokli_db::TargetDb::Index), &indexer_state);
+
+        let query = r#"subscription { ticketRedeemed { issuerAddress } }"#;
+        let mut stream = schema.execute_stream(query).boxed();
+
+        let indexer_clone = indexer_state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            indexer_clone.publish_event(IndexerEvent::KeyBindingFeeUpdated(TokenValueString("999".to_string())));
+        });
+
+        let timeout_result = tokio::time::timeout(Duration::from_millis(500), stream.next()).await;
+        assert!(
+            timeout_result.is_err(),
+            "non-TicketRedeemed events must not produce subscription items"
         );
     }
 }

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -1520,13 +1520,12 @@ mod tests {
     use std::time::Duration;
 
     use async_graphql::{EmptyMutation, Object, Schema};
+    use blokli_api_types::RedemptionResult;
     use blokli_chain_indexer::state::IndexerEvent;
     use blokli_db::{BlokliDbGeneralModelOperations, db::BlokliDb};
     use blokli_db_entity::{hopr_safe_contract, hopr_safe_contract_state};
     use futures::StreamExt;
     use sea_orm::{ActiveModelTrait, Set};
-
-    use blokli_api_types::RedemptionResult;
 
     use super::*;
     use crate::schema::GasMultiplier;

--- a/chain/indexer/src/handlers/channels.rs
+++ b/chain/indexer/src/handlers/channels.rs
@@ -1,7 +1,8 @@
+use blokli_api_types::RedeemTicketDetailsInfo;
 use blokli_chain_rpc::HoprIndexerRpcOperations;
 use blokli_chain_types::AlloyAddressExt;
 use blokli_db::{BlokliDbAllOperations, OpenTransaction, api::info::DomainSeparator, errors::DbSqlError};
-use hopr_bindings::hopr_channels::HoprChannels::HoprChannelsEvents;
+use hopr_bindings::{exports::alloy::hex, hopr_channels::HoprChannels::HoprChannelsEvents};
 use hopr_types::{
     crypto::types::Hash,
     internal::channels::{ChannelEntry, ChannelStatus, generate_channel_id},
@@ -376,6 +377,18 @@ where
 
                 // Decode the packed channel state from the event
                 let decoded = decode_channel(ticket_redeemed.channel);
+
+                // Earliest point in which we have all data for TicketRedeemed Indexer Event
+                let ticket_redeemed = RedeemTicketDetailsInfo {
+                    issuer_address: existing_channel.source.to_string(),
+                    recepient_address: existing_channel.destination.to_string(),
+                    epoch: decoded.epoch,
+                    index: decoded.ticket_index,
+                    channel_id: hex::encode(&channel_id),
+                    result: blokli_api_types::RedemptionResult::Redeemed,
+                }; //TODO: move this to some function or
+                //something
+                events.push(crate::state::IndexerEvent::TicketRedeemed(ticket_redeemed));
 
                 trace!(
                     %channel_id,

--- a/chain/indexer/src/handlers/channels.rs
+++ b/chain/indexer/src/handlers/channels.rs
@@ -378,17 +378,38 @@ where
                 // Decode the packed channel state from the event
                 let decoded = decode_channel(ticket_redeemed.channel);
 
-                // Earliest point in which we have all data for TicketRedeemed Indexer Event
-                let ticket_redeemed = RedeemTicketDetailsInfo {
-                    issuer_address: existing_channel.source.to_string(),
-                    recepient_address: existing_channel.destination.to_string(),
-                    epoch: decoded.epoch,
-                    index: decoded.ticket_index,
-                    channel_id: hex::encode(channel_id),
-                    result: blokli_api_types::RedemptionResult::Redeemed,
-                }; //TODO: move this to some function or
-                // something
-                events.push(crate::state::IndexerEvent::TicketRedeemed(ticket_redeemed));
+                let ticket_value = existing_channel.balance - decoded.balance;
+
+                // Fetch current minimum ticket price. If unavailable (oracle not yet indexed),
+                // allow the event through rather than silently dropping valid redemptions.
+                let min_ticket_price = match self.db.get_indexer_data(tx.into()).await {
+                    Ok(data) => data.ticket_price,
+                    Err(e) => {
+                        warn!(%e, "failed to fetch ticket price for low-value filter; allowing event through");
+                        None
+                    }
+                };
+
+                let above_minimum = min_ticket_price.is_none_or(|min| ticket_value >= min);
+
+                if above_minimum {
+                    let ticket_redeemed = RedeemTicketDetailsInfo {
+                        issuer_address: existing_channel.source.to_string(),
+                        recepient_address: existing_channel.destination.to_string(),
+                        epoch: decoded.epoch,
+                        index: decoded.ticket_index,
+                        channel_id: hex::encode(channel_id),
+                        result: blokli_api_types::RedemptionResult::Redeemed,
+                    };
+                    events.push(crate::state::IndexerEvent::TicketRedeemed(ticket_redeemed));
+                } else {
+                    trace!(
+                        %channel_id,
+                        ticket_value = %ticket_value,
+                        min = %min_ticket_price.unwrap(),
+                        "TicketRedeemed: skipping low-value ticket"
+                    );
+                }
 
                 trace!(
                     %channel_id,

--- a/chain/indexer/src/handlers/channels.rs
+++ b/chain/indexer/src/handlers/channels.rs
@@ -16,7 +16,7 @@ use super::{ContractEventHandlers, channel_utils::decode_channel, helpers::const
 use crate::{
     errors::{CoreEthereumIndexerError, Result},
     handlers::helpers::build_channel_entry,
-    state::RedeemTicketDetailsInfo,
+    state::{IndexerEvent, RedeemTicketDetailsInfo},
 };
 
 impl<T, Db> ContractEventHandlers<T, Db>
@@ -32,7 +32,7 @@ where
         tx_index: u32,
         log_index: u32,
         is_synced: bool,
-    ) -> Result<Vec<crate::state::IndexerEvent>> {
+    ) -> Result<Vec<IndexerEvent>> {
         #[cfg(all(feature = "telemetry", not(test)))]
         increment_indexer_contract_log_count("channels");
 
@@ -88,7 +88,7 @@ where
                     };
                     let above_minimum = min_ticket_price.is_none_or(|min| diff >= min);
                     if above_minimum {
-                        events.push(crate::state::IndexerEvent::TicketRedeemed(RedeemTicketDetailsInfo {
+                        events.push(IndexerEvent::TicketRedeemed(RedeemTicketDetailsInfo {
                             issuer_address: existing_channel.source.to_string(),
                             recipient_address: existing_channel.destination.to_string(),
                             epoch: decoded.epoch,
@@ -150,7 +150,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelBalanceDecreased");
@@ -218,7 +218,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelBalanceIncreased");
@@ -284,7 +284,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelClosed");
@@ -368,7 +368,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for ChannelOpened");
@@ -428,7 +428,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for TicketRedeemed");
@@ -488,7 +488,7 @@ where
                 if is_synced {
                     match construct_channel_update(tx.as_ref(), &channel_id).await {
                         Ok(channel_update) => {
-                            events.push(crate::state::IndexerEvent::ChannelUpdated(Box::new(channel_update)));
+                            events.push(IndexerEvent::ChannelUpdated(Box::new(channel_update)));
                         }
                         Err(e) => {
                             warn!(%channel_id, %e, "Failed to construct channel update for OutgoingChannelClosureInitiated");

--- a/chain/indexer/src/handlers/channels.rs
+++ b/chain/indexer/src/handlers/channels.rs
@@ -384,10 +384,10 @@ where
                     recepient_address: existing_channel.destination.to_string(),
                     epoch: decoded.epoch,
                     index: decoded.ticket_index,
-                    channel_id: hex::encode(&channel_id),
+                    channel_id: hex::encode(channel_id),
                     result: blokli_api_types::RedemptionResult::Redeemed,
                 }; //TODO: move this to some function or
-                //something
+                // something
                 events.push(crate::state::IndexerEvent::TicketRedeemed(ticket_redeemed));
 
                 trace!(

--- a/chain/indexer/src/handlers/channels.rs
+++ b/chain/indexer/src/handlers/channels.rs
@@ -1,4 +1,4 @@
-use blokli_api_types::RedeemTicketDetailsInfo;
+use blokli_api_types::RedemptionResult;
 use blokli_chain_rpc::HoprIndexerRpcOperations;
 use blokli_chain_types::AlloyAddressExt;
 use blokli_db::{BlokliDbAllOperations, OpenTransaction, api::info::DomainSeparator, errors::DbSqlError};
@@ -16,6 +16,7 @@ use super::{ContractEventHandlers, channel_utils::decode_channel, helpers::const
 use crate::{
     errors::{CoreEthereumIndexerError, Result},
     handlers::helpers::build_channel_entry,
+    state::RedeemTicketDetailsInfo,
 };
 
 impl<T, Db> ContractEventHandlers<T, Db>
@@ -76,6 +77,29 @@ where
                     diff = %diff,
                     "ChannelBalanceDecreased: decoded channel state"
                 );
+
+                if is_synced {
+                    let min_ticket_price = match self.db.get_indexer_data(tx.into()).await {
+                        Ok(data) => data.ticket_price,
+                        Err(e) => {
+                            warn!(%channel_id, %e, "ChannelBalanceDecreased: failed to get ticket price filter");
+                            None
+                        }
+                    };
+                    let above_minimum = min_ticket_price.is_none_or(|min| diff >= min);
+                    if above_minimum {
+                        events.push(crate::state::IndexerEvent::TicketRedeemed(RedeemTicketDetailsInfo {
+                            issuer_address: existing_channel.source.to_string(),
+                            recipient_address: existing_channel.destination.to_string(),
+                            epoch: decoded.epoch,
+                            index: decoded.ticket_index.saturating_sub(1),
+                            channel_id: hex::encode(channel_id),
+                            result: RedemptionResult::Redeemed,
+                        }));
+                    } else if let Some(min) = min_ticket_price {
+                        trace!(%channel_id, diff = %diff, min = %min, "ChannelBalanceDecreased: skipping low-value ticket redemption event");
+                    }
+                }
 
                 let destination_account = self.db.get_account(tx.into(), existing_channel.destination).await?;
 
@@ -377,39 +401,6 @@ where
 
                 // Decode the packed channel state from the event
                 let decoded = decode_channel(ticket_redeemed.channel);
-
-                let ticket_value = existing_channel.balance - decoded.balance;
-
-                // Fetch current minimum ticket price. If unavailable (oracle not yet indexed),
-                // allow the event through rather than silently dropping valid redemptions.
-                let min_ticket_price = match self.db.get_indexer_data(tx.into()).await {
-                    Ok(data) => data.ticket_price,
-                    Err(e) => {
-                        warn!(%e, "failed to fetch ticket price for low-value filter; allowing event through");
-                        None
-                    }
-                };
-
-                let above_minimum = min_ticket_price.is_none_or(|min| ticket_value >= min);
-
-                if above_minimum && is_synced {
-                    let ticket_redeemed = RedeemTicketDetailsInfo {
-                        issuer_address: existing_channel.source.to_string(),
-                        recipient_address: existing_channel.destination.to_string(),
-                        epoch: decoded.epoch,
-                        index: decoded.ticket_index,
-                        channel_id: hex::encode(channel_id),
-                        result: blokli_api_types::RedemptionResult::Redeemed,
-                    };
-                    events.push(crate::state::IndexerEvent::TicketRedeemed(ticket_redeemed));
-                } else if !above_minimum {
-                    trace!(
-                        %channel_id,
-                        ticket_value = %ticket_value,
-                        min = %min_ticket_price.unwrap(),
-                        "TicketRedeemed: skipping low-value ticket"
-                    );
-                }
 
                 trace!(
                     %channel_id,

--- a/chain/indexer/src/handlers/channels.rs
+++ b/chain/indexer/src/handlers/channels.rs
@@ -392,17 +392,17 @@ where
 
                 let above_minimum = min_ticket_price.is_none_or(|min| ticket_value >= min);
 
-                if above_minimum {
+                if above_minimum && is_synced {
                     let ticket_redeemed = RedeemTicketDetailsInfo {
                         issuer_address: existing_channel.source.to_string(),
-                        recepient_address: existing_channel.destination.to_string(),
+                        recipient_address: existing_channel.destination.to_string(),
                         epoch: decoded.epoch,
                         index: decoded.ticket_index,
                         channel_id: hex::encode(channel_id),
                         result: blokli_api_types::RedemptionResult::Redeemed,
                     };
                     events.push(crate::state::IndexerEvent::TicketRedeemed(ticket_redeemed));
-                } else {
+                } else if !above_minimum {
                     trace!(
                         %channel_id,
                         ticket_value = %ticket_value,

--- a/chain/indexer/src/state.rs
+++ b/chain/indexer/src/state.rs
@@ -13,7 +13,9 @@ use std::sync::{
 };
 
 use async_broadcast::{Receiver, Sender, broadcast};
-use blokli_api_types::{Account, ChannelUpdate, RedeemTicketDetails, TicketParameters, TokenValueString, UInt64};
+use blokli_api_types::{
+    Account, ChannelUpdate, RedeemTicketDetails, RedemptionResult, TicketParameters, TokenValueString, UInt64,
+};
 use hopr_types::primitive::prelude::Address;
 use tokio::sync::RwLock;
 
@@ -22,6 +24,23 @@ use tokio::sync::RwLock;
 /// Carries all fields needed to identify the ticket and report the outcome.
 /// The `channel_id` field is used for subscription filtering and stripped
 /// before the event is yielded to GraphQL clients (see `From` impl below).
+///
+/// # Examples
+///
+/// ```
+/// use blokli_api_types::{RedeemTicketDetails, RedemptionResult};
+/// use blokli_chain_indexer::state::RedeemTicketDetailsInfo;
+///
+/// let info = RedeemTicketDetailsInfo {
+///     issuer_address: "0xaabbccdd".to_string(),
+///     recipient_address: "0xddeeff00".to_string(),
+///     epoch: 1,
+///     index: 0,
+///     channel_id: "14a2c4f5".to_string(),
+///     result: RedemptionResult::Redeemed,
+/// };
+/// let gql: RedeemTicketDetails = info.into();
+/// ```
 #[derive(Debug, Clone)]
 pub struct RedeemTicketDetailsInfo {
     /// Issuer account on-chain address in hexadecimal format
@@ -35,7 +54,7 @@ pub struct RedeemTicketDetailsInfo {
     /// Index of the ticket within the channel epoch
     pub index: u64,
     /// Outcome of the redemption attempt
-    pub result: blokli_api_types::RedemptionResult,
+    pub result: RedemptionResult,
 }
 
 impl From<RedeemTicketDetailsInfo> for RedeemTicketDetails {

--- a/chain/indexer/src/state.rs
+++ b/chain/indexer/src/state.rs
@@ -46,6 +46,10 @@ pub enum IndexerEvent {
     /// for the GraphQL subscription.
     TicketParametersUpdated(TicketParameters),
 
+    /// A ticket redemption was observed on-chain (either accepted or rejected).
+    ///
+    /// Carries all fields needed to identify the ticket and report the outcome.
+    /// Subscribers filter by channel ID, issuer, or recipient address.
     TicketRedeemed(RedeemTicketDetailsInfo),
 }
 

--- a/chain/indexer/src/state.rs
+++ b/chain/indexer/src/state.rs
@@ -13,9 +13,42 @@ use std::sync::{
 };
 
 use async_broadcast::{Receiver, Sender, broadcast};
-use blokli_api_types::{Account, ChannelUpdate, RedeemTicketDetailsInfo, TicketParameters, TokenValueString};
+use blokli_api_types::{Account, ChannelUpdate, RedeemTicketDetails, TicketParameters, TokenValueString, UInt64};
 use hopr_types::primitive::prelude::Address;
 use tokio::sync::RwLock;
+
+/// Internal event payload for a ticket redemption observed on-chain.
+///
+/// Carries all fields needed to identify the ticket and report the outcome.
+/// The `channel_id` field is used for subscription filtering and stripped
+/// before the event is yielded to GraphQL clients (see `From` impl below).
+#[derive(Debug, Clone)]
+pub struct RedeemTicketDetailsInfo {
+    /// Issuer account on-chain address in hexadecimal format
+    pub issuer_address: String,
+    /// Recipient account on-chain address in hexadecimal format
+    pub recipient_address: String,
+    /// Epoch of the channel where the ticket was redeemed
+    pub epoch: u32,
+    /// Channel ID in lowercase hex (no `0x` prefix), used for subscription filtering
+    pub channel_id: String,
+    /// Index of the ticket within the channel epoch
+    pub index: u64,
+    /// Outcome of the redemption attempt
+    pub result: blokli_api_types::RedemptionResult,
+}
+
+impl From<RedeemTicketDetailsInfo> for RedeemTicketDetails {
+    fn from(value: RedeemTicketDetailsInfo) -> Self {
+        Self {
+            issuer_address: value.issuer_address,
+            recipient_address: value.recipient_address,
+            epoch: UInt64(value.epoch as u64),
+            index: UInt64(value.index),
+            result: value.result,
+        }
+    }
+}
 
 /// Event type for the subscription event bus
 ///

--- a/chain/indexer/src/state.rs
+++ b/chain/indexer/src/state.rs
@@ -13,7 +13,7 @@ use std::sync::{
 };
 
 use async_broadcast::{Receiver, Sender, broadcast};
-use blokli_api_types::{Account, ChannelUpdate, TicketParameters, TokenValueString};
+use blokli_api_types::{Account, ChannelUpdate, RedeemTicketDetailsInfo, TicketParameters, TokenValueString};
 use hopr_types::primitive::prelude::Address;
 use tokio::sync::RwLock;
 
@@ -45,6 +45,8 @@ pub enum IndexerEvent {
     /// Contains both ticket price and winning probability since both are needed
     /// for the GraphQL subscription.
     TicketParametersUpdated(TicketParameters),
+
+    TicketRedeemed(RedeemTicketDetailsInfo),
 }
 
 /// Shared state for coordinating indexer operations with subscriptions

--- a/client/src/api/mod.rs
+++ b/client/src/api/mod.rs
@@ -5,6 +5,6 @@ pub(crate) use v1::{Result, internal};
 pub const VERSION: &str = "v1";
 pub use v1::{
     AccountSelector, BlokliQueryClient, BlokliSubscriptionClient, BlokliTransactionClient, ChainAddress, ChannelFilter,
-    ChannelId, ChannelSelector, KeyId, ModulePredictionInput, PacketKey, RedeemedStatsSelector, SafeSelector, TxId,
-    TxReceipt, types,
+    ChannelId, ChannelSelector, KeyId, ModulePredictionInput, PacketKey, RedeemedStatsSelector, SafeSelector,
+    TicketSelector, TxId, TxReceipt, types,
 };

--- a/client/src/api/v1/graphql/mod.rs
+++ b/client/src/api/v1/graphql/mod.rs
@@ -6,6 +6,7 @@ pub mod channels;
 pub mod graph;
 pub mod info;
 pub mod safe;
+pub mod tickets;
 pub mod txs;
 
 #[cynic::schema("blokli")]

--- a/client/src/api/v1/graphql/tickets.rs
+++ b/client/src/api/v1/graphql/tickets.rs
@@ -1,0 +1,33 @@
+use super::{Uint64, schema};
+
+#[derive(cynic::QueryVariables, Default)]
+pub struct TicketRedeemedVariables {
+    pub channel_id: Option<cynic::Id>,
+    pub issuer_address: Option<cynic::Id>,
+    pub recepient_address: Option<cynic::Id>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(graphql_type = "SubscriptionRoot", variables = "TicketRedeemedVariables")]
+pub struct SubscribeTicketRedeemed {
+    #[arguments(channelId: $channel_id, issuerAddress: $issuer_address, recepientAddress: $recepient_address)]
+    pub ticket_redeemed: RedeemTicketDetails,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct RedeemTicketDetails {
+    pub issuer_address: String,
+    pub recepient_address: String,
+    pub epoch: Uint64,
+    pub index: Uint64,
+    pub result: RedemptionResult,
+}
+
+#[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RedemptionResult {
+    #[cynic(rename = "REDEEMED")]
+    Redeemed,
+    #[cynic(rename = "REJECTED")]
+    Rejected,
+}

--- a/client/src/api/v1/graphql/tickets.rs
+++ b/client/src/api/v1/graphql/tickets.rs
@@ -3,6 +3,10 @@ use hex::ToHex;
 use super::{Uint64, schema};
 use crate::api::v1::TicketSelector;
 
+/// GraphQL subscription variables for the `ticketRedeemed` subscription.
+///
+/// At most one filter field should be set; all `None` matches every redemption.
+/// Constructed via the [`From<TicketSelector>`] impl.
 #[derive(cynic::QueryVariables, Default)]
 pub struct TicketRedeemedVariables {
     pub channel_id: Option<cynic::Id>,
@@ -30,6 +34,9 @@ impl From<TicketSelector> for TicketRedeemedVariables {
     }
 }
 
+/// cynic query fragment for the `ticketRedeemed` GraphQL subscription.
+///
+/// Use [`TicketRedeemedVariables`] to set optional filters before executing.
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(graphql_type = "SubscriptionRoot", variables = "TicketRedeemedVariables")]
 pub struct SubscribeTicketRedeemed {
@@ -37,6 +44,11 @@ pub struct SubscribeTicketRedeemed {
     pub ticket_redeemed: RedeemTicketDetails,
 }
 
+/// Details of a single on-chain ticket redemption event.
+///
+/// Returned as stream items by [`BlokliSubscriptionClient::subscribe_ticket_redeemed`].
+/// The `epoch` and `index` fields identify which ticket was redeemed; `result` indicates
+/// whether the chain accepted or rejected it.
 #[derive(cynic::QueryFragment, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct RedeemTicketDetails {
@@ -47,6 +59,7 @@ pub struct RedeemTicketDetails {
     pub result: RedemptionResult,
 }
 
+/// Outcome of an on-chain ticket redemption attempt.
 #[derive(cynic::Enum, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RedemptionResult {
     #[cynic(rename = "REDEEMED")]

--- a/client/src/api/v1/graphql/tickets.rs
+++ b/client/src/api/v1/graphql/tickets.rs
@@ -1,10 +1,33 @@
+use hex::ToHex;
+
 use super::{Uint64, schema};
+use crate::api::v1::TicketSelector;
 
 #[derive(cynic::QueryVariables, Default)]
 pub struct TicketRedeemedVariables {
     pub channel_id: Option<cynic::Id>,
     pub issuer_address: Option<cynic::Id>,
     pub recipient_address: Option<cynic::Id>,
+}
+
+impl From<TicketSelector> for TicketRedeemedVariables {
+    fn from(value: TicketSelector) -> Self {
+        match value {
+            TicketSelector::ChannelId(channel_id) => TicketRedeemedVariables {
+                channel_id: Some(channel_id.encode_hex::<String>().into()),
+                ..Default::default()
+            },
+            TicketSelector::IssuerAddress(address) => TicketRedeemedVariables {
+                issuer_address: Some(address.encode_hex::<String>().into()),
+                ..Default::default()
+            },
+            TicketSelector::RecipientAddress(address) => TicketRedeemedVariables {
+                recipient_address: Some(address.encode_hex::<String>().into()),
+                ..Default::default()
+            },
+            TicketSelector::Any => TicketRedeemedVariables::default(),
+        }
+    }
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/client/src/api/v1/graphql/tickets.rs
+++ b/client/src/api/v1/graphql/tickets.rs
@@ -4,13 +4,13 @@ use super::{Uint64, schema};
 pub struct TicketRedeemedVariables {
     pub channel_id: Option<cynic::Id>,
     pub issuer_address: Option<cynic::Id>,
-    pub recepient_address: Option<cynic::Id>,
+    pub recipient_address: Option<cynic::Id>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(graphql_type = "SubscriptionRoot", variables = "TicketRedeemedVariables")]
 pub struct SubscribeTicketRedeemed {
-    #[arguments(channelId: $channel_id, issuerAddress: $issuer_address, recepientAddress: $recepient_address)]
+    #[arguments(channelId: $channel_id, issuerAddress: $issuer_address, recipientAddress: $recipient_address)]
     pub ticket_redeemed: RedeemTicketDetails,
 }
 
@@ -18,7 +18,7 @@ pub struct SubscribeTicketRedeemed {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct RedeemTicketDetails {
     pub issuer_address: String,
-    pub recepient_address: String,
+    pub recipient_address: String,
     pub epoch: Uint64,
     pub index: Uint64,
     pub result: RedemptionResult,

--- a/client/src/api/v1/mod.rs
+++ b/client/src/api/v1/mod.rs
@@ -283,7 +283,7 @@ pub trait BlokliSubscriptionClient {
         &self,
         channel_id: Option<cynic::Id>,
         issuer_address: Option<cynic::Id>,
-        recepient_address: Option<cynic::Id>,
+        recipient_address: Option<cynic::Id>,
     ) -> Result<impl futures::Stream<Item = Result<types::RedeemTicketDetails>> + Send>;
 }
 

--- a/client/src/api/v1/mod.rs
+++ b/client/src/api/v1/mod.rs
@@ -10,6 +10,7 @@ pub mod types {
         graph::OpenedChannelsGraphEntry,
         info::{ChainInfo, Compatibility, ContractAddressMap, TicketParameters},
         safe::{ModuleAddress, Safe},
+        tickets::{RedeemTicketDetails, RedemptionResult},
         txs::{SafeExecution, Transaction, TransactionStatus},
     };
 }
@@ -33,6 +34,7 @@ pub(crate) mod internal {
             ModuleAddressVariables, QueryModuleAddress, QuerySafeBy, SafeByVariables, SafeSelectorInput,
             SubscribeSafeDeployment,
         },
+        tickets::{SubscribeTicketRedeemed, TicketRedeemedVariables},
         txs::{
             ConfirmTransactionVariables, MutateConfirmTransaction, MutateSendTransaction, MutateTrackTransaction,
             QueryTransaction, SendTransactionVariables, SubscribeTransaction, TransactionsVariables,
@@ -276,6 +278,13 @@ pub trait BlokliSubscriptionClient {
         &self,
         tx_id: TxId,
     ) -> Result<impl futures::Stream<Item = Result<types::Transaction>> + Send>;
+    /// Subscribes to updates of ticket redemptions.
+    fn subscribe_ticket_redeemed(
+        &self,
+        channel_id: Option<cynic::Id>,
+        issuer_address: Option<cynic::Id>,
+        recepient_address: Option<cynic::Id>,
+    ) -> Result<impl futures::Stream<Item = Result<types::RedeemTicketDetails>> + Send>;
 }
 
 /// Trait defining Blokli API for signed transaction submission to the chain.

--- a/client/src/api/v1/mod.rs
+++ b/client/src/api/v1/mod.rs
@@ -178,7 +178,26 @@ impl std::fmt::Debug for RedeemedStatsSelector {
     }
 }
 
-/// Allows filtering ticket redemption subscription events by channel id, issuer address, or recipient address.
+/// Filters which ticket redemption events are delivered by a [`BlokliSubscriptionClient::subscribe_ticket_redeemed`]
+/// subscription.
+///
+/// Pass one of the variants to receive only events matching that criterion, or [`TicketSelector::Any`] to receive all
+/// events.
+///
+/// # Examples
+///
+/// ```ignore
+/// use blokli_client::api::v1::{TicketSelector, ChannelId, ChainAddress};
+///
+/// // Subscribe to all redemptions in a specific channel
+/// let by_channel = TicketSelector::ChannelId(channel_id);
+///
+/// // Subscribe to all redemptions where a specific node is the issuer
+/// let by_issuer = TicketSelector::IssuerAddress(issuer_address);
+///
+/// // Subscribe to every redemption event regardless of channel or party
+/// let any = TicketSelector::Any;
+/// ```
 #[derive(Clone)]
 pub enum TicketSelector {
     /// Filter by channel id.
@@ -302,9 +321,32 @@ pub trait BlokliSubscriptionClient {
         &self,
         tx_id: TxId,
     ) -> Result<impl futures::Stream<Item = Result<types::Transaction>> + Send>;
-    /// Subscribes to updates of ticket redemptions matching the given [`selector`](TicketSelector).
+    /// Subscribes to on-chain ticket redemption events matching the given [`TicketSelector`].
     ///
-    /// If [`TicketSelector::Any`] is given, subscribes to all ticket redemption events.
+    /// Returns an infinite stream of `Result<`[`types::RedeemTicketDetails`]`>`. Each item represents
+    /// one redemption event that passed the selector filter. The stream terminates when the
+    /// underlying SSE connection closes; errors (network, parse) are yielded as `Err` items.
+    ///
+    /// Use [`TicketSelector::Any`] to receive every redemption, or narrow by channel, issuer, or
+    /// recipient address.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use futures::StreamExt;
+    /// use blokli_client::api::v1::{BlokliSubscriptionClient, TicketSelector};
+    ///
+    /// let mut stream = client
+    ///     .subscribe_ticket_redeemed(TicketSelector::Any)
+    ///     .expect("failed to subscribe");
+    ///
+    /// while let Some(result) = stream.next().await {
+    ///     match result {
+    ///         Ok(event) => println!("redeemed ticket {} in epoch {}", event.index, event.epoch),
+    ///         Err(e) => eprintln!("stream error: {e}"),
+    ///     }
+    /// }
+    /// ```
     fn subscribe_ticket_redeemed(
         &self,
         selector: TicketSelector,

--- a/client/src/api/v1/mod.rs
+++ b/client/src/api/v1/mod.rs
@@ -178,6 +178,30 @@ impl std::fmt::Debug for RedeemedStatsSelector {
     }
 }
 
+/// Allows filtering ticket redemption subscription events by channel id, issuer address, or recipient address.
+#[derive(Clone)]
+pub enum TicketSelector {
+    /// Filter by channel id.
+    ChannelId(ChannelId),
+    /// Filter by issuer (source node) address.
+    IssuerAddress(ChainAddress),
+    /// Filter by recipient (destination node) address.
+    RecipientAddress(ChainAddress),
+    /// Matches any ticket redemption event.
+    Any,
+}
+
+impl std::fmt::Debug for TicketSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ChannelId(channel_id) => write!(f, "ChannelId({})", hex::encode(channel_id)),
+            Self::IssuerAddress(address) => write!(f, "IssuerAddress({})", hex::encode(address)),
+            Self::RecipientAddress(address) => write!(f, "RecipientAddress({})", hex::encode(address)),
+            Self::Any => write!(f, "Any"),
+        }
+    }
+}
+
 /// Input for the [`query_module_address_prediction`] query.
 #[derive(Clone, PartialEq, Eq)]
 pub struct ModulePredictionInput {
@@ -278,12 +302,12 @@ pub trait BlokliSubscriptionClient {
         &self,
         tx_id: TxId,
     ) -> Result<impl futures::Stream<Item = Result<types::Transaction>> + Send>;
-    /// Subscribes to updates of ticket redemptions.
+    /// Subscribes to updates of ticket redemptions matching the given [`selector`](TicketSelector).
+    ///
+    /// If [`TicketSelector::Any`] is given, subscribes to all ticket redemption events.
     fn subscribe_ticket_redeemed(
         &self,
-        channel_id: Option<cynic::Id>,
-        issuer_address: Option<cynic::Id>,
-        recipient_address: Option<cynic::Id>,
+        selector: TicketSelector,
     ) -> Result<impl futures::Stream<Item = Result<types::RedeemTicketDetails>> + Send>;
 }
 

--- a/client/src/client/subscriptions.rs
+++ b/client/src/client/subscriptions.rs
@@ -3,7 +3,7 @@ use futures::{Stream, TryStreamExt};
 
 use super::{BlokliClient, GraphQlQueries};
 use crate::api::{
-    AccountSelector, BlokliSubscriptionClient, ChannelSelector, Result, TxId,
+    AccountSelector, BlokliSubscriptionClient, ChannelSelector, Result, TicketSelector, TxId,
     internal::{
         AccountVariables, ChannelsVariables, SubscribeAccounts, SubscribeChannels, SubscribeGraph,
         SubscribeSafeDeployment, SubscribeTicketParams, SubscribeTicketRedeemed, TicketRedeemedVariables,
@@ -43,15 +43,9 @@ impl GraphQlQueries {
 
     /// `SubscribeTicketRedeemed` subscription GraphQL query.
     pub fn subscribe_ticket_redeemed(
-        channel_id: Option<cynic::Id>,
-        issuer_address: Option<cynic::Id>,
-        recipient_address: Option<cynic::Id>,
+        selector: TicketSelector,
     ) -> cynic::StreamingOperation<SubscribeTicketRedeemed, TicketRedeemedVariables> {
-        SubscribeTicketRedeemed::build(TicketRedeemedVariables {
-            channel_id,
-            issuer_address,
-            recipient_address,
-        })
+        SubscribeTicketRedeemed::build(TicketRedeemedVariables::from(selector))
     }
 }
 
@@ -98,19 +92,13 @@ impl BlokliSubscriptionClient for BlokliClient {
             .try_filter_map(|item| futures::future::ok(Some(item.transaction_updated))))
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self), fields(?selector))]
     fn subscribe_ticket_redeemed(
         &self,
-        channel_id: Option<cynic::Id>,
-        issuer_address: Option<cynic::Id>,
-        recipient_address: Option<cynic::Id>,
+        selector: TicketSelector,
     ) -> Result<impl futures::Stream<Item = Result<RedeemTicketDetails>> + Send> {
         Ok(self
-            .build_subscription_stream(GraphQlQueries::subscribe_ticket_redeemed(
-                channel_id,
-                issuer_address,
-                recipient_address,
-            ))?
+            .build_subscription_stream(GraphQlQueries::subscribe_ticket_redeemed(selector))?
             .try_filter_map(|item| futures::future::ok(Some(item.ticket_redeemed))))
     }
 }

--- a/client/src/client/subscriptions.rs
+++ b/client/src/client/subscriptions.rs
@@ -45,12 +45,12 @@ impl GraphQlQueries {
     pub fn subscribe_ticket_redeemed(
         channel_id: Option<cynic::Id>,
         issuer_address: Option<cynic::Id>,
-        recepient_address: Option<cynic::Id>,
+        recipient_address: Option<cynic::Id>,
     ) -> cynic::StreamingOperation<SubscribeTicketRedeemed, TicketRedeemedVariables> {
         SubscribeTicketRedeemed::build(TicketRedeemedVariables {
             channel_id,
             issuer_address,
-            recepient_address,
+            recipient_address,
         })
     }
 }
@@ -103,13 +103,13 @@ impl BlokliSubscriptionClient for BlokliClient {
         &self,
         channel_id: Option<cynic::Id>,
         issuer_address: Option<cynic::Id>,
-        recepient_address: Option<cynic::Id>,
+        recipient_address: Option<cynic::Id>,
     ) -> Result<impl futures::Stream<Item = Result<RedeemTicketDetails>> + Send> {
         Ok(self
             .build_subscription_stream(GraphQlQueries::subscribe_ticket_redeemed(
                 channel_id,
                 issuer_address,
-                recepient_address,
+                recipient_address,
             ))?
             .try_filter_map(|item| futures::future::ok(Some(item.ticket_redeemed))))
     }

--- a/client/src/client/subscriptions.rs
+++ b/client/src/client/subscriptions.rs
@@ -6,9 +6,9 @@ use crate::api::{
     AccountSelector, BlokliSubscriptionClient, ChannelSelector, Result, TxId,
     internal::{
         AccountVariables, ChannelsVariables, SubscribeAccounts, SubscribeChannels, SubscribeGraph,
-        SubscribeSafeDeployment, SubscribeTicketParams,
+        SubscribeSafeDeployment, SubscribeTicketParams, SubscribeTicketRedeemed, TicketRedeemedVariables,
     },
-    types::{Account, Channel, OpenedChannelsGraphEntry, Safe, TicketParameters, Transaction},
+    types::{Account, Channel, OpenedChannelsGraphEntry, RedeemTicketDetails, Safe, TicketParameters, Transaction},
 };
 
 impl GraphQlQueries {
@@ -39,6 +39,19 @@ impl GraphQlQueries {
     /// `SubscribeSafeDeployment` subscription GraphQL query.
     pub fn subscribe_safe_deployments() -> cynic::StreamingOperation<SubscribeSafeDeployment, ()> {
         SubscribeSafeDeployment::build(())
+    }
+
+    /// `SubscribeTicketRedeemed` subscription GraphQL query.
+    pub fn subscribe_ticket_redeemed(
+        channel_id: Option<cynic::Id>,
+        issuer_address: Option<cynic::Id>,
+        recepient_address: Option<cynic::Id>,
+    ) -> cynic::StreamingOperation<SubscribeTicketRedeemed, TicketRedeemedVariables> {
+        SubscribeTicketRedeemed::build(TicketRedeemedVariables {
+            channel_id,
+            issuer_address,
+            recepient_address,
+        })
     }
 }
 
@@ -83,5 +96,21 @@ impl BlokliSubscriptionClient for BlokliClient {
         Ok(self
             .build_subscription_stream(GraphQlQueries::subscribe_track_transaction(tx_id))?
             .try_filter_map(|item| futures::future::ok(Some(item.transaction_updated))))
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn subscribe_ticket_redeemed(
+        &self,
+        channel_id: Option<cynic::Id>,
+        issuer_address: Option<cynic::Id>,
+        recepient_address: Option<cynic::Id>,
+    ) -> Result<impl futures::Stream<Item = Result<RedeemTicketDetails>> + Send> {
+        Ok(self
+            .build_subscription_stream(GraphQlQueries::subscribe_ticket_redeemed(
+                channel_id,
+                issuer_address,
+                recepient_address,
+            ))?
+            .try_filter_map(|item| futures::future::ok(Some(item.ticket_redeemed))))
     }
 }

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -808,9 +808,7 @@ impl<M: BlokliTestStateMutator + Send + Sync> BlokliSubscriptionClient for Blokl
 
     fn subscribe_ticket_redeemed(
         &self,
-        _channel_id: Option<cynic::Id>,
-        _issuer_address: Option<cynic::Id>,
-        _recipient_address: Option<cynic::Id>,
+        _selector: TicketSelector,
     ) -> Result<impl futures::Stream<Item = Result<RedeemTicketDetails>> + Send> {
         Ok(futures::stream::empty())
     }

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -805,6 +805,15 @@ impl<M: BlokliTestStateMutator + Send + Sync> BlokliSubscriptionClient for Blokl
 
         Ok(futures::stream::once(futures::future::ok(tx)).delay(Duration2::from(self.tx_simulation_delay)))
     }
+
+    fn subscribe_ticket_redeemed(
+        &self,
+        _channel_id: Option<cynic::Id>,
+        _issuer_address: Option<cynic::Id>,
+        _recepient_address: Option<cynic::Id>,
+    ) -> Result<impl futures::Stream<Item = Result<RedeemTicketDetails>> + Send> {
+        Ok(futures::stream::empty())
+    }
 }
 
 fn simulate_tx_execution(

--- a/client/src/client/testing/mod.rs
+++ b/client/src/client/testing/mod.rs
@@ -810,7 +810,7 @@ impl<M: BlokliTestStateMutator + Send + Sync> BlokliSubscriptionClient for Blokl
         &self,
         _channel_id: Option<cynic::Id>,
         _issuer_address: Option<cynic::Id>,
-        _recepient_address: Option<cynic::Id>,
+        _recipient_address: Option<cynic::Id>,
     ) -> Result<impl futures::Stream<Item = Result<RedeemTicketDetails>> + Send> {
         Ok(futures::stream::empty())
     }

--- a/design/target-api-schema.graphql
+++ b/design/target-api-schema.graphql
@@ -726,7 +726,7 @@ type RedeemTicketDetails {
   "Issuer account on-chain address in hexadecimal format"
   issuerAddress: String!
   "Recipient account on-chain address in hexadecimal format"
-  recepientAddress: String!
+  recipientAddress: String!
   "Outcome of the redemption attempt"
   result: RedemptionResult!
 }
@@ -1013,7 +1013,7 @@ type SubscriptionRoot {
     "Filter by ticket issuer (hexadecimal format)"
     issuerAddress: ID
     "Filter by ticket recipient (hexadecimal format)"
-    recepientAddress: ID
+    recipientAddress: ID
   ): RedeemTicketDetails!
   """
   Subscribe to real-time updates of a specific transaction

--- a/design/target-api-schema.graphql
+++ b/design/target-api-schema.graphql
@@ -704,6 +704,34 @@ type QueryRoot {
 }
 
 """
+Outcome of a ticket redemption attempt.
+"""
+enum RedemptionResult {
+  "Ticket was successfully redeemed on-chain."
+  REDEEMED
+  "Ticket redemption was rejected (inner Safe transaction failed)."
+  REJECTED
+}
+
+"""
+Details of a ticket redemption event.
+
+Uniquely identifies the ticket and reports whether it was accepted or rejected.
+"""
+type RedeemTicketDetails {
+  "Epoch of the channel where the ticket was redeemed"
+  epoch: UInt64!
+  "Index of the ticket within the channel epoch"
+  index: UInt64!
+  "Issuer account on-chain address in hexadecimal format"
+  issuerAddress: String!
+  "Recipient account on-chain address in hexadecimal format"
+  recepientAddress: String!
+  "Outcome of the redemption attempt"
+  result: RedemptionResult!
+}
+
+"""
 Aggregated redeemed ticket statistics
 """
 type RedeemedStats {
@@ -973,6 +1001,20 @@ type SubscriptionRoot {
   and payment channel operation.
   """
   ticketParametersUpdated: TicketParameters!
+  """
+  Subscribe to real-time updates of ticket redemptions.
+
+  Streams a RedeemTicketDetails item each time a ticket redemption is observed
+  on-chain. Filters are optional and ANDed; omit all to receive every event.
+  """
+  ticketRedeemed(
+    "Filter by channel ID (hexadecimal format)"
+    channelId: ID
+    "Filter by ticket issuer (hexadecimal format)"
+    issuerAddress: ID
+    "Filter by ticket recipient (hexadecimal format)"
+    recepientAddress: ID
+  ): RedeemTicketDetails!
   """
   Subscribe to real-time updates of a specific transaction
 

--- a/flake.lock
+++ b/flake.lock
@@ -210,16 +210,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780293100,
-        "narHash": "sha256-BLy1Q5VWwv5MewwYa9BGmdYrdXtEutU32qkYRfPW0Xg=",
+        "lastModified": 1780875359,
+        "narHash": "sha256-H9DfJNbILxfSlqThz6z/7zyGb85SqMvvRg2snMjWiAk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "428470363e6f6003ac3989322b8b9272d2243001",
+        "rev": "d7fed073bedb1782de1f26683422ccd5b0207cd9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-26.05",
+        "ref": "release-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
   inputs = {
     # Core Nix ecosystem dependencies
     flake-parts.url = "github:hercules-ci/flake-parts";
-    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -744,7 +744,7 @@ async fn subscribe_ticket_redeemed(#[future(awt)] fixture: IntegrationFixture) -
         "issuer must be src"
     );
     assert_eq!(
-        event.recepient_address.to_lowercase(),
+        event.recipient_address.to_lowercase(),
         dst.address.to_string().to_lowercase(),
         "recipient must be dst"
     );

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -766,7 +766,7 @@ async fn subscribe_ticket_redeemed(#[future(awt)] fixture: IntegrationFixture) -
         dst.address.to_string().to_lowercase(),
         "recipient must be dst"
     );
-    assert_eq!(event.index.0, "0", "ticket index must be 0");
+    assert_eq!(event.index.0, ticket_index.to_string(), "ticket index must match");
     assert_eq!(event.result, RedemptionResult::Redeemed, "ticket must be accepted");
 
     Ok(())

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -1,8 +1,12 @@
-use std::time::{Duration, Instant};
+use std::{
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use anyhow::{Result, anyhow};
 use blokli_client::api::{
     AccountSelector, BlokliQueryClient, BlokliSubscriptionClient, ChannelFilter, ChannelSelector, SafeSelector,
+    TicketSelector,
     types::{ChannelStatus, RedemptionResult, TransactionStatus},
 };
 use blokli_integration_tests::{
@@ -13,6 +17,7 @@ use eventsource_client::{Client, ClientBuilder, SSE};
 use futures::stream::StreamExt;
 use futures_time::{future::FutureExt as FutureTimeoutExt, time::Duration as FuturesDuration};
 use hex::{FromHex, ToHex};
+use hopli_lib::exports::alloy::sol_types::sol_data::Address;
 use hopr_bindings::exports::alloy::primitives::U256;
 use hopr_types::{
     crypto::{keypairs::Keypair, types::Hash},
@@ -678,9 +683,8 @@ async fn subscribe_transaction_status_updates(#[future(awt)] fixture: Integratio
 async fn subscribe_ticket_redeemed(#[future(awt)] fixture: IntegrationFixture) -> Result<()> {
     let [src, dst] = fixture.sample_accounts::<2>();
     let channel_id = generate_channel_id(&src.address, &dst.address);
-    let channel_id_hex = Hash::from(channel_id).encode_hex::<String>();
 
-    let ticket_amount = "1 wei wxHOPR".parse::<HoprBalance>().expect("failed to parse amount");
+    let ticket_amount = "0.2 wxHOPR".parse::<HoprBalance>().expect("failed to parse amount");
     let safe_balance = parsed_safe_balance();
 
     // Deploy safes for both accounts and announce their presence on-chain.
@@ -695,34 +699,41 @@ async fn subscribe_ticket_redeemed(#[future(awt)] fixture: IntegrationFixture) -
         .open_channel(src, dst, ticket_amount, &src_safe.module_address, None)
         .await?;
 
+    let channel_selector = ChannelSelector {
+        filter: Some(ChannelFilter::ChannelId(channel_id.into())),
+        status: Some(ChannelStatus::Open),
+        ..Default::default()
+    };
     // Wait for the channel to be indexed before subscribing so we know epoch=1 is stable.
-    let poll_client = fixture.client().clone();
-    let poll_channel_id = channel_id;
-    poll_until(
-        "channel indexed before ticket redemption subscription",
+    let selector = channel_selector.clone();
+    let client = fixture.client().clone();
+    let channels = poll_until(
+        "channel open indexed",
         Duration::from_secs(30),
         Duration::from_millis(500),
         || {
-            let client = poll_client.clone();
-            let selector = ChannelSelector {
-                filter: Some(ChannelFilter::ChannelId(poll_channel_id.into())),
-                status: Some(ChannelStatus::Open),
-                ..Default::default()
-            };
+            let client = client.clone();
+            let selector = selector.clone();
             async move {
-                let count = client.count_channels(selector).await?;
-                Ok(if count >= 1 { Some(count) } else { None })
+                let channels = client.query_channels(selector).await?;
+                Ok(if channels.channels.is_empty() {
+                    None
+                } else {
+                    Some(channels)
+                })
             }
         },
     )
     .await?;
+    let channel = channels.channels.first().unwrap();
+
+    let ticket_index: u64 = channel.ticket_index.0.parse()?;
+    let channel_epoch = u32::try_from(channel.epoch).unwrap();
 
     // Subscribe to ticket redemptions filtered by the channel ID we just opened.
-    let client = fixture.client().clone();
-    let subscribe_channel_id = channel_id_hex.clone();
     let handle = tokio::task::spawn(async move {
         client
-            .subscribe_ticket_redeemed(Some(subscribe_channel_id.into()), None, None)
+            .subscribe_ticket_redeemed(TicketSelector::ChannelId(channel_id.into()))
             .expect("failed to create ticket redeemed subscription")
             .next()
             .timeout(subscription_timeout())
@@ -731,7 +742,14 @@ async fn subscribe_ticket_redeemed(#[future(awt)] fixture: IntegrationFixture) -
 
     // Redeem a single ticket: dst redeems ticket index 0 in epoch 1 issued by src.
     fixture
-        .redeem_ticket(&src, &dst, ticket_amount, &dst_safe.module_address, 0, 1)
+        .redeem_ticket(
+            &src,
+            &dst,
+            ticket_amount,
+            &dst_safe.module_address,
+            ticket_index,
+            channel_epoch,
+        )
         .await?;
 
     let event = handle

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Result, anyhow};
 use blokli_client::api::{
     AccountSelector, BlokliQueryClient, BlokliSubscriptionClient, ChannelFilter, ChannelSelector, SafeSelector,
-    types::{ChannelStatus, TransactionStatus},
+    types::{ChannelStatus, RedemptionResult, TransactionStatus},
 };
 use blokli_integration_tests::{
     constants::{EPSILON, parsed_safe_balance, subscription_timeout},
@@ -664,6 +664,92 @@ async fn subscribe_transaction_status_updates(#[future(awt)] fixture: Integratio
         statuses.contains(&TransactionStatus::Confirmed),
         "Should receive CONFIRMED status"
     );
+
+    Ok(())
+}
+
+#[rstest]
+#[test_log::test(tokio::test)]
+#[serial]
+/// Deploys two safes and announces both nodes. Opens a channel from src to dst, then subscribes
+/// to ticketRedeemed events filtered by that channel ID. Redeems a single ticket from dst's
+/// perspective. Asserts that the subscription delivers exactly one event with the correct issuer,
+/// recipient, ticket index, and redemption outcome (Redeemed).
+async fn subscribe_ticket_redeemed(#[future(awt)] fixture: IntegrationFixture) -> Result<()> {
+    let [src, dst] = fixture.sample_accounts::<2>();
+    let channel_id = generate_channel_id(&src.address, &dst.address);
+    let channel_id_hex = Hash::from(channel_id).encode_hex::<String>();
+
+    let ticket_amount = "1 wei wxHOPR".parse::<HoprBalance>().expect("failed to parse amount");
+    let safe_balance = parsed_safe_balance();
+
+    // Deploy safes for both accounts and announce their presence on-chain.
+    let (src_safe, dst_safe) = tokio::try_join!(
+        fixture.deploy_safe_and_announce(&src, safe_balance),
+        fixture.deploy_safe_and_announce(&dst, safe_balance),
+    )?;
+
+    // Approve the channel contract to pull wxHOPR from src's safe and open the channel.
+    fixture.approve(&src, ticket_amount, &src_safe.module_address).await?;
+    fixture
+        .open_channel(src, dst, ticket_amount, &src_safe.module_address, None)
+        .await?;
+
+    // Wait for the channel to be indexed before subscribing so we know epoch=1 is stable.
+    let poll_client = fixture.client().clone();
+    let poll_channel_id = channel_id;
+    poll_until(
+        "channel indexed before ticket redemption subscription",
+        Duration::from_secs(30),
+        Duration::from_millis(500),
+        || {
+            let client = poll_client.clone();
+            let selector = ChannelSelector {
+                filter: Some(ChannelFilter::ChannelId(poll_channel_id.into())),
+                status: Some(ChannelStatus::Open),
+                ..Default::default()
+            };
+            async move {
+                let count = client.count_channels(selector).await?;
+                Ok(if count >= 1 { Some(count) } else { None })
+            }
+        },
+    )
+    .await?;
+
+    // Subscribe to ticket redemptions filtered by the channel ID we just opened.
+    let client = fixture.client().clone();
+    let subscribe_channel_id = channel_id_hex.clone();
+    let handle = tokio::task::spawn(async move {
+        client
+            .subscribe_ticket_redeemed(Some(subscribe_channel_id.into()), None, None)
+            .expect("failed to create ticket redeemed subscription")
+            .next()
+            .timeout(subscription_timeout())
+            .await
+    });
+
+    // Redeem a single ticket: dst redeems ticket index 0 in epoch 1 issued by src.
+    fixture
+        .redeem_ticket(&src, &dst, ticket_amount, &dst_safe.module_address, 0, 1)
+        .await?;
+
+    let event = handle
+        .await??
+        .ok_or_else(|| anyhow!("no ticket redeemed event received from subscription"))??;
+
+    assert_eq!(
+        event.issuer_address.to_lowercase(),
+        src.address.to_string().to_lowercase(),
+        "issuer must be src"
+    );
+    assert_eq!(
+        event.recepient_address.to_lowercase(),
+        dst.address.to_string().to_lowercase(),
+        "recipient must be dst"
+    );
+    assert_eq!(event.index.0, "0", "ticket index must be 0");
+    assert_eq!(event.result, RedemptionResult::Redeemed, "ticket must be accepted");
 
     Ok(())
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -699,7 +699,7 @@ pub enum RedemptionResult {
 
 /// GraphQL output type for a ticket redemption event.
 ///
-/// Uniquely identifies the ticket (`issuerAddress` + `recepientAddress` +
+/// Uniquely identifies the ticket (`issuerAddress` + `recipientAddress` +
 /// `epoch` + `index`) and reports whether it was accepted or rejected.
 ///
 /// Returned by the `ticketRedeemed` subscription.
@@ -709,12 +709,12 @@ pub struct RedeemTicketDetails {
     #[graphql(name = "issuerAddress")]
     pub issuer_address: String,
     /// Recipient account on-chain address in hexadecimal format
-    #[graphql(name = "recepientAddress")]
-    pub recepient_address: String,
+    #[graphql(name = "recipientAddress")]
+    pub recipient_address: String,
     /// Epoch of the channel where the ticket was redeemed
-    pub epoch: u32,
+    pub epoch: UInt64,
     /// Index of the ticket within the channel epoch
-    pub index: u64,
+    pub index: UInt64,
     /// Outcome of the redemption attempt
     pub result: RedemptionResult,
 }
@@ -730,7 +730,7 @@ pub struct RedeemTicketDetailsInfo {
     /// Issuer account on-chain address in hexadecimal format
     pub issuer_address: String,
     /// Recipient account on-chain address in hexadecimal format
-    pub recepient_address: String,
+    pub recipient_address: String,
     /// Epoch of the channel where the ticket was redeemed
     pub epoch: u32,
     /// Channel ID in lowercase hex (no `0x` prefix), used for subscription filtering
@@ -746,9 +746,9 @@ impl From<RedeemTicketDetailsInfo> for RedeemTicketDetails {
     fn from(value: RedeemTicketDetailsInfo) -> Self {
         Self {
             issuer_address: value.issuer_address,
-            recepient_address: value.recepient_address,
-            epoch: value.epoch,
-            index: value.index,
+            recipient_address: value.recipient_address,
+            epoch: UInt64(value.epoch as u64),
+            index: UInt64(value.index),
             result: value.result,
         }
     }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -684,12 +684,25 @@ pub struct RedeemedStatsFilter {
     pub node_address: Option<String>,
 }
 
+/// Outcome of a ticket redemption attempt.
+///
+/// Carried in [`RedeemTicketDetails`] to allow subscribers to distinguish
+/// successful on-chain redemptions from inner Safe transaction failures
+/// (rejected) without polling the chain.
 #[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
 pub enum RedemptionResult {
+    /// Ticket was successfully redeemed on-chain.
     Redeemed,
+    /// Ticket redemption was rejected (inner Safe transaction failed).
     Rejected,
 }
 
+/// GraphQL output type for a ticket redemption event.
+///
+/// Uniquely identifies the ticket (`issuerAddress` + `recepientAddress` +
+/// `epoch` + `index`) and reports whether it was accepted or rejected.
+///
+/// Returned by the `ticketRedeemed` subscription.
 #[derive(SimpleObject, Clone, Debug)]
 pub struct RedeemTicketDetails {
     /// Issuer account on-chain address in hexadecimal format
@@ -698,31 +711,37 @@ pub struct RedeemTicketDetails {
     /// Recipient account on-chain address in hexadecimal format
     #[graphql(name = "recepientAddress")]
     pub recepient_address: String,
-    /// Epoch of the Channel where the ticket has been redeemed
+    /// Epoch of the channel where the ticket was redeemed
     pub epoch: u32,
-    /// Index of the ticket in the Channel
+    /// Index of the ticket within the channel epoch
     pub index: u64,
-    /// Result of the redemption attempt
+    /// Outcome of the redemption attempt
     pub result: RedemptionResult,
 }
 
-/// DTO for ReedemTicketDetail, carying extra information.
+/// Internal event payload for ticket redemption, extending [`RedeemTicketDetails`]
+/// with the channel ID needed for subscription filtering.
+///
+/// Produced by the indexer handler and published on the event bus.
+/// Converted to [`RedeemTicketDetails`] (dropping `channel_id`) before
+/// yielding to GraphQL subscribers.
 #[derive(Debug, Clone)]
 pub struct RedeemTicketDetailsInfo {
     /// Issuer account on-chain address in hexadecimal format
     pub issuer_address: String,
     /// Recipient account on-chain address in hexadecimal format
     pub recepient_address: String,
-    /// Epoch of the Channel where the ticket has been redeemed
+    /// Epoch of the channel where the ticket was redeemed
     pub epoch: u32,
-    /// Channel ID
+    /// Channel ID in lowercase hex (no `0x` prefix), used for subscription filtering
     pub channel_id: String,
-    /// Index of the ticket in the Channel
+    /// Index of the ticket within the channel epoch
     pub index: u64,
-    /// Result of the redemption attempt
+    /// Outcome of the redemption attempt
     pub result: RedemptionResult,
 }
 
+/// Strip `channel_id` (used only for filtering) and expose the GraphQL fields.
 impl From<RedeemTicketDetailsInfo> for RedeemTicketDetails {
     fn from(value: RedeemTicketDetailsInfo) -> Self {
         Self {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -719,41 +719,6 @@ pub struct RedeemTicketDetails {
     pub result: RedemptionResult,
 }
 
-/// Internal event payload for ticket redemption, extending [`RedeemTicketDetails`]
-/// with the channel ID needed for subscription filtering.
-///
-/// Produced by the indexer handler and published on the event bus.
-/// Converted to [`RedeemTicketDetails`] (dropping `channel_id`) before
-/// yielding to GraphQL subscribers.
-#[derive(Debug, Clone)]
-pub struct RedeemTicketDetailsInfo {
-    /// Issuer account on-chain address in hexadecimal format
-    pub issuer_address: String,
-    /// Recipient account on-chain address in hexadecimal format
-    pub recipient_address: String,
-    /// Epoch of the channel where the ticket was redeemed
-    pub epoch: u32,
-    /// Channel ID in lowercase hex (no `0x` prefix), used for subscription filtering
-    pub channel_id: String,
-    /// Index of the ticket within the channel epoch
-    pub index: u64,
-    /// Outcome of the redemption attempt
-    pub result: RedemptionResult,
-}
-
-/// Strip `channel_id` (used only for filtering) and expose the GraphQL fields.
-impl From<RedeemTicketDetailsInfo> for RedeemTicketDetails {
-    fn from(value: RedeemTicketDetailsInfo) -> Self {
-        Self {
-            issuer_address: value.issuer_address,
-            recipient_address: value.recipient_address,
-            epoch: UInt64(value.epoch as u64),
-            index: UInt64(value.index),
-            result: value.result,
-        }
-    }
-}
-
 /// Selector for safe lookup queries.
 ///
 /// This enum is used together with a single `address` argument when querying

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -684,6 +684,57 @@ pub struct RedeemedStatsFilter {
     pub node_address: Option<String>,
 }
 
+#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
+pub enum RedemptionResult {
+    Redeemed,
+    Rejected,
+}
+
+#[derive(SimpleObject, Clone, Debug)]
+pub struct RedeemTicketDetails {
+    /// Issuer account on-chain address in hexadecimal format
+    #[graphql(name = "issuerAddress")]
+    pub issuer_address: String,
+    /// Recipient account on-chain address in hexadecimal format
+    #[graphql(name = "recepientAddress")]
+    pub recepient_address: String,
+    /// Epoch of the Channel where the ticket has been redeemed
+    pub epoch: u32,
+    /// Index of the ticket in the Channel
+    pub index: u64,
+    /// Result of the redemption attempt
+    pub result: RedemptionResult,
+}
+
+/// DTO for ReedemTicketDetail, carying extra information.
+#[derive(Debug, Clone)]
+pub struct RedeemTicketDetailsInfo {
+    /// Issuer account on-chain address in hexadecimal format
+    pub issuer_address: String,
+    /// Recipient account on-chain address in hexadecimal format
+    pub recepient_address: String,
+    /// Epoch of the Channel where the ticket has been redeemed
+    pub epoch: u32,
+    /// Channel ID
+    pub channel_id: String,
+    /// Index of the ticket in the Channel
+    pub index: u64,
+    /// Result of the redemption attempt
+    pub result: RedemptionResult,
+}
+
+impl From<RedeemTicketDetailsInfo> for RedeemTicketDetails {
+    fn from(value: RedeemTicketDetailsInfo) -> Self {
+        Self {
+            issuer_address: value.issuer_address,
+            recepient_address: value.recepient_address,
+            epoch: value.epoch,
+            index: value.index,
+            result: value.result,
+        }
+    }
+}
+
 /// Selector for safe lookup queries.
 ///
 /// This enum is used together with a single `address` argument when querying


### PR DESCRIPTION
Key changes:

  - New IndexerEvent::TicketRedeemed variant — published from ChannelBalanceDecreased handler when a ticket redemption is detected
  - Min-price filter — events below the configured minimum ticket price are silently skipped (avoids noise from dust)
  - RedemptionResult enum — distinguishes Redeemed (on-chain success) from Rejected (Safe inner tx failure)
  - RedeemTicketDetails GraphQL type — carries issuer/recipient address, epoch, index, and result
  - New ticketRedeemed resolver in api/src/subscription.rs with full unit test coverage
  - Client bindings — tickets.rs added to blokli-client with subscription query
  - Target schema updated — design/target-api-schema.graphql reflects new subscription