### PR TITLE
feat(ci): grant id-token permission for crates.io trusted publishing

### DIFF
--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6c5db2cd898f1f2c8fdae39498b6d7b3ee7d0258 # build-library-v3
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -22,6 +22,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.ref_name }}
       version_type: release
@@ -32,7 +33,6 @@ jobs:
       runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      cargo_registry_token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   release:
     name: Close release
     needs:


### PR DESCRIPTION
## Summary

- Add \`id-token: write\` to the \`build-library\` job in \`release-library.yaml\` so the OIDC token exchange in \`hoprnet/hopr-workflows\` can succeed
- Remove \`cargo_registry_token\` secret — no longer needed
- Bump \`build-library\` reference to \`6c5db2c # build-library-v3\`

~~Depends on: hoprnet/hopr-workflows#80~~ (merged)