### PR TITLE
feat: improve ITs stability

### DIFF
--- a/tests/integration/src/constants.rs
+++ b/tests/integration/src/constants.rs
@@ -4,7 +4,7 @@ use futures_time::time::Duration;
 use hopr_types::primitive::prelude::HoprBalance;
 
 const INITIAL_SAFE_BALANCE: &str = "0.5 wxHOPR";
-const SUBSCRIPTION_TIMEOUT_SECS: u64 = 60;
+const SUBSCRIPTION_TIMEOUT_SECS: u64 = 120;
 
 pub const EPSILON: f64 = 1e-5;
 pub const STACK_STARTUP_WAIT: StdDuration = StdDuration::from_secs(120);

--- a/tests/integration/src/fixtures.rs
+++ b/tests/integration/src/fixtures.rs
@@ -562,6 +562,41 @@ impl IntegrationFixture {
             .await
     }
 
+    /// Finalizes closure of an outgoing channel from `from` to `to`.
+    /// Must be called after `initiate_outgoing_channel_closure` and after the notice period has elapsed.
+    pub async fn finalize_outgoing_channel_closure(
+        &self,
+        from: &AnvilAccount,
+        to: &AnvilAccount,
+        module: &str,
+    ) -> Result<[u8; 32]> {
+        let nonce = self.rpc().transaction_count(&from.address).await?;
+
+        let payload_generator = SafePayloadGenerator::new(
+            &from.keypair,
+            *self.contract_addresses(),
+            HoprAddress::from_str(module)?,
+        );
+
+        let payload = payload_generator.finalize_outgoing_channel_closure(to.address)?;
+
+        let payload_bytes = payload
+            .sign_and_encode_to_eip2718(nonce, self.rpc().chain_id().await?, None, &from.keypair)
+            .await?;
+
+        self.submit_and_confirm_tx(&payload_bytes, self.config().tx_confirmations)
+            .await
+    }
+
+    /// Fully closes an outgoing channel from `from` to `to` (initiates then finalizes).
+    /// Notice period in test contracts is 1 second; the confirmation wait between the two
+    /// transactions is enough for it to elapse.
+    pub async fn close_outgoing_channel(&self, from: &AnvilAccount, to: &AnvilAccount, module: &str) -> Result<()> {
+        self.initiate_outgoing_channel_closure(from, to, module).await?;
+        self.finalize_outgoing_channel_closure(from, to, module).await?;
+        Ok(())
+    }
+
     fn teardown(&self) {
         self.inner.teardown();
     }

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -78,6 +78,10 @@ async fn subscribe_channels(#[future(awt)] fixture: IntegrationFixture) -> Resul
 
     assert_eq!(channel.balance.0, amount.to_string());
 
+    fixture
+        .close_outgoing_channel(src, dst, &src_safe.module_address)
+        .await?;
+
     Ok(())
 }
 
@@ -166,14 +170,10 @@ async fn subscribe_graph(#[future(awt)] fixture: IntegrationFixture) -> Result<(
             .subscribe_graph()
             .expect("failed to create safe deployments subscription")
             .skip_while(|entry| {
-                let retrieved_channel = entry
-                    .as_ref()
-                    .expect("failed to get subscription update")
-                    .channel
-                    .concrete_channel_id
-                    .to_lowercase();
-
-                let should_skip = expected_id.encode_hex::<String>() != retrieved_channel;
+                let entry = entry.as_ref().expect("failed to get subscription update");
+                let retrieved_channel = entry.channel.concrete_channel_id.to_lowercase();
+                let should_skip = expected_id.encode_hex::<String>() != retrieved_channel
+                    || entry.channel.status != ChannelStatus::Open;
                 futures::future::ready(should_skip)
             })
             .next()
@@ -193,6 +193,10 @@ async fn subscribe_graph(#[future(awt)] fixture: IntegrationFixture) -> Result<(
     assert_eq!(graph_entry.source.chain_key, src.address.to_string());
     assert_eq!(graph_entry.destination.chain_key, dst.address.to_string());
     assert_eq!(graph_entry.channel.status, ChannelStatus::Open);
+
+    fixture
+        .close_outgoing_channel(src, dst, &src_safe.module_address)
+        .await?;
 
     Ok(())
 }
@@ -553,6 +557,10 @@ async fn subscribe_channels_no_duplicate_initial_state(#[future(awt)] fixture: I
         received_channel?.concrete_channel_id.to_lowercase(),
         expected_channel_id.to_lowercase()
     );
+
+    fixture
+        .close_outgoing_channel(src, dst, &src_safe.module_address)
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
 Improve integration test stability

  - Double subscription timeout (60s → 120s) to reduce false failures on slow CI runs
  - Add finalize_outgoing_channel_closure and close_outgoing_channel helpers to IntegrationFixture — wraps the two-step initiate+finalize flow; test contract notice period is 1s so the confirmation wait between TXs is sufficient
  - Call close_outgoing_channel at end of subscribe_channels, subscribe_graph, and subscribe_channels_no_duplicate_initial_state — leaves channels closed between serial tests, preventing state bleed that caused flaky failures
  - Fix subscribe_graph skip predicate: also filter on ChannelStatus::Open so stale PendingToClose events from prior tests don't satisfy the assertion prematurely