### PR TITLE
chore(deps): silence cargo-machete false positives for build-only deps

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -65,3 +65,8 @@ parking_lot = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 tokio       = { workspace = true }
+
+# `cynic-codegen` is a build-dependency used only in `build.rs` (GraphQL schema
+# registration). cargo-machete does not scan build scripts, so it reports it as unused.
+[package.metadata.cargo-machete]
+ignored = ["cynic-codegen"]

--- a/db/entity/Cargo.toml
+++ b/db/entity/Cargo.toml
@@ -43,3 +43,15 @@ hopr-types = { workspace = true, features = [
   "internal",
   "primitive",
 ] }
+
+# These are all build-dependencies used only in `build.rs` (SeaORM codegen).
+# cargo-machete does not scan build scripts, so it reports them as unused.
+[package.metadata.cargo-machete]
+ignored = [
+  "anyhow",
+  "blokli-db-migration",
+  "clap",
+  "sea-orm-cli",
+  "sea-orm-migration",
+  "tokio",
+]


### PR DESCRIPTION
cargo-machete does not scan build.rs, so it flagged build-dependencies used solely by build scripts as unused:

- db/entity: anyhow, blokli-db-migration, clap, sea-orm-cli, sea-orm-migration, tokio (used by the SeaORM codegen build script)
- client: cynic-codegen (used by the GraphQL schema-registration build script)

Add `[package.metadata.cargo-machete] ignored` entries (matching the existing convention in api/bloklid/db-core/tests) so `cargo machete` reports a clean, actionable signal instead of 7 false positives.

No dependencies were added or removed; an audit confirmed every direct and workspace dependency is already in use.