### PR TITLE
fix: use repo's devshell in the build-release workflow

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -60,7 +60,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@91ab5099f01685dd0d14f960a5cb1408f076c763 # setup-nix-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -60,7 +60,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@91ab5099f01685dd0d14f960a5cb1408f076c763 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # setup-nix-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -181,7 +181,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@91ab5099f01685dd0d14f960a5cb1408f076c763 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # setup-nix-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -181,7 +181,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@91ab5099f01685dd0d14f960a5cb1408f076c763 # setup-nix-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@91ab5099f01685dd0d14f960a5cb1408f076c763 # setup-nix-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@91ab5099f01685dd0d14f960a5cb1408f076c763 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # setup-nix-v2
     permissions:
       contents: read
     with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/flake.nix
+++ b/flake.nix
@@ -389,6 +389,7 @@
               kubernetes-helm
               cargo-insta
               cargo-machete
+              cargo-release
               cargo-shear
               yq
               uv


### PR DESCRIPTION
Adds `cargo-release` to the devshell to avoid nested `nix` invocation in the `build-library` workflow.
Based on the changes in https://github.com/hoprnet/hopr-workflows/pull/78