### PR TITLE
fix(ci): enforce nix fmt --ci via Format matrix entry

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,9 +83,10 @@ jobs:
   # ── Shared checks (lint, pre-commit, audit) ─────────────────────────────────
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@5477bd53d62ac15c4804b31fbd55966b29a43997 # setup-nix-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@2002c3d074e48378468372a6de710f88377c94e2 # workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      format: true
       lint_command: "nix develop --command just quick"
       audit_command: "nix run -L .#audit"
       deps: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,10 +83,9 @@ jobs:
   # ── Shared checks (lint, pre-commit, audit) ─────────────────────────────────
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      format: true
       lint_command: "nix develop --command just quick"
       audit_command: "nix run -L .#audit"
       deps: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,7 +83,7 @@ jobs:
   # ── Shared checks (lint, pre-commit, audit) ─────────────────────────────────
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@2002c3d074e48378468372a6de710f88377c94e2 # workflow-checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       format: true


### PR DESCRIPTION
## Summary

- Adds \`format: true\` to the \`checks:\` CI job, enabling the new first-class \`Format\` matrix entry from [hopr-workflows#77](https://github.com/hoprnet/hopr-workflows/pull/77) (merged, tagged \`workflow-checks-v2\`)
- The \`Format\` job runs \`nix fmt -- --ci\` (treefmt: \`--no-cache --fail-on-change\`) as the first step so cheap formatting violations surface before heavier checks
- The repo is already clean (\`nix fmt -- --ci\` exits 0 on main)