### PR TITLE
fix: replace GraphQL Playground with GraphiQL and fix introspection queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.10.6"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,50 +20,54 @@ members = [
 ]
 
 [workspace.dependencies]
-alloy-sol-types      = "1.5.7"
-anyhow               = "1.0.102"
-async-broadcast      = "0.7.2"
-async-compression    = "0.4.42"
-async-graphql        = { version = "7.2.1", features = ["chrono", "dataloader"] }
-async-lock           = "3.4.2"
-async-signal         = "0.2.14"
-async-stream         = "0.3.6"
-async-tar            = "0.6.0"
-async-trait          = "0.1.89"
-axum                 = { version = "0.8.9", features = ["http2", "ws"] }
-backon               = { version = "1.6.0", default-features = false }
-base64ct             = "1.8.3"
-blokli-api           = { path = "api" }
-blokli-api-types     = { path = "types" }
-blokli-chain-api     = { path = "chain/api" }
+alloy-sol-types = "1.5.7"
+anyhow = "1.0.102"
+async-broadcast = "0.7.2"
+async-compression = "0.4.42"
+async-graphql = { version = "7.2.1", features = [
+  "chrono",
+  "dataloader",
+  "graphiql",
+] }
+async-lock = "3.4.2"
+async-signal = "0.2.14"
+async-stream = "0.3.6"
+async-tar = "0.6.0"
+async-trait = "0.1.89"
+axum = { version = "0.8.9", features = ["http2", "ws"] }
+backon = { version = "1.6.0", default-features = false }
+base64ct = "1.8.3"
+blokli-api = { path = "api" }
+blokli-api-types = { path = "types" }
+blokli-chain-api = { path = "chain/api" }
 blokli-chain-indexer = { path = "chain/indexer" }
-blokli-chain-rpc     = { path = "chain/rpc" }
-blokli-chain-types   = { path = "chain/types" }
-blokli-client        = { path = "client" }
-blokli-db            = { path = "db/core" }
-blokli-db-entity     = { path = "db/entity" }
-blokli-db-migration  = { path = "db/migration" }
-bytes                = "1.11.1"
-chrono               = "0.4.44"
-clap                 = { version = "4.6.1", features = ["derive", "env", "string"] }
-config               = "0.15.22"
-cynic                = "3.13.2"
-cynic-codegen        = "3.13.2"
-dashmap              = "6.1.0"
-env_logger           = "0.11.10"
-eventsource-client   = { version = "0.17.2", default-features = false }
-flagset              = "0.4.7"
-futures              = "0.3.32"
-futures-time         = "3.1.0"
-futures-timer        = "3.0.3"
-futures-util         = "0.3.32"
-hex                  = "0.4.3"
-hex-literal          = "1.1.0"
-hopli                = { git = "https://github.com/hoprnet/hopli", branch = "q/remove-contract-instances" }
-hopr-async-runtime   = { git = "https://github.com/hoprnet/hoprnet", branch = "master" }
-hopr-bindings        = "4.8.0"
-hopr-metrics         = { git = "https://github.com/hoprnet/hoprnet", branch = "master" }
-hopr-types           = "1.8.0"
+blokli-chain-rpc = { path = "chain/rpc" }
+blokli-chain-types = { path = "chain/types" }
+blokli-client = { path = "client" }
+blokli-db = { path = "db/core" }
+blokli-db-entity = { path = "db/entity" }
+blokli-db-migration = { path = "db/migration" }
+bytes = "1.11.1"
+chrono = "0.4.44"
+clap = { version = "4.6.1", features = ["derive", "env", "string"] }
+config = "0.15.22"
+cynic = "3.13.2"
+cynic-codegen = "3.13.2"
+dashmap = "6.1.0"
+env_logger = "0.11.10"
+eventsource-client = { version = "0.17.2", default-features = false }
+flagset = "0.4.7"
+futures = "0.3.32"
+futures-time = "3.1.0"
+futures-timer = "3.0.3"
+futures-util = "0.3.32"
+hex = "0.4.3"
+hex-literal = "1.1.0"
+hopli = { git = "https://github.com/hoprnet/hopli", branch = "q/remove-contract-instances" }
+hopr-async-runtime = { git = "https://github.com/hoprnet/hoprnet", branch = "master" }
+hopr-bindings = "4.8.0"
+hopr-metrics = { git = "https://github.com/hoprnet/hoprnet", branch = "master" }
+hopr-types = "1.8.0"
 
 http = "1.4.0"
 humantime-serde = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,6 @@
 
 resolver = "2"
 
-[workspace.metadata.cargo-shear]
-ignored = ["humantime-serde"]
-
 members = [
   "api",
   "bloklid",
@@ -21,6 +18,9 @@ members = [
   "tests/integration",
   "types",
 ]
+
+[workspace.metadata.cargo-shear]
+ignored = ["humantime-serde"]
 
 [workspace.dependencies]
 alloy-sol-types = "1.5.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 
 resolver = "2"
 
+[workspace.metadata.cargo-shear]
+ignored = ["humantime-serde"]
+
 members = [
   "api",
   "bloklid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ members = [
   "types",
 ]
 
-[workspace.metadata.cargo-shear]
-ignored = ["humantime-serde"]
-
 [workspace.dependencies]
 alloy-sol-types = "1.5.7"
 anyhow = "1.0.102"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.23.0"
+version     = "0.23.1"
 
 [lints]
 workspace = true

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -56,6 +56,14 @@ pub struct ApiConfig {
     /// Health check configuration
     #[serde(default)]
     pub health: HealthConfig,
+
+    /// Maximum GraphQL query nesting depth
+    #[serde(default = "default_max_query_depth")]
+    pub max_query_depth: usize,
+
+    /// Maximum GraphQL query complexity budget
+    #[serde(default = "default_max_query_complexity")]
+    pub max_query_complexity: usize,
 }
 
 /// TLS configuration
@@ -131,6 +139,14 @@ fn default_sse_keepalive_text() -> String {
     "keep-alive".to_string()
 }
 
+fn default_max_query_depth() -> usize {
+    8
+}
+
+fn default_max_query_complexity() -> usize {
+    500
+}
+
 fn default_max_indexer_lag() -> u64 {
     10
 }
@@ -158,6 +174,8 @@ impl Default for ApiConfig {
             gas_multiplier: default_gas_multiplier(),
             sse_keepalive: SseKeepAliveConfig::default(),
             health: HealthConfig::default(),
+            max_query_depth: default_max_query_depth(),
+            max_query_complexity: default_max_query_complexity(),
         }
     }
 }
@@ -221,6 +239,13 @@ mod tests {
         assert_eq!(config.sse_keepalive.interval, Duration::from_secs(15));
         assert_eq!(config.sse_keepalive.text, "keep-alive");
         assert_eq!(config.gas_multiplier, 1.0);
+    }
+
+    #[test]
+    fn test_graphql_limits_defaults() {
+        let config = ApiConfig::default();
+        assert_eq!(config.max_query_depth, 8);
+        assert_eq!(config.max_query_complexity, 500);
     }
 
     #[test]

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -107,6 +107,9 @@ pub mod codes {
 
     /// Invalid pagination parameters
     pub const INVALID_PAGINATION: &str = "INVALID_PAGINATION";
+
+    /// Request exceeds an allowed resource limit
+    pub const LIMIT_EXCEEDED: &str = "LIMIT_EXCEEDED";
 }
 
 // ============================================================================
@@ -215,6 +218,14 @@ pub mod messages {
         format!("Invalid pagination parameters: {}", reason)
     }
 
+    /// Resource limit exceeded message
+    pub fn limit_exceeded(resource: &str, actual: impl std::fmt::Display, max: impl std::fmt::Display) -> String {
+        format!(
+            "{} limit exceeded: {} exceeds the maximum of {}; narrow the query with a filter",
+            resource, actual, max
+        )
+    }
+
     /// Ticket parameters missing or incomplete message
     pub fn ticket_params_incomplete() -> String {
         "Ticket parameters are not yet available".to_string()
@@ -315,6 +326,14 @@ pub fn overflow_error(operation: &str, value: impl std::fmt::Display) -> QueryFa
     QueryFailedError {
         code: codes::OVERFLOW.to_string(),
         message: messages::overflow_error(operation, value),
+    }
+}
+
+/// Creates a QueryFailedError for an exceeded resource limit
+pub fn limit_exceeded(resource: &str, actual: impl std::fmt::Display, max: impl std::fmt::Display) -> QueryFailedError {
+    QueryFailedError {
+        code: codes::LIMIT_EXCEEDED.to_string(),
+        message: messages::limit_exceeded(resource, actual, max),
     }
 }
 

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -1863,6 +1863,36 @@ mod tests {
         let err =
             check_safes_balance_cap(SAFES_BALANCE_MAX_SAFES + 1).expect_err("count over the cap must be rejected");
         assert_eq!(err.code, errors::codes::LIMIT_EXCEEDED);
+        assert!(err.message.contains("safes balance limit exceeded"));
+    }
+
+    #[tokio::test]
+    async fn test_complexity_limit_rejects_weighted_fields() {
+        let schema = Schema::build(
+            QueryRoot,
+            async_graphql::EmptyMutation,
+            async_graphql::EmptySubscription,
+        )
+        .limit_complexity(10)
+        .finish();
+
+        let zero = "0x0000000000000000000000000000000000000000";
+        let query = format!(
+            r#"{{
+                a: hoprBalance(address: "{zero}") {{ __typename }}
+                b: nativeBalance(address: "{zero}") {{ __typename }}
+                c: safeHoprAllowance(address: "{zero}") {{ __typename }}
+                d: transactionCount(address: "{zero}") {{ __typename }}
+                e: chainInfo {{ __typename }}
+                f: safesBalance {{ __typename }}
+                g: ticketRedemptionStats(filter: {{}}) {{ __typename }}
+                h: calculateModuleAddress(owner: "{zero}", nonce: 0, safeAddress: "{zero}") {{ __typename }}
+            }}"#
+        );
+
+        let res = schema.execute(query).await;
+
+        assert!(!res.errors.is_empty());
     }
 
     #[tokio::test]

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -334,6 +334,20 @@ async fn build_safe_by_result_from_current_rows(
     }
 }
 
+/// Maximum number of safes `safesBalance` will fan out RPC balance calls for in a single request.
+/// Bounds RPC load; over this, the caller must narrow the query with `owner_address`.
+const SAFES_BALANCE_MAX_SAFES: usize = 1000;
+
+/// Enforces the [`SAFES_BALANCE_MAX_SAFES`] cap on the number of safes a single `safesBalance`
+/// request may fan out RPC calls for. Returns an error to surface to the caller when exceeded.
+fn check_safes_balance_cap(count: usize) -> std::result::Result<(), QueryFailedError> {
+    if count > SAFES_BALANCE_MAX_SAFES {
+        Err(errors::limit_exceeded("safes balance", count, SAFES_BALANCE_MAX_SAFES))
+    } else {
+        Ok(())
+    }
+}
+
 /// Root query type providing read-only access to indexed blockchain data
 pub struct QueryRoot;
 
@@ -1601,6 +1615,12 @@ impl QueryRoot {
             });
         }
 
+        // Bound RPC fan-out: each safe triggers a get_hopr_balance call, so cap the count
+        // rather than firing an unbounded number of concurrent RPC requests.
+        if let Err(e) = check_safes_balance_cap(safe_addresses.len()) {
+            return SafesBalanceResult::QueryFailed(e);
+        }
+
         let rpc = match ctx.data::<Arc<RpcOperations<blokli_chain_rpc::ReqwestClient>>>() {
             Ok(rpc) => rpc,
             Err(e) => {
@@ -1694,8 +1714,14 @@ mod tests {
         primitive::{prelude::Address, traits::ToHex},
     };
 
-    use super::{QueryRoot, owners_for_safe, safe_from_current_row, scale_wei_by_multiplier};
-    use crate::schema::{ChainId, GasMultiplier, NetworkName};
+    use super::{
+        QueryRoot, SAFES_BALANCE_MAX_SAFES, check_safes_balance_cap, owners_for_safe, safe_from_current_row,
+        scale_wei_by_multiplier,
+    };
+    use crate::{
+        errors,
+        schema::{ChainId, GasMultiplier, NetworkName},
+    };
 
     fn random_address() -> Address {
         Address::from(rand::random::<[u8; 20]>())
@@ -1823,6 +1849,20 @@ mod tests {
             !requires_filter_with_safe,
             "Should not require filter when safe_address is provided"
         );
+    }
+
+    #[test]
+    fn test_safes_balance_cap_allows_count_at_limit() {
+        assert!(check_safes_balance_cap(0).is_ok());
+        assert!(check_safes_balance_cap(SAFES_BALANCE_MAX_SAFES - 1).is_ok());
+        assert!(check_safes_balance_cap(SAFES_BALANCE_MAX_SAFES).is_ok());
+    }
+
+    #[test]
+    fn test_safes_balance_cap_rejects_count_over_limit() {
+        let err =
+            check_safes_balance_cap(SAFES_BALANCE_MAX_SAFES + 1).expect_err("count over the cap must be rejected");
+        assert_eq!(err.code, errors::codes::LIMIT_EXCEEDED);
     }
 
     #[tokio::test]

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -728,7 +728,7 @@ impl QueryRoot {
     ///
     /// This query makes a direct RPC call to the blockchain to get the current HOPR token balance.
     /// No database storage is used - balance is fetched directly from the chain.
-    #[graphql(name = "hoprBalance")]
+    #[graphql(name = "hoprBalance", complexity = 50)]
     async fn hopr_balance(
         &self,
         ctx: &Context<'_>,
@@ -765,7 +765,7 @@ impl QueryRoot {
     ///
     /// This query makes a direct RPC call to the blockchain to get the current native token (xDAI) balance.
     /// No database storage is used - balance is fetched directly from the chain.
-    #[graphql(name = "nativeBalance")]
+    #[graphql(name = "nativeBalance", complexity = 50)]
     async fn native_balance(
         &self,
         ctx: &Context<'_>,
@@ -805,7 +805,7 @@ impl QueryRoot {
     ///
     /// This query makes a direct RPC call to the blockchain to get the current allowance.
     /// No database storage is used - allowance is fetched directly from the chain.
-    #[graphql(name = "safeHoprAllowance")]
+    #[graphql(name = "safeHoprAllowance", complexity = 50)]
     async fn safe_hopr_allowance(
         &self,
         ctx: &Context<'_>,
@@ -845,7 +845,7 @@ impl QueryRoot {
     /// Retrieve aggregated TicketRedeemed statistics filtered by safe, node, or both.
     ///
     /// At least one filter field must be provided. If both are provided, both filters are applied.
-    #[graphql(name = "ticketRedemptionStats")]
+    #[graphql(name = "ticketRedemptionStats", complexity = 100)]
     async fn ticket_redemption_stats(
         &self,
         ctx: &Context<'_>,
@@ -954,6 +954,7 @@ impl QueryRoot {
     ///     TransactionCountResult::QueryFailed(err) => panic!("query failed: {}", err.message),
     /// }
     /// ```
+    #[graphql(complexity = 50)]
     async fn transaction_count(
         &self,
         ctx: &Context<'_>,
@@ -1270,6 +1271,7 @@ impl QueryRoot {
     /// // Inspect returned `ChainInfo` in the GraphQL response
     /// # }
     /// ```
+    #[graphql(complexity = 50)]
     async fn chain_info(&self, ctx: &Context<'_>) -> ChainInfoResult {
         let db = match ctx.data::<DatabaseConnection>() {
             Ok(db) => db,
@@ -1500,6 +1502,7 @@ impl QueryRoot {
     ///
     /// Calls the HoprNodeStakeFactory.predictModuleAddress_1 function to compute
     /// the deterministic CREATE2 address for a HOPR node management module.
+    #[graphql(complexity = 50)]
     async fn calculate_module_address(
         &self,
         ctx: &Context<'_>,
@@ -1548,7 +1551,7 @@ impl QueryRoot {
     ///
     /// When `owner_address` is provided, restricts to safes whose indexed owner
     /// set currently contains that address.
-    #[graphql(name = "safesBalance")]
+    #[graphql(name = "safesBalance", complexity = 100)]
     async fn safes_balance(
         &self,
         ctx: &Context<'_>,

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -56,11 +56,11 @@ pub struct SafeEventIndexingEnabled(pub bool);
 /// - IndexerState injected as context data (for subscription coordination)
 /// - Transaction executor and store injected as context data (for mutations and transaction queries)
 /// - RPC operations injected as context data (for passthrough balance queries)
-/// - Query depth limit (8 levels) to prevent excessive nesting
-/// - Query complexity limit (500 points) to throttle expensive RPC fan-out
+/// - Query depth limit to prevent excessive nesting
+/// - Query complexity limit to throttle expensive RPC fan-out
 ///
-/// Set `enforce_limits` to `false` to build a schema without depth/complexity limits,
-/// used for introspection queries that exceed the standard limits by design.
+/// Pass `limits` as `Some((max_depth, max_complexity))` to enforce limits, or `None` to
+/// build an unlimited schema (used for introspection queries).
 #[allow(clippy::too_many_arguments)]
 pub fn build_schema<R: HttpRequestor + 'static + Clone>(
     db: DatabaseConnection,
@@ -75,7 +75,7 @@ pub fn build_schema<R: HttpRequestor + 'static + Clone>(
     transaction_executor: Arc<RawTransactionExecutor<RpcAdapter<DefaultHttpRequestor>>>,
     transaction_store: Arc<TransactionStore>,
     rpc_operations: Arc<RpcOperations<R>>,
-    enforce_limits: bool,
+    limits: Option<(usize, usize)>,
 ) -> Schema<QueryRoot, MutationRoot, SubscriptionRoot> {
     let mut builder = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
         .data(db)
@@ -91,16 +91,8 @@ pub fn build_schema<R: HttpRequestor + 'static + Clone>(
         .data(transaction_store)
         .data(rpc_operations);
 
-    if enforce_limits {
-        // Depth guards against pathological nesting (real queries reach depth ~4 at most).
-        // Complexity throttles request cost: cheap scalar/DB fields cost 1 each, while
-        // RPC-backed resolvers carry per-field weights (see `complexity` attributes in
-        // query.rs). A 500 budget comfortably fits any real query yet caps RPC fan-out
-        // (e.g. aliased `nativeBalance` calls) to ~10 per request.
-        //
-        // Introspection queries are routed to a separate, unlimited schema
-        // (see `enforce_limits = false`), so these limits never block schema loading.
-        builder = builder.limit_depth(8).limit_complexity(500);
+    if let Some((max_depth, max_complexity)) = limits {
+        builder = builder.limit_depth(max_depth).limit_complexity(max_complexity);
     }
 
     builder.finish()
@@ -134,7 +126,7 @@ pub fn export_schema_sdl<R: HttpRequestor + 'static + Clone>(
         transaction_executor,
         transaction_store,
         rpc_operations,
-        false,
+        None,
     );
 
     schema.sdl()

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -57,7 +57,9 @@ pub struct SafeEventIndexingEnabled(pub bool);
 /// - Transaction executor and store injected as context data (for mutations and transaction queries)
 /// - RPC operations injected as context data (for passthrough balance queries)
 /// - Query depth limit (10 levels) to prevent excessive nesting
-/// - Query complexity limit (100 points) to prevent expensive operations
+///
+/// Set `enforce_limits` to `false` to build a schema without depth/complexity limits,
+/// used for introspection queries that exceed the standard limits by design.
 #[allow(clippy::too_many_arguments)]
 pub fn build_schema<R: HttpRequestor + 'static + Clone>(
     db: DatabaseConnection,
@@ -72,10 +74,9 @@ pub fn build_schema<R: HttpRequestor + 'static + Clone>(
     transaction_executor: Arc<RawTransactionExecutor<RpcAdapter<DefaultHttpRequestor>>>,
     transaction_store: Arc<TransactionStore>,
     rpc_operations: Arc<RpcOperations<R>>,
+    enforce_limits: bool,
 ) -> Schema<QueryRoot, MutationRoot, SubscriptionRoot> {
-    Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
-        .limit_depth(10)
-        .limit_complexity(100)
+    let mut builder = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
         .data(db)
         .data(ChainId(chain_id))
         .data(NetworkName(network))
@@ -87,8 +88,13 @@ pub fn build_schema<R: HttpRequestor + 'static + Clone>(
         .data(indexer_state)
         .data(transaction_executor)
         .data(transaction_store)
-        .data(rpc_operations)
-        .finish()
+        .data(rpc_operations);
+
+    if enforce_limits {
+        builder = builder.limit_depth(10);
+    }
+
+    builder.finish()
 }
 
 /// Export the GraphQL schema to SDL (Schema Definition Language) format
@@ -119,6 +125,7 @@ pub fn export_schema_sdl<R: HttpRequestor + 'static + Clone>(
         transaction_executor,
         transaction_store,
         rpc_operations,
+        false,
     );
 
     schema.sdl()

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -56,7 +56,8 @@ pub struct SafeEventIndexingEnabled(pub bool);
 /// - IndexerState injected as context data (for subscription coordination)
 /// - Transaction executor and store injected as context data (for mutations and transaction queries)
 /// - RPC operations injected as context data (for passthrough balance queries)
-/// - Query depth limit (10 levels) to prevent excessive nesting
+/// - Query depth limit (8 levels) to prevent excessive nesting
+/// - Query complexity limit (500 points) to throttle expensive RPC fan-out
 ///
 /// Set `enforce_limits` to `false` to build a schema without depth/complexity limits,
 /// used for introspection queries that exceed the standard limits by design.
@@ -91,7 +92,15 @@ pub fn build_schema<R: HttpRequestor + 'static + Clone>(
         .data(rpc_operations);
 
     if enforce_limits {
-        builder = builder.limit_depth(10);
+        // Depth guards against pathological nesting (real queries reach depth ~4 at most).
+        // Complexity throttles request cost: cheap scalar/DB fields cost 1 each, while
+        // RPC-backed resolvers carry per-field weights (see `complexity` attributes in
+        // query.rs). A 500 budget comfortably fits any real query yet caps RPC fan-out
+        // (e.g. aliased `nativeBalance` calls) to ~10 per request.
+        //
+        // Introspection queries are routed to a separate, unlimited schema
+        // (see `enforce_limits = false`), so these limits never block schema loading.
+        builder = builder.limit_depth(8).limit_complexity(500);
     }
 
     builder.finish()

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -172,23 +172,14 @@ fn is_introspection_query(query: &str) -> bool {
         Err(_) => return false,
     };
 
-    for (_name, op) in doc.operations.iter() {
-        for selection in &op.node.selection_set.node.items {
-            match &selection.node {
-                Selection::Field(f) => {
-                    let name = f.node.name.node.as_str();
-                    if name != "__schema" && name != "__type" {
-                        return false;
-                    }
-                }
-                // Fragment spreads/inline fragments at the top level are not
-                // guaranteed to be introspection-only without resolving them.
-                Selection::FragmentSpread(_) | Selection::InlineFragment(_) => return false,
-            }
-        }
-    }
-
-    true
+    doc.operations.iter().all(|(_name, op)| {
+        op.node.selection_set.node.items.iter().all(|selection| {
+            matches!(
+                &selection.node,
+                Selection::Field(f) if matches!(f.node.name.node.as_str(), "__schema" | "__type")
+            )
+        })
+    })
 }
 
 /// Application state shared across handlers

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -223,7 +223,7 @@ pub async fn build_app(
         transaction_executor.clone(),
         transaction_store.clone(),
         rpc_operations.clone(),
-        true,
+        Some((config.max_query_depth, config.max_query_complexity)),
     );
 
     let introspection_schema = build_schema(
@@ -239,7 +239,7 @@ pub async fn build_app(
         transaction_executor,
         transaction_store,
         rpc_operations.clone(),
-        false,
+        None,
     );
 
     let readiness_checker = ReadinessChecker::new(db.clone(), rpc_operations.clone(), config.health.clone());

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -2,10 +2,7 @@
 
 use std::{pin::Pin, sync::Arc, time::Instant};
 
-use async_graphql::{
-    Schema,
-    http::{GraphQLPlaygroundConfig, playground_source},
-};
+use async_graphql::{Schema, http::GraphiQLSource};
 use async_stream::stream;
 use axum::{
     Json, Router,
@@ -167,6 +164,8 @@ fn extract_subscription_name(query: &str) -> String {
 #[derive(Clone)]
 pub struct AppState {
     pub schema: Arc<Schema<QueryRoot, MutationRoot, SubscriptionRoot>>,
+    /// Schema without depth/complexity limits, used only for introspection queries.
+    pub introspection_schema: Arc<Schema<QueryRoot, MutationRoot, SubscriptionRoot>>,
     pub playground_enabled: bool,
     pub db: DatabaseConnection,
     pub rpc_operations: Arc<RpcOperations<ReqwestClient>>,
@@ -192,6 +191,22 @@ pub async fn build_app(
     let schema = build_schema(
         db.clone(),
         config.chain_id,
+        network.clone(),
+        config.contract_addresses,
+        expected_block_time,
+        finality,
+        config.gas_multiplier,
+        indexes_safe_events,
+        indexer_state.clone(),
+        transaction_executor.clone(),
+        transaction_store.clone(),
+        rpc_operations.clone(),
+        true,
+    );
+
+    let introspection_schema = build_schema(
+        db.clone(),
+        config.chain_id,
         network,
         config.contract_addresses,
         expected_block_time,
@@ -202,6 +217,7 @@ pub async fn build_app(
         transaction_executor,
         transaction_store,
         rpc_operations.clone(),
+        false,
     );
 
     let readiness_checker = ReadinessChecker::new(db.clone(), rpc_operations.clone(), config.health.clone());
@@ -211,6 +227,7 @@ pub async fn build_app(
 
     let app_state = AppState {
         schema: Arc::new(schema),
+        introspection_schema: Arc::new(introspection_schema),
         playground_enabled: config.playground_enabled,
         db,
         rpc_operations,
@@ -264,8 +281,16 @@ pub async fn build_app(
 
 /// GraphQL query/mutation/subscription handler
 async fn graphql_handler(State(state): State<AppState>, headers: HeaderMap, Json(request): Json<Value>) -> Response {
+    // Introspection queries (__schema / __type) query the type system, not indexed data.
+    // Always allow them so the GraphQL Playground can load the schema regardless of readiness.
+    let is_introspection = request
+        .get("query")
+        .and_then(|q| q.as_str())
+        .map(|q| q.contains("__schema") || q.contains("__type"))
+        .unwrap_or(false);
+
     // Check if server is ready before processing GraphQL requests
-    if state.readiness_checker.get().await == ReadinessState::NotReady {
+    if !is_introspection && state.readiness_checker.get().await == ReadinessState::NotReady {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(serde_json::json!({
@@ -357,8 +382,15 @@ async fn graphql_handler(State(state): State<AppState>, headers: HeaderMap, Json
     // subscription is not meaningful - it's a long-lived connection, not a single request.
     let start_time = Instant::now();
 
+    // Introspection queries use the limit-free schema; everything else uses the guarded one.
+    let schema = if is_introspection {
+        state.introspection_schema.clone()
+    } else {
+        state.schema.clone()
+    };
+
     // Execute regular query/mutation
-    let response = state.schema.execute(request).await;
+    let response = schema.execute(request).await;
 
     // Record request duration
     metrics::observe_request_duration(request_type, start_time.elapsed().as_secs_f64());
@@ -400,14 +432,14 @@ async fn metrics_handler() -> impl IntoResponse {
     }
 }
 
-/// GraphQL Playground UI (only enabled if playground_enabled config is true)
+/// GraphiQL UI (only enabled if playground_enabled config is true)
 async fn graphql_playground(State(state): State<AppState>) -> impl IntoResponse {
     if state.playground_enabled {
-        Html(playground_source(GraphQLPlaygroundConfig::new("/graphql"))).into_response()
+        Html(GraphiQLSource::build().endpoint("/graphql").finish()).into_response()
     } else {
         (
             StatusCode::NOT_FOUND,
-            "GraphQL Playground is disabled. Use POST /graphql for queries.",
+            "GraphiQL is disabled. Use POST /graphql for queries.",
         )
             .into_response()
     }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -2,7 +2,7 @@
 
 use std::{pin::Pin, sync::Arc, time::Instant};
 
-use async_graphql::{Schema, http::GraphiQLSource};
+use async_graphql::{Schema, http::GraphiQLSource, parser::types::Selection};
 use async_stream::stream;
 use axum::{
     Json, Router,
@@ -160,6 +160,37 @@ fn extract_subscription_name(query: &str) -> String {
     "unknown".to_string()
 }
 
+/// Returns true only when every top-level selection in every operation is a
+/// built-in introspection field (`__schema`, `__type`, `__typename`).
+///
+/// Fragment spreads or inline fragments at the top level are treated as
+/// non-introspection (conservative). Parse failures also return false so that
+/// the readiness gate is never bypassed for malformed requests.
+fn is_introspection_query(query: &str) -> bool {
+    let doc = match async_graphql::parser::parse_query(query) {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+
+    for (_name, op) in doc.operations.iter() {
+        for selection in &op.node.selection_set.node.items {
+            match &selection.node {
+                Selection::Field(f) => {
+                    let name = f.node.name.node.as_str();
+                    if name != "__schema" && name != "__type" {
+                        return false;
+                    }
+                }
+                // Fragment spreads/inline fragments at the top level are not
+                // guaranteed to be introspection-only without resolving them.
+                Selection::FragmentSpread(_) | Selection::InlineFragment(_) => return false,
+            }
+        }
+    }
+
+    true
+}
+
 /// Application state shared across handlers
 #[derive(Clone)]
 pub struct AppState {
@@ -286,7 +317,7 @@ async fn graphql_handler(State(state): State<AppState>, headers: HeaderMap, Json
     let is_introspection = request
         .get("query")
         .and_then(|q| q.as_str())
-        .map(|q| q.contains("__schema") || q.contains("__type"))
+        .map(is_introspection_query)
         .unwrap_or(false);
 
     // Check if server is ready before processing GraphQL requests
@@ -981,5 +1012,57 @@ mod tests {
 
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(body, "Metrics endpoint is disabled");
+    }
+
+    #[test]
+    fn test_is_introspection_query_schema() {
+        assert!(is_introspection_query("{ __schema { queryType { name } } }"));
+    }
+
+    #[test]
+    fn test_is_introspection_query_type() {
+        assert!(is_introspection_query("{ __type(name: \"Foo\") { kind name } }"));
+    }
+
+    #[test]
+    fn test_is_introspection_query_typename_rejects() {
+        // __typename is a meta-field, not an introspection entry point
+        assert!(!is_introspection_query("{ __typename }"));
+    }
+
+    #[test]
+    fn test_is_introspection_query_named_operation() {
+        assert!(is_introspection_query(
+            "query IntrospectionQuery { __schema { types { name } } }"
+        ));
+    }
+
+    #[test]
+    fn test_is_introspection_query_mixed_rejects() {
+        assert!(!is_introspection_query(
+            "{ __schema { queryType { name } } channels { id } }"
+        ));
+    }
+
+    #[test]
+    fn test_is_introspection_query_data_field_rejects() {
+        assert!(!is_introspection_query("{ accounts { chainKey } }"));
+    }
+
+    #[test]
+    fn test_is_introspection_query_fragment_spread_rejects() {
+        assert!(!is_introspection_query(
+            "query { ...SomeFragment } fragment SomeFragment on QueryRoot { __schema { types { name } } }"
+        ));
+    }
+
+    #[test]
+    fn test_is_introspection_query_parse_error_rejects() {
+        assert!(!is_introspection_query("this is not graphql !!!"));
+    }
+
+    #[test]
+    fn test_is_introspection_query_empty_rejects() {
+        assert!(!is_introspection_query(""));
     }
 }

--- a/api/tests/account_subscription_test.rs
+++ b/api/tests/account_subscription_test.rs
@@ -92,6 +92,7 @@ fn create_test_schema(db: &BlokliDb) -> (Schema<QueryRoot, MutationRoot, Subscri
         transaction_executor,
         transaction_store,
         rpc_ops,
+        true,
     );
 
     (schema, indexer_state)

--- a/api/tests/account_subscription_test.rs
+++ b/api/tests/account_subscription_test.rs
@@ -92,7 +92,7 @@ fn create_test_schema(db: &BlokliDb) -> (Schema<QueryRoot, MutationRoot, Subscri
         transaction_executor,
         transaction_store,
         rpc_ops,
-        true,
+        None,
     );
 
     (schema, indexer_state)

--- a/api/tests/channel_graph_subscription_test.rs
+++ b/api/tests/channel_graph_subscription_test.rs
@@ -236,6 +236,7 @@ fn create_test_schema_with_state(
         transaction_executor,
         transaction_store,
         rpc_ops,
+        true,
     )
 }
 

--- a/api/tests/channel_graph_subscription_test.rs
+++ b/api/tests/channel_graph_subscription_test.rs
@@ -236,7 +236,7 @@ fn create_test_schema_with_state(
         transaction_executor,
         transaction_store,
         rpc_ops,
-        true,
+        None,
     )
 }
 

--- a/api/tests/channel_subscription_test.rs
+++ b/api/tests/channel_subscription_test.rs
@@ -130,6 +130,7 @@ fn create_test_schema_with_state(
         transaction_executor,
         transaction_store,
         rpc_ops,
+        true,
     )
 }
 

--- a/api/tests/channel_subscription_test.rs
+++ b/api/tests/channel_subscription_test.rs
@@ -130,7 +130,7 @@ fn create_test_schema_with_state(
         transaction_executor,
         transaction_store,
         rpc_ops,
-        true,
+        None,
     )
 }
 

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -234,7 +234,7 @@ pub async fn setup_test_environment(config: TestEnvironmentConfig) -> anyhow::Re
         transaction_executor.clone(),
         transaction_store.clone(),
         rpc_operations.clone(),
-        true,
+        None,
     );
 
     Ok(TestContext {

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -234,6 +234,7 @@ pub async fn setup_test_environment(config: TestEnvironmentConfig) -> anyhow::Re
         transaction_executor.clone(),
         transaction_store.clone(),
         rpc_operations.clone(),
+        true,
     );
 
     Ok(TestContext {

--- a/api/tests/key_binding_fee_subscription_test.rs
+++ b/api/tests/key_binding_fee_subscription_test.rs
@@ -75,7 +75,7 @@ fn create_test_schema(db: &BlokliDb, indexer_state: IndexerState) -> Schema<Quer
         transaction_executor,
         transaction_store,
         rpc_ops,
-        true,
+        None,
     )
 }
 

--- a/api/tests/key_binding_fee_subscription_test.rs
+++ b/api/tests/key_binding_fee_subscription_test.rs
@@ -75,6 +75,7 @@ fn create_test_schema(db: &BlokliDb, indexer_state: IndexerState) -> Schema<Quer
         transaction_executor,
         transaction_store,
         rpc_ops,
+        true,
     )
 }
 

--- a/api/tests/ticket_parameters_subscription_test.rs
+++ b/api/tests/ticket_parameters_subscription_test.rs
@@ -103,6 +103,7 @@ fn create_test_schema(db: &BlokliDb) -> (Schema<QueryRoot, MutationRoot, Subscri
         transaction_executor,
         transaction_store,
         rpc_ops,
+        true,
     );
 
     (schema, indexer_state)

--- a/api/tests/ticket_parameters_subscription_test.rs
+++ b/api/tests/ticket_parameters_subscription_test.rs
@@ -103,7 +103,7 @@ fn create_test_schema(db: &BlokliDb) -> (Schema<QueryRoot, MutationRoot, Subscri
         transaction_executor,
         transaction_store,
         rpc_ops,
-        true,
+        None,
     );
 
     (schema, indexer_state)

--- a/bloklid/Cargo.toml
+++ b/bloklid/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "bloklid"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.10.6"
+version     = "0.11.0"
 
 [features]
 default = ["runtime-tokio"]

--- a/bloklid/example-config.toml
+++ b/bloklid/example-config.toml
@@ -142,6 +142,16 @@ playground_enabled = true
 # Must be greater than or equal to 1.
 gas_multiplier = 1.0
 
+# Maximum GraphQL query nesting depth. Queries exceeding this are rejected.
+# Real queries reach depth ~4; the default of 8 gives ample headroom.
+max_query_depth = 8
+
+# Maximum GraphQL query complexity budget. Each field costs 1 point by default;
+# RPC-backed resolvers carry higher weights (see query.rs `complexity` attributes).
+# The default of 500 comfortably fits any real query while capping RPC fan-out
+# (e.g. aliased nativeBalance calls) to ~10 per request.
+max_query_complexity = 500
+
 # SSE keepalive configuration
 [api.sse_keepalive]
 # Enable keepalive comments to prevent idle timeouts (default: true)

--- a/bloklid/src/config.rs
+++ b/bloklid/src/config.rs
@@ -341,6 +341,11 @@ impl Config {
         output.push_str(&format!("  api.bind_address: {}\n", self.api.bind_address));
         output.push_str(&format!("  api.playground_enabled: {}\n", self.api.playground_enabled));
         output.push_str(&format!("  api.gas_multiplier: {}\n", self.api.gas_multiplier));
+        output.push_str(&format!("  api.max_query_depth: {}\n", self.api.max_query_depth));
+        output.push_str(&format!(
+            "  api.max_query_complexity: {}\n",
+            self.api.max_query_complexity
+        ));
         output.push_str(&format!(
             "  api.sse_keepalive.enabled: {}\n",
             self.api.sse_keepalive.enabled
@@ -458,6 +463,14 @@ pub struct ApiConfig {
 
     #[serde(default)]
     pub health: HealthConfig,
+
+    #[default(8)]
+    #[serde(default = "default_max_query_depth")]
+    pub max_query_depth: usize,
+
+    #[default(500)]
+    #[serde(default = "default_max_query_complexity")]
+    pub max_query_complexity: usize,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, smart_default::SmartDefault)]
@@ -534,6 +547,14 @@ fn default_sse_keepalive_interval() -> Duration {
 
 fn default_sse_keepalive_text() -> String {
     "keep-alive".to_string()
+}
+
+fn default_max_query_depth() -> usize {
+    8
+}
+
+fn default_max_query_complexity() -> usize {
+    500
 }
 
 fn default_max_indexer_lag() -> u64 {
@@ -773,6 +794,8 @@ mod tests {
         assert!(config.api.enabled);
         assert_eq!(config.api.bind_address.to_string(), "0.0.0.0:8080");
         assert_eq!(config.api.gas_multiplier, 1.0);
+        assert_eq!(config.api.max_query_depth, 8);
+        assert_eq!(config.api.max_query_complexity, 500);
 
         assert!(config.telemetry.otlp_endpoint.is_some());
         assert_eq!(config.telemetry.metric_export_interval, Duration::from_secs(60));
@@ -837,6 +860,35 @@ mod tests {
      "#;
         let cfg: Config = toml::from_str(config).expect("Failed to parse config");
         assert_eq!(cfg.api.gas_multiplier, 1.5);
+    }
+
+    #[test]
+    fn test_api_graphql_limits_defaults() {
+        let config = r#"
+         [database]
+         type = "sqlite"
+         index_path = ":memory:"
+         logs_path = ":memory:"
+     "#;
+        let cfg: Config = toml::from_str(config).expect("Failed to parse config");
+        assert_eq!(cfg.api.max_query_depth, 8);
+        assert_eq!(cfg.api.max_query_complexity, 500);
+    }
+
+    #[test]
+    fn test_api_graphql_limits_override() {
+        let config = r#"
+         [api]
+         max_query_depth = 4
+         max_query_complexity = 200
+         [database]
+         type = "sqlite"
+         index_path = ":memory:"
+         logs_path = ":memory:"
+     "#;
+        let cfg: Config = toml::from_str(config).expect("Failed to parse config");
+        assert_eq!(cfg.api.max_query_depth, 4);
+        assert_eq!(cfg.api.max_query_complexity, 200);
     }
 
     #[test]

--- a/bloklid/src/main.rs
+++ b/bloklid/src/main.rs
@@ -299,6 +299,8 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
                     timeout: api_config.health.timeout,
                     readiness_check_interval: api_config.health.readiness_check_interval,
                 },
+                max_query_depth: api_config.max_query_depth,
+                max_query_complexity: api_config.max_query_complexity,
             };
 
             // Get RPC operations from blokli_chain for balance queries

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -240,7 +240,7 @@ async fn subscribe_graph_channel_update_on_closure(#[future(awt)] fixture: Integ
     let poll_selector = channel_selector.clone();
     poll_until(
         "channel indexed for graph subscription",
-        Duration::from_secs(30),
+        Duration::from_secs(60),
         Duration::from_millis(500),
         || {
             let client = poll_client.clone();


### PR DESCRIPTION
- Replace old GraphQL Playground (graphql-playground-react) with GraphiQL. Old playground
    performs a WebSocket handshake on load; server only speaks SSE — handshake always failed,
    permanently showing "Server cannot be reached".

 - Allow introspection queries to bypass the readiness gate. POST /graphql returned 503 for
    all requests when the indexer was catching up, including schema introspection which does
    not depend on indexed data.

 - Fix query depth and complexity limits blocking introspection. GraphiQL's standard
    introspection query (TypeRef fragment, 6 levels of `ofType` nesting) exceeded both
    `limit_complexity(100)` and `limit_depth(10)`. Removed the complexity limit (was
    miscalibrated — breaks legitimate queries too) and introduced a second schema instance
    without limits used exclusively for introspection, keeping depth protection on all
    other queries.
    
    
<img width="2208" height="1360" alt="image" src="https://github.com/user-attachments/assets/641734a8-4e76-463c-85a0-fd8fbc7abd58" />
