### PR TITLE
feat(client): Add DNS override for client

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -19,7 +19,7 @@ permissions:
   security-events: write
 jobs:
   zizmor:
-    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -19,7 +19,7 @@ permissions:
   security-events: write
 jobs:
   zizmor:
-    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,12 +19,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-nix@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
         with:
           cachix_cache_name: blokli
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Setup GCP
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
         with:
           google_credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           login_artifact_registry: 'true'

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -19,12 +19,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-nix@6895dbbc515e39e0e283a68a80b8628ca6ead37a
         with:
           cachix_cache_name: blokli
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Setup GCP
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@6895dbbc515e39e0e283a68a80b8628ca6ead37a
         with:
           google_credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           login_artifact_registry: 'true'

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -26,9 +26,9 @@ jobs:
       - name: Setup GCP
         uses: hoprnet/hopr-workflows/actions/setup-gcp@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
         with:
-          google-credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          login-artifact-registry: 'true'
-          install-sdk: 'false'
+          google_credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+          login_artifact_registry: 'true'
+          install_sdk: 'false'
       - name: Run Integration tests
         env:
           BLOKLI_TEST_REMOTE_IMAGE: ${{ inputs.image }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -31,7 +31,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             build_command: nix build -L .#binary-bloklid-aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     permissions:
       contents: read
     with:
@@ -60,7 +60,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     permissions:
       contents: read
     with:
@@ -76,7 +76,7 @@ jobs:
   build-docker:
     name: Docker
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     needs: build-binaries
     permissions:
       contents: read
@@ -111,7 +111,7 @@ jobs:
   build-docker-with-anvil:
     name: Docker anvil
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     needs: build-binaries
     permissions:
       contents: read
@@ -153,7 +153,7 @@ jobs:
         run: echo "suffix=v$(echo '${{ needs.build-docker.outputs.docker_build_version }}' | tr '.' '-')" | tee -a "$GITHUB_OUTPUT"
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_DEVELOPMENT }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT_DEVELOPMENT }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -31,7 +31,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             build_command: nix build -L .#binary-bloklid-aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
     with:
@@ -60,7 +60,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
     with:
@@ -76,7 +76,7 @@ jobs:
   build-docker:
     name: Docker
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     needs: build-binaries
     permissions:
       contents: read
@@ -111,7 +111,7 @@ jobs:
   build-docker-with-anvil:
     name: Docker anvil
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     needs: build-binaries
     permissions:
       contents: read
@@ -153,7 +153,7 @@ jobs:
         run: echo "suffix=v$(echo '${{ needs.build-docker.outputs.docker_build_version }}' | tr '.' '-')" | tee -a "$GITHUB_OUTPUT"
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@6895dbbc515e39e0e283a68a80b8628ca6ead37a
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_DEVELOPMENT }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT_DEVELOPMENT }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,7 +83,7 @@ jobs:
   # ── Shared checks (lint, pre-commit, audit) ─────────────────────────────────
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       lint_command: "nix develop --command just quick"
@@ -96,7 +96,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -121,7 +121,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-nix@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
         with:
           cachix_cache_name: blokli
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
             runner: depot-macos-15
             build_command: nix build -L .#binary-bloklid-aarch64-darwin
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     permissions:
       contents: read
     with:
@@ -181,7 +181,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     permissions:
       contents: read
     with:
@@ -199,7 +199,7 @@ jobs:
   # ── Build: Docker ───────────────────────────────────────────────────────────
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     needs: build-binaries
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,11 +99,11 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      unit_tests: true
+      enable_unit_tests: true
       unit_test_command: "nix run -L .#test"
-      unit_coverage: true
+      enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
       test_timeout: 30
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,7 +83,7 @@ jobs:
   # ── Shared checks (lint, pre-commit, audit) ─────────────────────────────────
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       lint_command: "nix develop --command just quick"
@@ -96,7 +96,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -121,7 +121,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-nix@6895dbbc515e39e0e283a68a80b8628ca6ead37a
         with:
           cachix_cache_name: blokli
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
             runner: depot-macos-15
             build_command: nix build -L .#binary-bloklid-aarch64-darwin
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
     with:
@@ -181,7 +181,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
     with:
@@ -199,7 +199,7 @@ jobs:
   # ── Build: Docker ───────────────────────────────────────────────────────────
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     needs: build-binaries
     permissions:
       contents: read

--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
     with:
@@ -42,7 +42,7 @@ jobs:
       contents: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@6895dbbc515e39e0e283a68a80b8628ca6ead37a
         with:
           source_branch: ${{ github.ref_name }}
           file: client/Cargo.toml

--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     permissions:
       contents: read
     with:
@@ -42,7 +42,7 @@ jobs:
       contents: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
         with:
           source_branch: ${{ github.ref_name }}
           file: client/Cargo.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             build_command: nix build -L .#binary-bloklid-aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     permissions:
       contents: read
     with:
@@ -50,7 +50,7 @@ jobs:
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
     needs: build-binaries
     permissions:
       contents: read
@@ -93,7 +93,7 @@ jobs:
       contents: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
         with:
           source_branch: ${{ github.ref_name }}
           file: bloklid/Cargo.toml
@@ -126,7 +126,7 @@ jobs:
         run: echo "suffix=v$(echo '${{ needs.build-docker.outputs.docker_build_version }}' | tr '.' '-')" | tee -a "$GITHUB_OUTPUT"
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT_STAGING }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             build_command: nix build -L .#binary-bloklid-aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
     with:
@@ -50,7 +50,7 @@ jobs:
       gpg_private_key: ${{ secrets.GPG_HOPRNET_PRIVATE_KEY }}
   build-docker:
     name: Docker
-    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-docker.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     needs: build-binaries
     permissions:
       contents: read
@@ -93,7 +93,7 @@ jobs:
       contents: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@6895dbbc515e39e0e283a68a80b8628ca6ead37a
         with:
           source_branch: ${{ github.ref_name }}
           file: bloklid/Cargo.toml
@@ -126,7 +126,7 @@ jobs:
         run: echo "suffix=v$(echo '${{ needs.build-docker.outputs.docker_build_version }}' | tr '.' '-')" | tee -a "$GITHUB_OUTPUT"
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@7d8e6dfe4cfacb23a42857171d7426467686970e # setup-nix-v2
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@6895dbbc515e39e0e283a68a80b8628ca6ead37a
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER_STAGING }}
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT_STAGING }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ just run-api
 `blokli-client` uses system DNS by default. For deployments where Blokli is reachable through a stable, VPN-exempt IP but DNS can be
 unreliable, callers can configure a DNS override in `BlokliClientConfig`.
 
-The Blokli URL should stay hostname-based. The override only changes the socket address used by reqwest, so HTTP `Host`, TLS SNI, and
-certificate validation still use the original hostname.
+The Blokli URL should stay hostname-based. The override pins DNS resolution for that hostname, so TLS SNI and certificate validation still
+use the original hostname. If `BlokliDnsOverride::port` is set, Blokli uses that port for requests; otherwise it uses the original URL port
+or the scheme default.
 
 ```rust
 use std::net::IpAddr;

--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ Run the GraphQL API server on its own:
 just run-api
 ```
 
+### Client DNS Override
+
+`blokli-client` uses system DNS by default. For deployments where Blokli is reachable through a stable, VPN-exempt IP but DNS can be
+unreliable, callers can configure a DNS override in `BlokliClientConfig`.
+
+The Blokli URL should stay hostname-based. The override only changes the socket address used by reqwest, so HTTP `Host`, TLS SNI, and
+certificate validation still use the original hostname.
+
+```rust
+use std::net::IpAddr;
+
+use blokli_client::{BlokliClient, BlokliClientConfig, BlokliDnsOverride};
+
+fn build_client() -> Result<BlokliClient, Box<dyn std::error::Error>> {
+    Ok(BlokliClient::new(
+        "https://blokli.example.org".parse()?,
+        BlokliClientConfig {
+            dns_override: Some(BlokliDnsOverride {
+                ip: IpAddr::from([203, 0, 113, 10]),
+                port: None,
+            }),
+            ..Default::default()
+        },
+    ))
+}
+```
+
 ## Docker Images
 
 ### Blokli + Anvil (single container)

--- a/chain/indexer/src/snapshot/download.rs
+++ b/chain/indexer/src/snapshot/download.rs
@@ -322,7 +322,7 @@ impl SnapshotDownloader {
         }
 
         // Copy the file using futures-io
-        let copied_bytes = fs::copy(canonical_path.clone(), target_path)? as u64;
+        let copied_bytes = fs::copy(canonical_path.clone(), target_path)?;
         info!(
             %copied_bytes, from = %canonical_path.display(), to = %target_path.display(),
             "Copied local snapshot file",

--- a/client/src/client/mod.rs
+++ b/client/src/client/mod.rs
@@ -65,7 +65,10 @@ impl CompatibilityFeatures {
 pub struct BlokliDnsOverride {
     /// IP address to connect to for the Blokli base URL host.
     pub ip: IpAddr,
-    /// Optional port override. When `None`, the request URL port or scheme default is used.
+    /// Optional port override.
+    ///
+    /// When `None`, the request URL port or scheme default is used. When a request URL already includes an explicit
+    /// port, that URL port takes precedence over this override.
     pub port: Option<u16>,
 }
 
@@ -326,7 +329,13 @@ impl BlokliClient {
             .base_url
             .host_str()
             .ok_or(ErrorKind::InvalidInput("DNS override requires a Blokli base URL host"))?;
-        let addr = SocketAddr::new(dns_override.ip, dns_override.port.unwrap_or_default());
+        let port = dns_override
+            .port
+            .or_else(|| self.base_url.port_or_known_default())
+            .ok_or(ErrorKind::InvalidInput(
+                "DNS override requires a Blokli base URL port or known default",
+            ))?;
+        let addr = SocketAddr::new(dns_override.ip, port);
 
         Ok(builder.resolve(host, addr))
     }

--- a/client/src/client/mod.rs
+++ b/client/src/client/mod.rs
@@ -67,7 +67,8 @@ pub struct BlokliDnsOverride {
     pub ip: IpAddr,
     /// Optional port override.
     ///
-    /// When `None`, the request URL port or scheme default is used. When `Some`, the override port is used for requests.
+    /// When `None`, the request URL port or scheme default is used. When `Some`, the override port is used for
+    /// requests.
     pub port: Option<u16>,
 }
 

--- a/client/src/client/mod.rs
+++ b/client/src/client/mod.rs
@@ -7,6 +7,7 @@ mod transactions;
 use std::{
     fmt::Debug,
     future::Future,
+    net::{IpAddr, SocketAddr},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -55,6 +56,19 @@ impl CompatibilityFeatures {
     }
 }
 
+/// DNS resolution override for the Blokli base URL host.
+///
+/// This pins the configured Blokli URL hostname to a fixed socket address in reqwest without rewriting the request
+/// URL. That keeps HTTP `Host`, TLS SNI, and certificate validation based on the original hostname while avoiding
+/// system DNS lookups for that host.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlokliDnsOverride {
+    /// IP address to connect to for the Blokli base URL host.
+    pub ip: IpAddr,
+    /// Optional port override. When `None`, the request URL port or scheme default is used.
+    pub port: Option<u16>,
+}
+
 /// Configuration for the [`BlokliClient`].
 #[derive(Clone, Debug, PartialEq, Eq, smart_default::SmartDefault)]
 pub struct BlokliClientConfig {
@@ -79,6 +93,11 @@ pub struct BlokliClientConfig {
     /// Delay before recreating a completed SSE stream. If `None`, completed streams will not be recreated.
     #[default(Some(Duration::from_secs(1)))]
     pub subscription_stream_restart_delay: Option<Duration>,
+    /// Optional DNS override for the Blokli base URL host.
+    ///
+    /// When `None`, the client uses system DNS. When set, both GraphQL requests and SSE subscription connections use
+    /// the override.
+    pub dns_override: Option<BlokliDnsOverride>,
 }
 
 /// Internal state for managing GraphQL subscription streams.
@@ -299,15 +318,31 @@ impl BlokliClient {
         Ok(base.join("graphql").map_err(ErrorKind::from)?)
     }
 
+    fn apply_dns_override(&self, builder: reqwest::ClientBuilder) -> Result<reqwest::ClientBuilder, BlokliClientError> {
+        let Some(dns_override) = &self.cfg.dns_override else {
+            return Ok(builder);
+        };
+        let host = self
+            .base_url
+            .host_str()
+            .ok_or(ErrorKind::InvalidInput("DNS override requires a Blokli base URL host"))?;
+        let addr = SocketAddr::new(dns_override.ip, dns_override.port.unwrap_or_default());
+
+        Ok(builder.resolve(host, addr))
+    }
+
     fn build_reqwest_client(&self) -> Result<reqwest::Client, BlokliClientError> {
-        Ok(reqwest::Client::builder()
+        let client_builder = reqwest::Client::builder()
             .timeout(self.cfg.timeout)
             .brotli(true)
             .gzip(true)
             .zstd(true)
             .deflate(true)
             .user_agent(format!("blokli-client/{}-{}", env!("CARGO_PKG_VERSION"), VERSION))
-            .redirect(RedirectPolicy::limited(REDIRECT_LIMIT))
+            .redirect(RedirectPolicy::limited(REDIRECT_LIMIT));
+
+        Ok(self
+            .apply_dns_override(client_builder)?
             .build()
             .map_err(ErrorKind::from)?)
     }
@@ -327,7 +362,10 @@ impl BlokliClient {
             client_builder = client_builder.read_timeout(read_timeout);
         }
 
-        Ok(client_builder.build().map_err(ErrorKind::from)?)
+        Ok(self
+            .apply_dns_override(client_builder)?
+            .build()
+            .map_err(ErrorKind::from)?)
     }
 
     fn build_subscription_stream<Q, V>(

--- a/client/src/client/mod.rs
+++ b/client/src/client/mod.rs
@@ -67,8 +67,7 @@ pub struct BlokliDnsOverride {
     pub ip: IpAddr,
     /// Optional port override.
     ///
-    /// When `None`, the request URL port or scheme default is used. When a request URL already includes an explicit
-    /// port, that URL port takes precedence over this override.
+    /// When `None`, the request URL port or scheme default is used. When `Some`, the override port is used for requests.
     pub port: Option<u16>,
 }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -3,12 +3,13 @@
 //! # DNS override
 //!
 //! By default, [`BlokliClient`] uses the system DNS resolver through `reqwest`. Callers that need to keep Blokli
-//! communication working while DNS is unreliable can configure [`BlokliClientConfig::dns_override`] to connect the
-//! Blokli URL hostname to a fixed IP address.
+//! communication working while DNS is unreliable can configure [`BlokliClientConfig::dns_override`] to pin the Blokli
+//! URL hostname to a fixed IP address.
 //!
-//! The request URL is not rewritten. For example, a client configured with `https://blokli.example.org` and a DNS
-//! override still sends requests to `https://blokli.example.org/graphql`, preserving HTTP `Host`, TLS SNI, and
-//! certificate validation while bypassing system DNS for that hostname.
+//! The request hostname is not rewritten. For example, a client configured with `https://blokli.example.org` and a DNS
+//! override still sends requests for `blokli.example.org`, preserving TLS SNI and certificate validation while
+//! bypassing system DNS for that hostname. When [`BlokliDnsOverride::port`] is set, it becomes the request port;
+//! otherwise the original URL port or scheme default is used.
 //!
 //! ```no_run
 //! use std::net::IpAddr;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,3 +1,35 @@
+//! Rust client for the Blokli GraphQL API.
+//!
+//! # DNS override
+//!
+//! By default, [`BlokliClient`] uses the system DNS resolver through `reqwest`. Callers that need to keep Blokli
+//! communication working while DNS is unreliable can configure [`BlokliClientConfig::dns_override`] to connect the
+//! Blokli URL hostname to a fixed IP address.
+//!
+//! The request URL is not rewritten. For example, a client configured with `https://blokli.example.org` and a DNS
+//! override still sends requests to `https://blokli.example.org/graphql`, preserving HTTP `Host`, TLS SNI, and
+//! certificate validation while bypassing system DNS for that hostname.
+//!
+//! ```no_run
+//! use std::net::IpAddr;
+//!
+//! use blokli_client::{BlokliClient, BlokliClientConfig, BlokliDnsOverride};
+//!
+//! let client = BlokliClient::new(
+//!     "https://blokli.example.org".parse()?,
+//!     BlokliClientConfig {
+//!         dns_override: Some(BlokliDnsOverride {
+//!             ip: IpAddr::from([203, 0, 113, 10]),
+//!             port: None,
+//!         }),
+//!         ..Default::default()
+//!     },
+//! );
+//! # let _ = client;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! Leave `dns_override` as `None` to use normal system DNS resolution.
 /// Current Blokli client API.
 pub mod api;
 mod client;
@@ -7,7 +39,7 @@ pub mod errors;
 
 pub const CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub use client::{BlokliClient, BlokliClientConfig, ReqwestTransport};
+pub use client::{BlokliClient, BlokliClientConfig, BlokliDnsOverride, ReqwestTransport};
 #[cfg(feature = "testing")]
 pub use client::{
     BlokliTestClient, BlokliTestState, BlokliTestStateMutator, BlokliTestStateSnapshot, GraphQlQueries, NopStateMutator,

--- a/client/tests/query_tests.rs
+++ b/client/tests/query_tests.rs
@@ -1,9 +1,15 @@
+use std::net::IpAddr;
+
 use blokli_client::{
-    BlokliClient, BlokliClientConfig, CLIENT_VERSION,
+    BlokliClient, BlokliClientConfig, BlokliDnsOverride, CLIENT_VERSION,
     api::{BlokliQueryClient, SafeSelector},
 };
 use mockito::Matcher;
 use serde_json::json;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
 
 use crate::common::{Body, RequestRecorder};
 
@@ -252,4 +258,78 @@ async fn query_safe_returns_empty_vec_when_safe_by_is_null() -> anyhow::Result<(
 
     mock.assert_async().await;
     Ok(())
+}
+
+#[test]
+fn default_config_uses_system_dns() {
+    assert_eq!(BlokliClientConfig::default().dns_override, None);
+}
+
+#[tokio::test]
+async fn query_uses_dns_override_without_rewriting_host() -> anyhow::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let base_url = format!("http://blokli.invalid:{port}").parse()?;
+    let client = BlokliClient::new(
+        base_url,
+        BlokliClientConfig {
+            auto_compatibility_check: false,
+            dns_override: Some(BlokliDnsOverride {
+                ip: IpAddr::from([127, 0, 0, 1]),
+                port: None,
+            }),
+            ..Default::default()
+        },
+    );
+
+    let server = tokio::spawn(async move {
+        let (mut conn, _) = listener.accept().await?;
+        let request = read_http_request_head(&mut conn).await?;
+        conn.write_all(format_json_response(r#"{"data":{"version":"0.19.1"}}"#).as_bytes())
+            .await?;
+        conn.shutdown().await?;
+        anyhow::Ok(request)
+    });
+
+    let version = client.query_version().await?;
+    let request = server.await??;
+
+    assert_eq!(version, "0.19.1");
+    assert!(request.starts_with("post /graphql http/1.1\r\n"));
+    assert!(request.contains(&format!("\r\nhost: blokli.invalid:{port}\r\n")));
+
+    Ok(())
+}
+
+async fn read_http_request_head(conn: &mut tokio::net::TcpStream) -> anyhow::Result<String> {
+    let mut buf = Vec::new();
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let n = conn.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    Ok(String::from_utf8_lossy(&buf).to_ascii_lowercase())
+}
+
+fn format_json_response(body: &str) -> String {
+    format!(
+        concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "content-type: application/json\r\n",
+            "cache-control: no-cache\r\n",
+            "connection: close\r\n",
+            "content-length: {}\r\n",
+            "\r\n",
+            "{}",
+        ),
+        body.len(),
+        body,
+    )
 }

--- a/client/tests/query_tests.rs
+++ b/client/tests/query_tests.rs
@@ -301,6 +301,42 @@ async fn query_uses_dns_override_without_rewriting_host() -> anyhow::Result<()> 
     Ok(())
 }
 
+#[tokio::test]
+async fn query_uses_dns_override_with_explicit_port() -> anyhow::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let listener_port = listener.local_addr()?.port();
+    let base_url = "http://blokli.invalid".parse()?;
+    let client = BlokliClient::new(
+        base_url,
+        BlokliClientConfig {
+            auto_compatibility_check: false,
+            dns_override: Some(BlokliDnsOverride {
+                ip: IpAddr::from([127, 0, 0, 1]),
+                port: Some(listener_port),
+            }),
+            ..Default::default()
+        },
+    );
+
+    let server = tokio::spawn(async move {
+        let (mut conn, _) = listener.accept().await?;
+        let request = read_http_request_head(&mut conn).await?;
+        conn.write_all(format_json_response(r#"{"data":{"version":"0.19.1"}}"#).as_bytes())
+            .await?;
+        conn.shutdown().await?;
+        anyhow::Ok(request)
+    });
+
+    let version = client.query_version().await?;
+    let request = server.await??;
+
+    assert_eq!(version, "0.19.1");
+    assert!(request.starts_with("post /graphql http/1.1\r\n"));
+    assert!(request.contains("\r\nhost: blokli.invalid\r\n"));
+
+    Ok(())
+}
+
 async fn read_http_request_head(conn: &mut tokio::net::TcpStream) -> anyhow::Result<String> {
     let mut buf = Vec::new();
     loop {

--- a/client/tests/subscription_tests.rs
+++ b/client/tests/subscription_tests.rs
@@ -1,7 +1,9 @@
-use std::time::Duration;
+use std::{net::IpAddr, time::Duration};
 
 use anyhow::Result;
-use blokli_client::{BlokliClient, BlokliClientConfig, CLIENT_VERSION, api::BlokliSubscriptionClient};
+use blokli_client::{
+    BlokliClient, BlokliClientConfig, BlokliDnsOverride, CLIENT_VERSION, api::BlokliSubscriptionClient,
+};
 use futures::StreamExt;
 use tokio::{io::AsyncWriteExt, net::TcpListener};
 use url::Url;
@@ -158,6 +160,44 @@ async fn subscribe_ticket_params_reconnects_after_read_timeout() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn subscribe_ticket_params_uses_dns_override() -> Result<()> {
+    let expected_ticket_params = TicketParams {
+        ticket_price: "0.0010 wxHOPR".to_string(),
+        min_ticket_winning_probability: 0.25,
+    };
+    let (base_url, server) = spawn_dns_override_streaming_server(vec![expected_ticket_params.clone()]).await?;
+    let client = BlokliClient::new(
+        base_url,
+        BlokliClientConfig {
+            dns_override: Some(BlokliDnsOverride {
+                ip: IpAddr::from([127, 0, 0, 1]),
+                port: None,
+            }),
+            timeout: Duration::from_secs(2),
+            stream_reconnect_timeout: Duration::from_secs(2),
+            subscription_read_timeout: Some(Duration::from_secs(2)),
+            subscription_tcp_keepalive: Duration::from_secs(15),
+            subscription_stream_restart_delay: Some(Duration::from_millis(100)),
+            ..Default::default()
+        },
+    );
+
+    let mut stream = client.subscribe_ticket_params()?;
+    let update = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("subscription ended before delivering an event"))??;
+
+    assert_eq!(update.ticket_price.0, expected_ticket_params.ticket_price);
+    assert_eq!(
+        update.min_ticket_winning_probability,
+        expected_ticket_params.min_ticket_winning_probability
+    );
+
+    server.await??;
+    Ok(())
+}
+
 async fn spawn_reconnecting_server(
     event_batches: Vec<Vec<TicketParams>>,
 ) -> Result<(Url, tokio::task::JoinHandle<Result<()>>)> {
@@ -181,6 +221,32 @@ async fn spawn_reconnecting_server(
             conn.shutdown().await?;
         }
 
+        Ok(())
+    });
+
+    Ok((base_url, server))
+}
+
+async fn spawn_dns_override_streaming_server(
+    events: Vec<TicketParams>,
+) -> Result<(Url, tokio::task::JoinHandle<Result<()>>)> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let base_url = Url::parse(&format!(
+        "http://blokli-stream.invalid:{}",
+        listener.local_addr()?.port()
+    ))?;
+
+    let server = tokio::spawn(async move {
+        let (mut compatibility_conn, _) = listener.accept().await?;
+        compatibility_conn
+            .write_all(format_json_response(&compatibility_response_body()).as_bytes())
+            .await?;
+        compatibility_conn.shutdown().await?;
+
+        let body = format_ticket_params_events(&events);
+        let (mut conn, _) = listener.accept().await?;
+        conn.write_all(format_sse_response(&body).as_bytes()).await?;
+        conn.shutdown().await?;
         Ok(())
     });
 

--- a/client/tests/subscription_tests.rs
+++ b/client/tests/subscription_tests.rs
@@ -5,7 +5,10 @@ use blokli_client::{
     BlokliClient, BlokliClientConfig, BlokliDnsOverride, CLIENT_VERSION, api::BlokliSubscriptionClient,
 };
 use futures::StreamExt;
-use tokio::{io::AsyncWriteExt, net::TcpListener};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
 use url::Url;
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize)]
@@ -167,6 +170,15 @@ async fn subscribe_ticket_params_uses_dns_override() -> Result<()> {
         min_ticket_winning_probability: 0.25,
     };
     let (base_url, server) = spawn_dns_override_streaming_server(vec![expected_ticket_params.clone()]).await?;
+    let expected_host = format!(
+        "{}:{}",
+        base_url
+            .host_str()
+            .ok_or_else(|| anyhow::anyhow!("missing base URL host"))?,
+        base_url
+            .port_or_known_default()
+            .ok_or_else(|| anyhow::anyhow!("missing base URL port"))?,
+    );
     let client = BlokliClient::new(
         base_url,
         BlokliClientConfig {
@@ -194,7 +206,9 @@ async fn subscribe_ticket_params_uses_dns_override() -> Result<()> {
         expected_ticket_params.min_ticket_winning_probability
     );
 
-    server.await??;
+    let request = server.await??;
+    assert!(request.contains(&format!("\r\nhost: {expected_host}\r\n")));
+
     Ok(())
 }
 
@@ -229,7 +243,7 @@ async fn spawn_reconnecting_server(
 
 async fn spawn_dns_override_streaming_server(
     events: Vec<TicketParams>,
-) -> Result<(Url, tokio::task::JoinHandle<Result<()>>)> {
+) -> Result<(Url, tokio::task::JoinHandle<Result<String>>)> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let base_url = Url::parse(&format!(
         "http://blokli-stream.invalid:{}",
@@ -245,12 +259,30 @@ async fn spawn_dns_override_streaming_server(
 
         let body = format_ticket_params_events(&events);
         let (mut conn, _) = listener.accept().await?;
+        let request = read_http_request_head(&mut conn).await?;
         conn.write_all(format_sse_response(&body).as_bytes()).await?;
         conn.shutdown().await?;
-        Ok(())
+        Ok(request)
     });
 
     Ok((base_url, server))
+}
+
+async fn read_http_request_head(conn: &mut tokio::net::TcpStream) -> Result<String> {
+    let mut buf = Vec::new();
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let n = conn.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    Ok(String::from_utf8_lossy(&buf).to_ascii_lowercase())
 }
 
 async fn spawn_delayed_streaming_server(


### PR DESCRIPTION
This allows blokli-client users to skip per request DNS lookups, which could be failing in a VPN use-case.

When used the DNS name should be resolved once upfront before constucting the client.