### PR TITLE
fix: logging format improvements

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -76,7 +76,7 @@ rand = { workspace = true }
 
 # Logging
 tracing            = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json"] }
 
 # CLI
 clap = { workspace = true }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -78,7 +78,7 @@ pub async fn start_server(
     config: ApiConfig,
 ) -> ApiResult<()> {
     // Initialize tracing
-    logging::install_tracing("blokli_api=info,tower_http=debug")
+    logging::setup_tracing_env_like("blokli_api=info,tower_http=debug")
         .map_err(|error| ApiError::ConfigError(format!("Failed to initialize tracing: {error}")))?;
 
     info!("Starting blokli API server on {}", config.bind_address);

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod config;
 pub mod conversions;
 pub mod errors;
+pub mod logging;
 pub mod metrics;
 pub mod mutation;
 pub mod query;
@@ -77,12 +78,8 @@ pub async fn start_server(
     config: ApiConfig,
 ) -> ApiResult<()> {
     // Initialize tracing
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "blokli_api=info,tower_http=debug".into()),
-        )
-        .init();
+    logging::install_tracing("blokli_api=info,tower_http=debug")
+        .map_err(|error| ApiError::ConfigError(format!("Failed to initialize tracing: {error}")))?;
 
     info!("Starting blokli API server on {}", config.bind_address);
     info!("Connecting to database: {}", redact_url(&config.database_url));

--- a/api/src/logging.rs
+++ b/api/src/logging.rs
@@ -1,15 +1,27 @@
-use std::{any::Any, backtrace::Backtrace, io::stdout, panic, sync::Once};
+use std::{
+    any::Any,
+    backtrace::Backtrace,
+    io::stdout,
+    panic,
+    sync::{Once, OnceLock},
+};
 
 use tracing_subscriber::{Layer as _, Registry, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 static PANIC_HOOK_INSTALLED: Once = Once::new();
+static TRACING_INIT: OnceLock<Result<(), String>> = OnceLock::new();
 
 pub fn install_tracing(default_env_filter: &str) -> Result<(), String> {
-    let env_filter = if std::env::var(tracing_subscriber::EnvFilter::DEFAULT_ENV).is_ok() {
-        tracing_subscriber::EnvFilter::from_default_env()
-    } else {
-        tracing_subscriber::EnvFilter::new(default_env_filter)
-    };
+    TRACING_INIT
+        .get_or_init(|| try_install_tracing(default_env_filter))
+        .clone()?;
+    install_panic_hook();
+    Ok(())
+}
+
+fn try_install_tracing(default_env_filter: &str) -> Result<(), String> {
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_env_filter));
 
     let format = tracing_subscriber::fmt::layer()
         .with_level(true)
@@ -28,9 +40,7 @@ pub fn install_tracing(default_env_filter: &str) -> Result<(), String> {
         },
     );
 
-    let _ = subscriber.try_init();
-    install_panic_hook();
-    Ok(())
+    subscriber.try_init().map_err(|error| error.to_string())
 }
 
 fn install_panic_hook() {

--- a/api/src/logging.rs
+++ b/api/src/logging.rs
@@ -1,6 +1,7 @@
 use std::{
     any::Any,
     backtrace::Backtrace,
+    borrow::Cow,
     io::stdout,
     panic,
     sync::{Once, OnceLock},
@@ -11,11 +12,12 @@ use tracing_subscriber::{Layer as _, Registry, layer::SubscriberExt as _, util::
 static PANIC_HOOK_INSTALLED: Once = Once::new();
 static TRACING_INIT: OnceLock<Result<(), String>> = OnceLock::new();
 
-pub fn install_tracing(default_env_filter: &str) -> Result<(), String> {
+pub fn setup_tracing_env_like(default_env_filter: &str) -> anyhow::Result<()> {
     TRACING_INIT
         .get_or_init(|| try_install_tracing(default_env_filter))
-        .clone()?;
-    install_panic_hook();
+        .clone()
+        .map_err(|e| anyhow::anyhow!(e))?;
+    set_panic_hook();
     Ok(())
 }
 
@@ -43,17 +45,17 @@ fn try_install_tracing(default_env_filter: &str) -> Result<(), String> {
     subscriber.try_init().map_err(|error| error.to_string())
 }
 
-fn install_panic_hook() {
+fn set_panic_hook() {
     PANIC_HOOK_INSTALLED.call_once(|| {
         panic::set_hook(Box::new(|info| {
-            let payload = panic_payload_to_string(info.payload());
+            let payload = panic_payload_to_str(info.payload());
             let location = info.location();
             let panic_file = location.map(|value| value.file()).unwrap_or("unknown");
             let panic_line = location.map(|value| value.line()).unwrap_or(0);
             let panic_column = location.map(|value| value.column()).unwrap_or(0);
             let thread = std::thread::current();
             let thread_name = thread.name().unwrap_or("unnamed");
-            let backtrace = Backtrace::force_capture().to_string();
+            let backtrace = Backtrace::capture().to_string();
 
             tracing::error!(
                 panic_payload = %payload,
@@ -69,13 +71,13 @@ fn install_panic_hook() {
     });
 }
 
-fn panic_payload_to_string(payload: &(dyn Any + Send)) -> String {
-    if let Some(payload) = payload.downcast_ref::<&str>() {
-        (*payload).to_string()
+fn panic_payload_to_str(payload: &(dyn Any + Send)) -> Cow<'static, str> {
+    if let Some(payload) = payload.downcast_ref::<&'static str>() {
+        Cow::Borrowed(payload)
     } else if let Some(payload) = payload.downcast_ref::<String>() {
-        payload.clone()
+        Cow::Owned(payload.clone())
     } else {
-        "non-string panic payload".to_string()
+        Cow::Borrowed("non-string panic payload")
     }
 }
 
@@ -84,14 +86,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_panic_payload_to_string_from_str() {
+    fn test_panic_payload_to_str_from_str() {
         let payload: &(dyn Any + Send) = &"boom";
-        assert_eq!(panic_payload_to_string(payload), "boom");
+        assert_eq!(panic_payload_to_str(payload), "boom");
     }
 
     #[test]
-    fn test_panic_payload_to_string_from_string() {
+    fn test_panic_payload_to_str_from_string() {
         let payload: &(dyn Any + Send) = &"boom".to_string();
-        assert_eq!(panic_payload_to_string(payload), "boom");
+        assert_eq!(panic_payload_to_str(payload), "boom");
     }
 }

--- a/api/src/logging.rs
+++ b/api/src/logging.rs
@@ -1,37 +1,14 @@
-use std::{
-    any::Any,
-    backtrace::Backtrace,
-    io::stdout,
-    panic,
-    sync::{Once, OnceLock},
-};
+use std::{any::Any, backtrace::Backtrace, io::stdout, panic, sync::Once};
 
-use tracing_subscriber::{Registry, prelude::*, reload};
+use tracing_subscriber::{Layer as _, Registry, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
-use crate::errors::{BloklidError, Result};
-
-pub(crate) type OtelBoxedLayer = Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync + 'static>;
-
-static OTEL_HANDLE: OnceLock<reload::Handle<Vec<OtelBoxedLayer>, Registry>> = OnceLock::new();
 static PANIC_HOOK_INSTALLED: Once = Once::new();
 
-fn passthrough_layers(layers: Vec<OtelBoxedLayer>) -> Vec<OtelBoxedLayer> {
-    if layers.is_empty() {
-        vec![Box::new(tracing_subscriber::layer::Identity::new())]
-    } else {
-        layers
-    }
-}
-
-pub(crate) fn install_base_subscriber(verbosity: u8) -> Result<()> {
+pub fn install_tracing(default_env_filter: &str) -> Result<(), String> {
     let env_filter = if std::env::var(tracing_subscriber::EnvFilter::DEFAULT_ENV).is_ok() {
         tracing_subscriber::EnvFilter::from_default_env()
     } else {
-        match verbosity {
-            0 => tracing_subscriber::EnvFilter::new("info"),
-            1 => tracing_subscriber::EnvFilter::new("debug"),
-            _ => tracing_subscriber::EnvFilter::new("trace"),
-        }
+        tracing_subscriber::EnvFilter::new(default_env_filter)
     };
 
     let format = tracing_subscriber::fmt::layer()
@@ -40,32 +17,19 @@ pub(crate) fn install_base_subscriber(verbosity: u8) -> Result<()> {
         .with_thread_ids(true)
         .with_thread_names(false)
         .with_writer(stdout);
-    let format = if std::env::var("BLOKLI_LOG_FORMAT")
-        .map(|value| value.eq_ignore_ascii_case("json"))
-        .unwrap_or(false)
-    {
-        format.json().boxed()
-    } else {
-        format.boxed()
-    };
+    let subscriber = Registry::default().with(env_filter).with(
+        if std::env::var("BLOKLI_LOG_FORMAT")
+            .map(|value| value.eq_ignore_ascii_case("json"))
+            .unwrap_or(false)
+        {
+            format.json().boxed()
+        } else {
+            format.boxed()
+        },
+    );
 
-    let (reload_layer, handle) = reload::Layer::<Vec<OtelBoxedLayer>, Registry>::new(passthrough_layers(Vec::new()));
-    let _ = OTEL_HANDLE.set(handle);
-
-    let subscriber = Registry::default().with(reload_layer).with(env_filter).with(format);
-
-    tracing::subscriber::set_global_default(subscriber)
-        .map_err(|error| BloklidError::NonSpecific(error.to_string()))?;
+    let _ = subscriber.try_init();
     install_panic_hook();
-    Ok(())
-}
-
-pub(crate) fn install_otel_layers(layers: Vec<OtelBoxedLayer>) -> Result<()> {
-    OTEL_HANDLE
-        .get()
-        .ok_or_else(|| BloklidError::NonSpecific("base subscriber not initialized".into()))?
-        .reload(passthrough_layers(layers))
-        .map_err(|error| BloklidError::NonSpecific(error.to_string()))?;
     Ok(())
 }
 
@@ -108,13 +72,6 @@ fn panic_payload_to_string(payload: &(dyn Any + Send)) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_install_otel_layers_fails_before_base_subscriber_is_initialized() {
-        let error = install_otel_layers(Vec::new()).expect_err("otel layers should require a base subscriber");
-
-        assert!(error.to_string().contains("base subscriber not initialized"));
-    }
 
     #[test]
     fn test_panic_payload_to_string_from_str() {

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
-use blokli_api::schema::export_schema_sdl;
+use blokli_api::{logging, schema::export_schema_sdl};
 use blokli_chain_api::{
     rpc_adapter::RpcAdapter,
     transaction_executor::{RawTransactionExecutor, RawTransactionExecutorConfig},
@@ -53,6 +53,7 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    logging::install_tracing("blokli_api=info,tower_http=debug")?;
     let args = Args::parse();
 
     // Handle subcommands

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -53,7 +53,7 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    logging::install_tracing("blokli_api=info,tower_http=debug")?;
+    logging::setup_tracing_env_like("blokli_api=info,tower_http=debug")?;
     let args = Args::parse();
 
     // Handle subcommands

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -472,7 +472,7 @@ impl SubscriptionRoot {
                     }
                 }
                 Err(e) => {
-                    error!("Failed to query historical channels: {:?}", e);
+                    error!(error = ?e, "failed to query historical channels");
                     return; // Terminate subscription on error
                 }
             }
@@ -612,7 +612,7 @@ impl SubscriptionRoot {
                     }
                 }
                 Err(e) => {
-                    error!("Failed to query historical channels: {:?}", e);
+                    error!(error = ?e, "failed to query historical channels");
                     return; // Terminate subscription on error
                 }
             }
@@ -722,7 +722,7 @@ impl SubscriptionRoot {
                     }
                 }
                 Err(e) => {
-                    error!("Failed to fetch initial accounts: {:?}", e);
+                    error!(error = ?e, "failed to fetch initial accounts");
                 }
             }
 
@@ -807,7 +807,7 @@ impl SubscriptionRoot {
                     warn!("Ticket parameters not initialized when subscribing to ticketParametersUpdated");
                 }
                 Err(e) => {
-                    error!("Failed to fetch ticket parameters: {:?}", e);
+                    error!(error = ?e, "failed to fetch ticket parameters");
                 }
             }
 
@@ -917,7 +917,7 @@ impl SubscriptionRoot {
                     warn!("chain_info not initialized when subscribing to keyBindingFeeUpdated");
                 }
                 Err(e) => {
-                    error!("Failed to fetch chain_info for keyBindingFeeUpdated: {:?}", e);
+                    error!(error = ?e, "failed to fetch chain_info for keyBindingFeeUpdated");
                 }
             }
 

--- a/api/tests/allowance_api_integration_test.rs
+++ b/api/tests/allowance_api_integration_test.rs
@@ -204,7 +204,7 @@ async fn test_allowance_api_integration() -> anyhow::Result<()> {
         // Verify allowance
         assert!(allowance.is_some(), "Allowance should be returned");
         let allowance_str = allowance.unwrap();
-        tracing::info!(allowance = %allowance_str, "retrieved HOPR allowance");
+        tracing::info!(allowance = %allowance_str, unit = "HOPR", "retrieved allowance");
 
         let parsed_allowance =
             HoprBalance::from_str(&allowance_str).expect("Allowance string should be valid HoprBalance format");

--- a/api/tests/allowance_api_integration_test.rs
+++ b/api/tests/allowance_api_integration_test.rs
@@ -204,7 +204,7 @@ async fn test_allowance_api_integration() -> anyhow::Result<()> {
         // Verify allowance
         assert!(allowance.is_some(), "Allowance should be returned");
         let allowance_str = allowance.unwrap();
-        tracing::info!("HOPR allowance: {allowance_str}");
+        tracing::info!(allowance = %allowance_str, "retrieved HOPR allowance");
 
         let parsed_allowance =
             HoprBalance::from_str(&allowance_str).expect("Allowance string should be valid HoprBalance format");

--- a/api/tests/balance_api_integration_test.rs
+++ b/api/tests/balance_api_integration_test.rs
@@ -284,7 +284,7 @@ async fn test_balance_api_integration() -> anyhow::Result<()> {
         // Verify balance by parsing into HoprBalance type
         assert!(balance.is_some(), "Balance should be returned");
         let balance_str = balance.unwrap();
-        tracing::info!("HOPR balance: {balance_str}");
+        tracing::info!(balance = %balance_str, "retrieved HOPR balance");
 
         let parsed_balance =
             HoprBalance::from_str(&balance_str).expect("Balance string should be valid HoprBalance format");
@@ -311,7 +311,7 @@ async fn test_balance_api_integration() -> anyhow::Result<()> {
         // Verify balance exists and is non-zero
         assert!(balance.is_some(), "Balance should be returned");
         let balance_str = balance.unwrap();
-        tracing::info!("Native balance: {balance_str}");
+        tracing::info!(balance = %balance_str, "retrieved native balance");
         let parsed_balance =
             XDaiBalance::from_str(&balance_str).expect("Balance string should be valid XDaiBalance format");
 

--- a/api/tests/balance_api_integration_test.rs
+++ b/api/tests/balance_api_integration_test.rs
@@ -284,7 +284,7 @@ async fn test_balance_api_integration() -> anyhow::Result<()> {
         // Verify balance by parsing into HoprBalance type
         assert!(balance.is_some(), "Balance should be returned");
         let balance_str = balance.unwrap();
-        tracing::info!(balance = %balance_str, "retrieved HOPR balance");
+        tracing::info!(balance = %balance_str, unit = "HOPR", "retrieved balance");
 
         let parsed_balance =
             HoprBalance::from_str(&balance_str).expect("Balance string should be valid HoprBalance format");

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -173,11 +173,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 fn install_tracing() -> Result<(), Box<dyn Error>> {
-    let env_filter = if std::env::var(tracing_subscriber::EnvFilter::DEFAULT_ENV).is_ok() {
-        tracing_subscriber::EnvFilter::from_default_env()
-    } else {
-        tracing_subscriber::EnvFilter::new("info")
-    };
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
 
     let format = tracing_subscriber::fmt::layer()
         .with_writer(stdout)
@@ -196,7 +193,7 @@ fn install_tracing() -> Result<(), Box<dyn Error>> {
         },
     );
 
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    tracing::subscriber::set_global_default(subscriber)?;
     install_panic_hook();
     Ok(())
 }

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -1,5 +1,6 @@
 use std::{
-    any::Any, backtrace::Backtrace, error::Error, fs, io::stdout, panic, path::PathBuf, str::FromStr, sync::Once,
+    any::Any, backtrace::Backtrace, borrow::Cow, error::Error, fs, io::stdout, panic, path::PathBuf, str::FromStr,
+    sync::Once,
 };
 
 use blokli_chain_types::ContractAddresses as BlokliContractAddresses;
@@ -194,21 +195,21 @@ fn install_tracing() -> Result<(), Box<dyn Error>> {
     );
 
     tracing::subscriber::set_global_default(subscriber)?;
-    install_panic_hook();
+    set_panic_hook();
     Ok(())
 }
 
-fn install_panic_hook() {
+fn set_panic_hook() {
     PANIC_HOOK_INSTALLED.call_once(|| {
         panic::set_hook(Box::new(|info| {
-            let payload = panic_payload_to_string(info.payload());
+            let payload = panic_payload_to_str(info.payload());
             let location = info.location();
             let panic_file = location.map(|value| value.file()).unwrap_or("unknown");
             let panic_line = location.map(|value| value.line()).unwrap_or(0);
             let panic_column = location.map(|value| value.column()).unwrap_or(0);
             let thread = std::thread::current();
             let thread_name = thread.name().unwrap_or("unnamed");
-            let backtrace = Backtrace::force_capture().to_string();
+            let backtrace = Backtrace::capture().to_string();
 
             tracing::error!(
                 panic_payload = %payload,
@@ -224,13 +225,13 @@ fn install_panic_hook() {
     });
 }
 
-fn panic_payload_to_string(payload: &(dyn Any + Send)) -> String {
-    if let Some(payload) = payload.downcast_ref::<&str>() {
-        (*payload).to_string()
+fn panic_payload_to_str(payload: &(dyn Any + Send)) -> Cow<'static, str> {
+    if let Some(payload) = payload.downcast_ref::<&'static str>() {
+        Cow::Borrowed(payload)
     } else if let Some(payload) = payload.downcast_ref::<String>() {
-        payload.clone()
+        Cow::Owned(payload.clone())
     } else {
-        "non-string panic payload".to_string()
+        Cow::Borrowed("non-string panic payload")
     }
 }
 
@@ -242,18 +243,18 @@ mod tests {
     use clap::Parser;
     use hopr_types::{internal::prelude::WinningProbability, primitive::traits::IntoEndian};
 
-    use super::{Args, panic_payload_to_string};
+    use super::{Args, panic_payload_to_str};
 
     #[test]
-    fn test_panic_payload_to_string_from_str() {
+    fn test_panic_payload_to_str_from_str() {
         let payload: &(dyn Any + Send) = &"boom";
-        assert_eq!(panic_payload_to_string(payload), "boom");
+        assert_eq!(panic_payload_to_str(payload), "boom");
     }
 
     #[test]
-    fn test_panic_payload_to_string_from_string() {
+    fn test_panic_payload_to_str_from_string() {
         let payload: &(dyn Any + Send) = &"boom".to_string();
-        assert_eq!(panic_payload_to_string(payload), "boom");
+        assert_eq!(panic_payload_to_str(payload), "boom");
     }
 
     #[test]

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -1,4 +1,6 @@
-use std::{error::Error, fs, path::PathBuf, str::FromStr};
+use std::{
+    any::Any, backtrace::Backtrace, error::Error, fs, io::stdout, panic, path::PathBuf, str::FromStr, sync::Once,
+};
 
 use blokli_chain_types::ContractAddresses as BlokliContractAddresses;
 use clap::Parser;
@@ -20,9 +22,11 @@ use hopr_types::{
     primitive::{prelude::HoprBalance, primitives::Address, traits::IntoEndian},
 };
 use serde::Serialize;
+use tracing_subscriber::{Layer as _, prelude::*};
 use url::Url;
 
 const DEFAULT_ANVIL_PRIVATE_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+static PANIC_HOOK_INSTALLED: Once = Once::new();
 
 #[derive(Debug, Parser)]
 #[command(
@@ -65,11 +69,7 @@ struct ContractsOutput {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stdout)
-        .with_target(true)
-        .with_level(true)
-        .init();
+    install_tracing()?;
 
     let args = Args::parse();
 
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?
         .watch()
         .await?;
-    tracing::info!("Minter role granted to Anvil account {signer_address}");
+    tracing::info!(%signer_address, "granted minter role to Anvil account");
 
     // Mint 10M tokens to Anvil account 0
     instances
@@ -124,7 +124,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?
         .watch()
         .await?;
-    tracing::info!("10M tokens minted to Anvil account {signer_address}");
+    tracing::info!(%signer_address, "minted tokens to Anvil account");
 
     // Update the stake factory to use correct addresses
     let network = instances.stake_factory.defaultHoprNetwork().call().await?;
@@ -172,13 +172,92 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn install_tracing() -> Result<(), Box<dyn Error>> {
+    let env_filter = if std::env::var(tracing_subscriber::EnvFilter::DEFAULT_ENV).is_ok() {
+        tracing_subscriber::EnvFilter::from_default_env()
+    } else {
+        tracing_subscriber::EnvFilter::new("info")
+    };
+
+    let format = tracing_subscriber::fmt::layer()
+        .with_writer(stdout)
+        .with_target(true)
+        .with_level(true)
+        .with_thread_ids(true)
+        .with_thread_names(false);
+    let subscriber = tracing_subscriber::registry().with(env_filter).with(
+        if std::env::var("BLOKLI_LOG_FORMAT")
+            .map(|value| value.eq_ignore_ascii_case("json"))
+            .unwrap_or(false)
+        {
+            format.json().boxed()
+        } else {
+            format.boxed()
+        },
+    );
+
+    let _ = tracing::subscriber::set_global_default(subscriber);
+    install_panic_hook();
+    Ok(())
+}
+
+fn install_panic_hook() {
+    PANIC_HOOK_INSTALLED.call_once(|| {
+        panic::set_hook(Box::new(|info| {
+            let payload = panic_payload_to_string(info.payload());
+            let location = info.location();
+            let panic_file = location.map(|value| value.file()).unwrap_or("unknown");
+            let panic_line = location.map(|value| value.line()).unwrap_or(0);
+            let panic_column = location.map(|value| value.column()).unwrap_or(0);
+            let thread = std::thread::current();
+            let thread_name = thread.name().unwrap_or("unnamed");
+            let backtrace = Backtrace::force_capture().to_string();
+
+            tracing::error!(
+                panic_payload = %payload,
+                panic_file,
+                panic_line,
+                panic_column,
+                thread_name,
+                thread_id = ?thread.id(),
+                backtrace = %backtrace,
+                "process panic"
+            );
+        }));
+    });
+}
+
+fn panic_payload_to_string(payload: &(dyn Any + Send)) -> String {
+    if let Some(payload) = payload.downcast_ref::<&str>() {
+        (*payload).to_string()
+    } else if let Some(payload) = payload.downcast_ref::<String>() {
+        payload.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+
     use anyhow::Result;
     use clap::Parser;
     use hopr_types::{internal::prelude::WinningProbability, primitive::traits::IntoEndian};
 
-    use super::Args;
+    use super::{Args, panic_payload_to_string};
+
+    #[test]
+    fn test_panic_payload_to_string_from_str() {
+        let payload: &(dyn Any + Send) = &"boom";
+        assert_eq!(panic_payload_to_string(payload), "boom");
+    }
+
+    #[test]
+    fn test_panic_payload_to_string_from_string() {
+        let payload: &(dyn Any + Send) = &"boom".to_string();
+        assert_eq!(panic_payload_to_string(payload), "boom");
+    }
 
     #[test]
     fn ticket_price_arg_default_parses() -> Result<()> {

--- a/bloklid/src/main.rs
+++ b/bloklid/src/main.rs
@@ -46,7 +46,8 @@ async fn main() -> ExitCode {
                 tracing::info!(%error, "displaying command output");
                 return ExitCode::SUCCESS;
             }
-            tracing::error!(bin_name = BIN_NAME, %error, "error parsing arguments");
+            let raw_args: Vec<String> = std::env::args().skip(1).collect();
+            tracing::error!(bin_name = BIN_NAME, args = ?raw_args, %error, "error parsing arguments");
             return ExitCode::FAILURE;
         }
     };

--- a/bloklid/src/main.rs
+++ b/bloklid/src/main.rs
@@ -43,10 +43,10 @@ async fn main() -> ExitCode {
                 error.kind(),
                 clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
             ) {
-                tracing::info!("{error}");
+                tracing::info!(%error, "displaying command output");
                 return ExitCode::SUCCESS;
             }
-            tracing::error!(%error, "error parsing '{BIN_NAME}' arguments");
+            tracing::error!(bin_name = BIN_NAME, %error, "error parsing arguments");
             return ExitCode::FAILURE;
         }
     };
@@ -55,7 +55,7 @@ async fn main() -> ExitCode {
         let config = match args.load_config(true) {
             Ok(config) => config,
             Err(error) => {
-                tracing::error!(%error, "error loading '{BIN_NAME}' config");
+                tracing::error!(bin_name = BIN_NAME, %error, "error loading config");
                 return ExitCode::FAILURE;
             }
         };
@@ -63,7 +63,7 @@ async fn main() -> ExitCode {
         let telemetry_handles = match telemetry::init(args.verbose, &config.telemetry) {
             Ok(handles) => handles,
             Err(error) => {
-                tracing::error!(%error, "error initializing '{BIN_NAME}' telemetry");
+                tracing::error!(bin_name = BIN_NAME, %error, "error initializing telemetry");
                 return ExitCode::FAILURE;
             }
         };
@@ -72,11 +72,11 @@ async fn main() -> ExitCode {
         drop(telemetry_handles);
 
         if let Err(error) = run_result {
-            tracing::error!(%error, "error while running '{BIN_NAME}'");
+            tracing::error!(bin_name = BIN_NAME, %error, "error while running process");
             return ExitCode::FAILURE;
         }
     } else if let Err(error) = run(args, None).await {
-        tracing::error!(%error, "error while running '{BIN_NAME}'");
+        tracing::error!(bin_name = BIN_NAME, %error, "error while running process");
         return ExitCode::FAILURE;
     }
     ExitCode::SUCCESS
@@ -87,7 +87,7 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
     if let Some(command) = args.command {
         match command {
             Command::GenerateConfig { output } => {
-                tracing::info!("Generating configuration template at: {}", output.display());
+                tracing::info!(path = %output.display(), "generating configuration template");
 
                 // Generate the template content
                 let template = generate_config_template();
@@ -103,7 +103,7 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
                 std::fs::write(&output, template)
                     .map_err(|e| BloklidError::NonSpecific(format!("Failed to write configuration template: {}", e)))?;
 
-                tracing::info!("Configuration template successfully written to: {}", output.display());
+                tracing::info!(path = %output.display(), "configuration template written");
                 return Ok(());
             }
         }
@@ -127,7 +127,7 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
         let cfg = config
             .read()
             .map_err(|_| BloklidError::NonSpecific("failed to lock config for logging".into()))?;
-        tracing::info!("{}", cfg.display_redacted());
+        tracing::info!(config = %cfg.display_redacted(), "loaded redacted configuration");
     }
 
     // Initialize components
@@ -390,7 +390,7 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
 
     // Abort all chain processes
     for (process_type, handle) in process_handles {
-        tracing::info!("Stopping {:?} process", process_type);
+        tracing::info!(?process_type, "stopping process");
         handle.abort();
     }
     tracing::info!("All BlokliChain processes stopped");

--- a/bloklid/src/telemetry_common.rs
+++ b/bloklid/src/telemetry_common.rs
@@ -1,6 +1,7 @@
 use std::{
     any::Any,
     backtrace::Backtrace,
+    borrow::Cow,
     io::stdout,
     panic,
     sync::{Once, OnceLock},
@@ -56,7 +57,7 @@ pub(crate) fn install_base_subscriber(verbosity: u8) -> Result<()> {
 
     tracing::subscriber::set_global_default(subscriber)
         .map_err(|error| BloklidError::NonSpecific(error.to_string()))?;
-    install_panic_hook();
+    set_panic_hook();
     Ok(())
 }
 
@@ -69,17 +70,17 @@ pub(crate) fn install_otel_layers(layers: Vec<OtelBoxedLayer>) -> Result<()> {
     Ok(())
 }
 
-fn install_panic_hook() {
+fn set_panic_hook() {
     PANIC_HOOK_INSTALLED.call_once(|| {
         panic::set_hook(Box::new(|info| {
-            let payload = panic_payload_to_string(info.payload());
+            let payload = panic_payload_to_str(info.payload());
             let location = info.location();
             let panic_file = location.map(|value| value.file()).unwrap_or("unknown");
             let panic_line = location.map(|value| value.line()).unwrap_or(0);
             let panic_column = location.map(|value| value.column()).unwrap_or(0);
             let thread = std::thread::current();
             let thread_name = thread.name().unwrap_or("unnamed");
-            let backtrace = Backtrace::force_capture().to_string();
+            let backtrace = Backtrace::capture().to_string();
 
             tracing::error!(
                 panic_payload = %payload,
@@ -95,13 +96,13 @@ fn install_panic_hook() {
     });
 }
 
-fn panic_payload_to_string(payload: &(dyn Any + Send)) -> String {
-    if let Some(payload) = payload.downcast_ref::<&str>() {
-        (*payload).to_string()
+fn panic_payload_to_str(payload: &(dyn Any + Send)) -> Cow<'static, str> {
+    if let Some(payload) = payload.downcast_ref::<&'static str>() {
+        Cow::Borrowed(payload)
     } else if let Some(payload) = payload.downcast_ref::<String>() {
-        payload.clone()
+        Cow::Owned(payload.clone())
     } else {
-        "non-string panic payload".to_string()
+        Cow::Borrowed("non-string panic payload")
     }
 }
 
@@ -117,14 +118,14 @@ mod tests {
     }
 
     #[test]
-    fn test_panic_payload_to_string_from_str() {
+    fn test_panic_payload_to_str_from_str() {
         let payload: &(dyn Any + Send) = &"boom";
-        assert_eq!(panic_payload_to_string(payload), "boom");
+        assert_eq!(panic_payload_to_str(payload), "boom");
     }
 
     #[test]
-    fn test_panic_payload_to_string_from_string() {
+    fn test_panic_payload_to_str_from_string() {
         let payload: &(dyn Any + Send) = &"boom".to_string();
-        assert_eq!(panic_payload_to_string(payload), "boom");
+        assert_eq!(panic_payload_to_str(payload), "boom");
     }
 }

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -229,7 +229,8 @@ impl<T: BlokliDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static>
                 ))
             })?;
 
-        info!("RPC debug tracing support verified (traced tx {tx_hash:#x})");
+        let traced_tx_hash = format!("{tx_hash:#x}");
+        info!(tx_hash = %traced_tx_hash, "RPC debug tracing support verified");
         Ok(())
     }
 

--- a/chain/api/src/revert_decoder.rs
+++ b/chain/api/src/revert_decoder.rs
@@ -56,7 +56,7 @@ fn find_deepest_revert(frame: &serde_json::Value, depth: usize, best: &mut Optio
     let output_bytes = match hex_decode(output_hex) {
         Some(bytes) => bytes,
         None => {
-            debug!("Failed to decode hex output from trace frame at depth {depth}: {output_hex}");
+            debug!(depth, output_hex, "failed to decode hex output from trace frame");
             return;
         }
     };

--- a/chain/api/src/rpc_adapter.rs
+++ b/chain/api/src/rpc_adapter.rs
@@ -43,7 +43,7 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
     /// Converts the raw transaction bytes to alloy Bytes format and submits to the RPC provider.
     /// Returns the transaction hash immediately without waiting for confirmation.
     async fn send_raw_transaction(&self, raw_tx: Vec<u8>) -> Result<Hash, String> {
-        debug!(raw_tx_len = raw_tx.len(), "sending raw transaction");
+        debug!(length = raw_tx.len(), "sending raw transaction");
 
         // Convert Vec<u8> to alloy Bytes
         let bytes = Bytes::from(raw_tx);

--- a/chain/api/src/rpc_adapter.rs
+++ b/chain/api/src/rpc_adapter.rs
@@ -43,7 +43,7 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
     /// Converts the raw transaction bytes to alloy Bytes format and submits to the RPC provider.
     /// Returns the transaction hash immediately without waiting for confirmation.
     async fn send_raw_transaction(&self, raw_tx: Vec<u8>) -> Result<Hash, String> {
-        debug!("Sending raw transaction ({} bytes)", raw_tx.len());
+        debug!(raw_tx_len = raw_tx.len(), "sending raw transaction");
 
         // Convert Vec<u8> to alloy Bytes
         let bytes = Bytes::from(raw_tx);
@@ -52,14 +52,14 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
         match self.rpc.provider.send_raw_transaction(&bytes).await {
             Ok(pending_tx) => {
                 let tx_hash = pending_tx.tx_hash();
-                debug!("Transaction submitted with hash: {:?}", tx_hash);
+                debug!(?tx_hash, "transaction submitted");
 
                 // Convert alloy B256 to Hash
                 let hash = Hash::from(tx_hash.0);
                 Ok(hash)
             }
             Err(e) => {
-                error!("Failed to send raw transaction: {}", e);
+                error!(error = %e, "failed to send raw transaction");
                 Err(format!("RPC error: {}", e))
             }
         }
@@ -76,9 +76,8 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
         timeout: Option<Duration>,
     ) -> Result<Hash, String> {
         debug!(
-            "Sending raw transaction ({} bytes) and waiting for {} confirmations",
-            raw_tx.len(),
-            confirmations
+            raw_tx_len = raw_tx.len(),
+            confirmations, "sending raw transaction and waiting for confirmations"
         );
 
         // Convert Vec<u8> to alloy Bytes
@@ -88,7 +87,7 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
         match self.rpc.provider.send_raw_transaction(&bytes).await {
             Ok(pending_tx) => {
                 let tx_hash = *pending_tx.tx_hash();
-                debug!("Transaction submitted with hash: {:?}", tx_hash);
+                debug!(?tx_hash, "transaction submitted");
 
                 // Use configured timeout or default to 60 seconds
                 let timeout_duration = timeout.unwrap_or(Duration::from_secs(60));
@@ -98,29 +97,29 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
 
                 match tokio::time::timeout(timeout_duration, receipt_future).await {
                     Ok(Ok(receipt)) => {
-                        debug!("Transaction {:?} confirmed", tx_hash);
+                        debug!(?tx_hash, "Transaction confirmed");
 
                         // Check transaction status
                         if receipt.status() {
                             let hash = Hash::from(receipt.transaction_hash.0);
                             Ok(hash)
                         } else {
-                            error!("Transaction {:?} reverted", tx_hash);
+                            error!(?tx_hash, "Transaction reverted");
                             Err(format!("Transaction reverted: {:?}", tx_hash))
                         }
                     }
                     Ok(Err(e)) => {
-                        error!("Error waiting for transaction confirmation: {}", e);
+                        error!(error = %e, "error waiting for transaction confirmation");
                         Err(format!("Confirmation error: {}", e))
                     }
                     Err(_) => {
-                        error!("Transaction {:?} timed out after {:?}", tx_hash, timeout_duration);
+                        error!(?timeout_duration, ?tx_hash, "Transaction timed out");
                         Err(format!("Transaction timeout: timed out after {:?}", timeout_duration))
                     }
                 }
             }
             Err(e) => {
-                error!("Failed to send raw transaction: {}", e);
+                error!(error = %e, "failed to send raw transaction");
                 Err(format!("RPC error: {}", e))
             }
         }
@@ -136,7 +135,7 @@ impl<R: HttpRequestor + 'static + Clone> ReceiptProvider for RpcAdapter<R> {
     /// - Some(false) if the transaction is confirmed but reverted
     /// - None if the transaction is still pending or not found
     async fn get_transaction_status(&self, tx_hash: Hash) -> Result<Option<bool>, String> {
-        debug!("Checking transaction status for hash: {:?}", tx_hash);
+        debug!(?tx_hash, "checking transaction status");
 
         // Convert Hash to alloy B256
         let b256_hash = B256::from_slice(tx_hash.as_ref());
@@ -146,27 +145,23 @@ impl<R: HttpRequestor + 'static + Clone> ReceiptProvider for RpcAdapter<R> {
             Ok(Some(receipt)) => {
                 // Transaction found - check status
                 let success = receipt.status();
-                debug!(
-                    "Transaction {:?} status: {}",
-                    tx_hash,
-                    if success { "confirmed" } else { "reverted" }
-                );
+                debug!(?tx_hash, success, "transaction status retrieved");
                 Ok(Some(success))
             }
             Ok(None) => {
                 // Transaction not found (still pending)
-                debug!("Transaction {:?} still pending", tx_hash);
+                debug!(?tx_hash, "transaction still pending");
                 Ok(None)
             }
             Err(e) => {
-                error!("Error getting transaction receipt for {:?}: {}", tx_hash, e);
+                error!(?tx_hash, error = %e, "error getting transaction receipt");
                 Err(format!("Receipt error: {}", e))
             }
         }
     }
 
     async fn get_transaction_receipt_logs(&self, tx_hash: Hash) -> Result<Option<Vec<ReceiptLog>>, String> {
-        debug!("Fetching receipt logs for hash: {:?}", tx_hash);
+        debug!(?tx_hash, "fetching receipt logs");
 
         let b256_hash = B256::from_slice(tx_hash.as_ref());
 
@@ -185,11 +180,11 @@ impl<R: HttpRequestor + 'static + Clone> ReceiptProvider for RpcAdapter<R> {
                 Ok(Some(logs))
             }
             Ok(None) => {
-                debug!("No receipt found for {:?} (transaction still pending)", tx_hash);
+                debug!(?tx_hash, "no receipt found, transaction still pending");
                 Ok(None)
             }
             Err(e) => {
-                error!("Error getting receipt logs for {:?}: {}", tx_hash, e);
+                error!(?tx_hash, error = %e, "error getting receipt logs");
                 Err(format!("Receipt error: {}", e))
             }
         }
@@ -216,7 +211,8 @@ impl<R: HttpRequestor + 'static + Clone> ReceiptProvider for RpcAdapter<R> {
             Err(e) => {
                 // RPC supports tracing (verified at startup) but this specific
                 // call failed — log and return None rather than blocking confirmation.
-                warn!("debug_traceTransaction failed for {b256_hash:#x}: {e}");
+                let tx_hash = format!("{b256_hash:#x}");
+                warn!(tx_hash = %tx_hash, error = %e, "debug_traceTransaction failed");
                 Ok(None)
             }
         }

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -483,10 +483,10 @@ where
 
             match self.download_snapshot().await {
                 Ok(snapshot_info) => {
-                    info!("Logs snapshot downloaded successfully: {:?}", snapshot_info);
+                    info!(snapshot_info = ?snapshot_info, "logs snapshot downloaded successfully");
                 }
                 Err(e) => {
-                    error!("Failed to download logs snapshot: {}. Continuing with regular sync.", e);
+                    error!(error = %e, "failed to download logs snapshot, continuing with regular sync");
                 }
             }
         }
@@ -499,13 +499,10 @@ where
                     let seconds = period.as_secs();
                     match self.db.set_channel_closure_grace_period(None, seconds).await {
                         Ok(_) => {
-                            info!("Channel closure grace period initialized: {} seconds", seconds);
+                            info!(seconds, "channel closure grace period initialized");
                         }
                         Err(e) => {
-                            warn!(
-                                "Failed to store channel closure grace period in database: {}. Continuing startup.",
-                                e
-                            );
+                            warn!(error = %e, "failed to store channel closure grace period, continuing startup");
                         }
                     }
                 }

--- a/chain/indexer/src/snapshot/mod.rs
+++ b/chain/indexer/src/snapshot/mod.rs
@@ -131,7 +131,7 @@ impl SnapshotWorkflow {
 
         // Extract snapshot
         let extracted_files = self.extractor.extract_snapshot(&archive_path, &temp_dir).await?;
-        debug!("Extracted snapshot files: {:?}", extracted_files);
+        debug!(extracted_files = ?extracted_files, "extracted snapshot files");
 
         // Validate extracted SQL dump
         let sql_path = temp_dir.join("hopr_logs.sql");
@@ -145,7 +145,7 @@ impl SnapshotWorkflow {
         // Cleanup temporary directory if we created it manually
         if use_temp_subdir {
             if let Err(e) = fs::remove_dir_all(&temp_dir) {
-                error!("Failed to cleanup temp directory: {}", e);
+                error!(error = %e, "failed to clean up temp directory");
             }
         }
         // tempfile cleanup is automatic via Drop

--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -649,6 +649,10 @@ impl SnapshotRequestor {
         self.next_id.store(1, Ordering::Relaxed);
     }
 
+    fn snapshot_error(action: &str, file: &str, error: impl std::error::Error) -> Error {
+        Error::other(format!("{action} '{file}': {error}"))
+    }
+
     /// Clears all entries and loads them from the snapshot file.
     /// If `fail_on_miss` is set and the data is successfully loaded, all later
     /// requests that miss the loaded snapshot will result in HTTP error 404.
@@ -657,8 +661,10 @@ impl SnapshotRequestor {
             return Ok(());
         }
 
-        let loaded = serde_yaml::from_reader::<_, Vec<RequestorResponseSnapshot>>(File::open(&self.file)?)
-            .map_err(Error::other)?;
+        let file = File::open(&self.file)
+            .map_err(|error| Self::snapshot_error("failed to open snapshot file", &self.file, error))?;
+        let loaded = serde_yaml::from_reader::<_, Vec<RequestorResponseSnapshot>>(file)
+            .map_err(|error| Self::snapshot_error("failed to parse snapshot file", &self.file, error))?;
 
         self.clear();
 
@@ -675,7 +681,7 @@ impl SnapshotRequestor {
             self.fail_on_miss = fail_on_miss;
         }
 
-        tracing::debug!("snapshot with {loaded_len} entries has been loaded from {}", &self.file);
+        tracing::debug!(loaded_len, file = %self.file, "snapshot loaded from file");
         Ok(())
     }
 
@@ -717,13 +723,18 @@ impl SnapshotRequestor {
         let mut values: Vec<RequestorResponseSnapshot> = self.entries.iter().map(|(_, r)| r).collect();
         values.sort_unstable_by_key(|a| a.id);
 
-        let mut writer = BufWriter::new(File::create(&self.file)?);
+        let file = File::create(&self.file)
+            .map_err(|error| Self::snapshot_error("failed to create snapshot file", &self.file, error))?;
+        let mut writer = BufWriter::new(file);
 
-        serde_yaml::to_writer(&mut writer, &values).map_err(Error::other)?;
+        serde_yaml::to_writer(&mut writer, &values)
+            .map_err(|error| Self::snapshot_error("failed to write snapshot file", &self.file, error))?;
 
-        writer.flush()?;
+        writer
+            .flush()
+            .map_err(|error| Self::snapshot_error("failed to flush snapshot file", &self.file, error))?;
 
-        tracing::debug!("snapshot with {} entries saved to file {}", values.len(), self.file);
+        tracing::debug!(entries = values.len(), file = %self.file, "snapshot saved to file");
         Ok(())
     }
 }
@@ -731,7 +742,7 @@ impl SnapshotRequestor {
 impl Drop for SnapshotRequestor {
     fn drop(&mut self) {
         if let Err(e) = self.save() {
-            tracing::error!("failed to save snapshot: {e}");
+            tracing::error!(error = %e, "failed to save snapshot");
         }
     }
 }
@@ -803,7 +814,7 @@ where
                 .entry(request_string.clone())
                 .or_try_insert_with(async {
                     if snapshot_requestor.fail_on_miss {
-                        tracing::error!("Snapshot entry missing in {}", &snapshot_requestor.file);
+                        tracing::error!(file = %snapshot_requestor.file, "snapshot entry missing");
                         return Err(TransportErrorKind::http_error(
                             http::StatusCode::NOT_FOUND.into(),
                             "".into(),
@@ -847,7 +858,7 @@ where
 
                     let id = snapshot_requestor.next_id.fetch_add(1, Ordering::SeqCst);
                     inserted.store(true, Ordering::Relaxed);
-                    tracing::debug!("saved new snapshot entry #{id}");
+                    tracing::debug!(id, "saved new snapshot entry");
 
                     Ok(RequestorResponseSnapshot {
                         id,
@@ -899,7 +910,7 @@ pub fn create_rpc_client_to_anvil(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{fs, time::Duration};
 
     use hopr_bindings::exports::alloy::{
         primitives::U64,
@@ -908,8 +919,9 @@ mod tests {
         transports::{http::ReqwestTransport, layers::RetryBackoffLayer},
     };
     use serde_json::json;
+    use tempfile::{NamedTempFile, tempdir};
 
-    use crate::client::{DefaultRetryPolicy, ZeroRetryPolicy};
+    use crate::client::{DefaultRetryPolicy, SnapshotRequestor, ZeroRetryPolicy};
 
     #[tokio::test]
     async fn test_client_should_fail_on_malformed_response() {
@@ -1265,5 +1277,36 @@ mod tests {
         //     client.requests_enqueued.load(Ordering::SeqCst),
         //     "retry queue should be zero when policy says no more retries"
         // );
+    }
+
+    #[tokio::test]
+    async fn snapshot_try_load_error_includes_snapshot_path() {
+        let snapshot_file = NamedTempFile::new().expect("temp file should be created");
+        fs::write(snapshot_file.path(), "not: [valid: yaml").expect("invalid snapshot yaml should be written");
+
+        let path = snapshot_file.path().display().to_string();
+        let mut requestor = SnapshotRequestor::new(&path);
+
+        let error = requestor
+            .try_load(false)
+            .await
+            .expect_err("malformed yaml should fail to load");
+
+        let error_text = error.to_string();
+        assert!(error_text.contains("failed to parse snapshot file"));
+        assert!(error_text.contains(&path));
+    }
+
+    #[test]
+    fn snapshot_save_error_includes_snapshot_path() {
+        let snapshot_dir = tempdir().expect("temp dir should be created");
+        let path = snapshot_dir.path().display().to_string();
+        let requestor = SnapshotRequestor::new(&path);
+
+        let error = requestor.save().expect_err("saving to a directory path should fail");
+
+        let error_text = error.to_string();
+        assert!(error_text.contains("failed to create snapshot file"));
+        assert!(error_text.contains(&path));
     }
 }

--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -10,10 +10,11 @@
 //!
 //! This module contains defalut gas estimation constants for EIP-1559 for Gnosis chain,
 use std::{
+    error::Error as StdError,
     fmt::Debug,
     fs::File,
     future::IntoFuture,
-    io::{BufWriter, Error, Write},
+    io::{BufWriter, Error, ErrorKind, Write},
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -66,6 +67,44 @@ pub const EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE_GNOSIS: u128 = 100_000_000
 use hopr_metrics::{MultiCounter, MultiHistogram};
 
 use crate::{rpc::DEFAULT_GAS_ORACLE_URL, transport::HttpRequestor};
+
+#[derive(Debug)]
+struct SnapshotIoError {
+    action: &'static str,
+    file: String,
+    source: Error,
+}
+
+impl std::fmt::Display for SnapshotIoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} '{}': {}", self.action, self.file, self.source)
+    }
+}
+
+impl StdError for SnapshotIoError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[derive(Debug)]
+struct SnapshotSerdeError {
+    action: &'static str,
+    file: String,
+    source: serde_yaml::Error,
+}
+
+impl std::fmt::Display for SnapshotSerdeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} '{}': {}", self.action, self.file, self.source)
+    }
+}
+
+impl StdError for SnapshotSerdeError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.source)
+    }
+}
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
@@ -649,8 +688,26 @@ impl SnapshotRequestor {
         self.next_id.store(1, Ordering::Relaxed);
     }
 
-    fn snapshot_error(action: &str, file: &str, error: impl std::error::Error) -> Error {
-        Error::other(format!("{action} '{file}': {error}"))
+    fn snapshot_io_error(action: &'static str, file: &str, error: Error) -> Error {
+        Error::new(
+            error.kind(),
+            SnapshotIoError {
+                action,
+                file: file.to_string(),
+                source: error,
+            },
+        )
+    }
+
+    fn snapshot_serde_error(action: &'static str, file: &str, kind: ErrorKind, error: serde_yaml::Error) -> Error {
+        Error::new(
+            kind,
+            SnapshotSerdeError {
+                action,
+                file: file.to_string(),
+                source: error,
+            },
+        )
     }
 
     /// Clears all entries and loads them from the snapshot file.
@@ -662,9 +719,15 @@ impl SnapshotRequestor {
         }
 
         let file = File::open(&self.file)
-            .map_err(|error| Self::snapshot_error("failed to open snapshot file", &self.file, error))?;
-        let loaded = serde_yaml::from_reader::<_, Vec<RequestorResponseSnapshot>>(file)
-            .map_err(|error| Self::snapshot_error("failed to parse snapshot file", &self.file, error))?;
+            .map_err(|error| Self::snapshot_io_error("failed to open snapshot file", &self.file, error))?;
+        let loaded = serde_yaml::from_reader::<_, Vec<RequestorResponseSnapshot>>(file).map_err(|error| {
+            Self::snapshot_serde_error(
+                "failed to parse snapshot file",
+                &self.file,
+                ErrorKind::InvalidData,
+                error,
+            )
+        })?;
 
         self.clear();
 
@@ -724,15 +787,21 @@ impl SnapshotRequestor {
         values.sort_unstable_by_key(|a| a.id);
 
         let file = File::create(&self.file)
-            .map_err(|error| Self::snapshot_error("failed to create snapshot file", &self.file, error))?;
+            .map_err(|error| Self::snapshot_io_error("failed to create snapshot file", &self.file, error))?;
         let mut writer = BufWriter::new(file);
 
-        serde_yaml::to_writer(&mut writer, &values)
-            .map_err(|error| Self::snapshot_error("failed to write snapshot file", &self.file, error))?;
+        serde_yaml::to_writer(&mut writer, &values).map_err(|error| {
+            Self::snapshot_serde_error(
+                "failed to write snapshot file",
+                &self.file,
+                ErrorKind::InvalidData,
+                error,
+            )
+        })?;
 
         writer
             .flush()
-            .map_err(|error| Self::snapshot_error("failed to flush snapshot file", &self.file, error))?;
+            .map_err(|error| Self::snapshot_io_error("failed to flush snapshot file", &self.file, error))?;
 
         tracing::debug!(entries = values.len(), file = %self.file, "snapshot saved to file");
         Ok(())
@@ -1295,16 +1364,38 @@ mod tests {
         let error_text = error.to_string();
         assert!(error_text.contains("failed to parse snapshot file"));
         assert!(error_text.contains(&path));
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn snapshot_try_load_missing_file_preserves_error_kind() {
+        let snapshot_dir = tempdir().expect("temp dir should be created");
+        let path = snapshot_dir.path().join("missing.yaml").display().to_string();
+        let mut requestor = SnapshotRequestor::new(&path);
+
+        let error = requestor
+            .try_load(false)
+            .await
+            .expect_err("missing snapshot file should fail to load");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        assert!(error.to_string().contains(&path));
     }
 
     #[test]
-    fn snapshot_save_error_includes_snapshot_path() {
+    fn snapshot_save_error_preserves_error_kind_and_path() {
         let snapshot_dir = tempdir().expect("temp dir should be created");
-        let path = snapshot_dir.path().display().to_string();
+        let path = snapshot_dir
+            .path()
+            .join("missing")
+            .join("snapshot.yaml")
+            .display()
+            .to_string();
         let requestor = SnapshotRequestor::new(&path);
 
         let error = requestor.save().expect_err("saving to a directory path should fail");
 
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
         let error_text = error.to_string();
         assert!(error_text.contains("failed to create snapshot file"));
         assert!(error_text.contains(&path));

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -284,7 +284,7 @@ impl<R: HttpRequestor + 'static + Clone> HoprIndexerRpcOperations for RpcOperati
                                         current_block_log.block_id = log.block_number;
                                     }
 
-                                    debug!("retrieved {log}");
+                                    debug!(%log, "retrieved log");
                                     current_block_log.logs.insert(log.into());
                                 },
                                 None => {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -284,7 +284,7 @@ impl<R: HttpRequestor + 'static + Clone> HoprIndexerRpcOperations for RpcOperati
                                         current_block_log.block_id = log.block_number;
                                     }
 
-                                    debug!(%log, "retrieved log");
+                                    debug!(hex = %log, "retrieved log");
                                     current_block_log.logs.insert(log.into());
                                 },
                                 None => {

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -185,7 +185,7 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
         }
         provider.client().set_poll_interval(cfg.tx_polling_interval);
 
-        debug!("{:?}", cfg.contract_addrs);
+        debug!(contract_addresses = ?cfg.contract_addrs, "configured contract addresses");
 
         Ok(Self {
             contract_instances: Arc::new(ContractInstances::new(
@@ -279,30 +279,26 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
 
         if code.is_empty() {
             // Empty code means EOA (Externally Owned Account), use eth_getTransactionCount
-            debug!("Address {} has no code (EOA), using eth_getTransactionCount", address);
+            debug!(%address, "address has no code, using eth_getTransactionCount");
             let tx_count = provider.get_transaction_count(address_alloy).await?;
             return Ok(tx_count);
         }
 
         // Address has code, verify it's a Safe contract by calling getThreshold()
         // This prevents false positives from non-Safe contracts that have a nonce() method
-        debug!("Address {} has code, verifying if it's a Safe contract", address);
+        debug!(%address, "address has code, verifying Safe contract");
         let safe_contract = SafeSingleton::new(address_alloy, provider.clone());
 
         match safe_contract.getThreshold().call().await {
             Ok(_threshold) => {
                 // Successfully called getThreshold(), this is a Safe contract
                 // Now get the Safe nonce (transaction count)
-                debug!("Address {} is a Safe contract, getting nonce", address);
+                debug!(%address, "address is a Safe contract, getting nonce");
                 match safe_contract.nonce().call().await {
                     Ok(nonce) => nonce.try_into().map_err(|_| RpcError::SafeNonceOverflow(nonce)),
                     Err(e) => {
                         // This should rarely happen if getThreshold() succeeded
-                        tracing::error!(
-                            "Safe contract {} getThreshold() succeeded but nonce() failed: {}",
-                            address,
-                            e
-                        );
+                        tracing::error!(%address, error = %e, "safe getThreshold succeeded but nonce failed");
                         Err(e.into())
                     }
                 }

--- a/chain/rpc/tests/log_streaming_test.rs
+++ b/chain/rpc/tests/log_streaming_test.rs
@@ -74,14 +74,14 @@ async fn test_try_stream_logs_should_contain_all_logs_when_opening_channel() -> 
         no_token: vec![filter_channels_opened, filter_channels_balance_increased],
     };
 
-    debug!("{:#?}", contract_addrs);
-    debug!("{:#?}", log_filter);
+    debug!(contract_addresses = ?contract_addrs, "configured contract addresses");
+    debug!(log_filter = ?log_filter, "configured log filter");
 
     let tokens_minted_at =
         blokli_chain_types::utils::mint_tokens(contract_instances.token.clone(), U256::from(1000_u128))
             .await?
             .unwrap();
-    debug!("tokens were minted at block {tokens_minted_at}");
+    debug!(tokens_minted_at, "tokens were minted");
 
     let transport_client = ReqwestTransport::new(anvil.endpoint_url());
 
@@ -138,16 +138,16 @@ async fn test_try_stream_logs_should_contain_all_logs_when_opening_channel() -> 
     let channel_balance_filter = ChannelBalanceIncreased::SIGNATURE_HASH;
 
     debug!(
-        "channel_open_filter: {:?} - {:?}",
-        channel_open_filter,
-        channel_open_filter.0.to_vec()
+        channel_open_filter = ?channel_open_filter,
+        channel_open_filter_bytes = ?channel_open_filter.0.to_vec(),
+        "channel open filter"
     );
     debug!(
-        "channel_balance_filter: {:?} - {:?}",
-        channel_balance_filter,
-        channel_balance_filter.0.to_vec()
+        channel_balance_filter = ?channel_balance_filter,
+        channel_balance_filter_bytes = ?channel_balance_filter.0.to_vec(),
+        "channel balance filter"
     );
-    debug!("logs: {:#?}", last_block_logs);
+    debug!(last_block_logs = ?last_block_logs, "retrieved logs");
 
     assert!(
         last_block_logs
@@ -186,7 +186,7 @@ async fn test_try_stream_logs_should_contain_only_channel_logs_when_filtered_on_
         blokli_chain_types::utils::mint_tokens(contract_instances.token.clone(), U256::from(1000_u128))
             .await?
             .unwrap();
-    debug!("tokens were minted at block {tokens_minted_at}");
+    debug!(tokens_minted_at, "tokens were minted");
 
     let contract_addrs = ContractAddresses::from(&contract_instances);
 
@@ -227,8 +227,8 @@ async fn test_try_stream_logs_should_contain_only_channel_logs_when_filtered_on_
         no_token: vec![filter_channels_opened, filter_channels_balance_increased],
     };
 
-    debug!("{:#?}", contract_addrs);
-    debug!("{:#?}", log_filter);
+    debug!(contract_addresses = ?contract_addrs, "configured contract addresses");
+    debug!(log_filter = ?log_filter, "configured log filter");
 
     // Spawn stream
     let count_filtered_topics = 2;

--- a/chain/rpc/tests/log_streaming_test.rs
+++ b/chain/rpc/tests/log_streaming_test.rs
@@ -251,10 +251,14 @@ async fn test_try_stream_logs_should_contain_only_channel_logs_when_filtered_on_
     .await?;
 
     let retrieved_logs = timeout(Duration::from_secs(30), retrieved_logs) // Give up after 30 seconds
-        .await???;
+        .await
+        .context("log streaming timed out")?
+        .context("log stream task failed")?;
 
-    // The last block must contain all 2 events
-    let last_block_logs = retrieved_logs.context("log stream yielded no blocks")?.logs;
+    let last_block_logs = retrieved_logs
+        .context("log stream task returned error")?
+        .context("log stream yielded no blocks")?
+        .logs;
 
     let channel_open_filter = ChannelOpened::SIGNATURE_HASH;
     let channel_balance_filter = ChannelBalanceIncreased::SIGNATURE_HASH;

--- a/db/core/src/logs.rs
+++ b/db/core/src/logs.rs
@@ -100,7 +100,7 @@ impl BlokliDbLogOperations for BlokliDb {
                                         Ok(())
                                     }
                                     Err(e) => {
-                                        error!(%log_id, "Failed to insert log status into db: {:?}", e);
+                                        error!(%log_id, error = ?e, "failed to insert log status into db");
                                         Err(DbError::General(e.to_string()))
                                     }
                                 }
@@ -138,7 +138,7 @@ impl BlokliDbLogOperations for BlokliDb {
                                                 Ok(())
                                             }
                                             Err(e) => {
-                                                error!(%log_id, "Failed to insert log status into db: {:?}", e);
+                                                error!(%log_id, error = ?e, "failed to insert log status into db");
                                                 Err(DbError::General(e.to_string()))
                                             }
                                         }
@@ -148,13 +148,13 @@ impl BlokliDbLogOperations for BlokliDb {
                                         Err(DbError::General(format!("Log not found: {log_id}")))
                                     }
                                     Err(e) => {
-                                        error!(%log_id, "Failed to find existing log: {:?}", e);
+                                        error!(%log_id, error = ?e, "failed to find existing log");
                                         Err(DbError::General(e.to_string()))
                                     }
                                 }
                             }
                             Err(e) => {
-                                error!("Failed to insert log into db: {:?}", e);
+                                error!(error = ?e, "failed to insert log into db");
                                 Err(DbError::General(e.to_string()))
                             }
                         }
@@ -211,13 +211,13 @@ impl BlokliDbLogOperations for BlokliDb {
                     if let Some(status) = status {
                         create_log(log, status).map_err(DbError::from)
                     } else {
-                        error!("Missing log status for log in db: {:?}", log);
+                        error!(log = ?log, "missing log status for log in db");
                         Err(DbError::MissingLogStatus)
                     }
                 })
                 .collect::<Result<Vec<_>>>(),
             Err(e) => {
-                error!("Failed to get logs from db: {:?}", e);
+                error!(error = ?e, "failed to get logs from db");
                 Err(DbError::from(DbSqlError::from(e)))
             }
         }
@@ -263,7 +263,7 @@ impl BlokliDbLogOperations for BlokliDb {
             .await
             .map(|res| res.into_iter().map(|b| b.block_number as u64).collect())
             .map_err(|e| {
-                error!("Failed to get logs block numbers from db: {:?}", e);
+                error!(error = ?e, "failed to get logs block numbers from db");
                 DbError::from(DbSqlError::from(e))
             })
     }

--- a/tests/integration/src/fixtures.rs
+++ b/tests/integration/src/fixtures.rs
@@ -768,7 +768,7 @@ pub async fn build_integration_fixture() -> Result<IntegrationFixture> {
 
     let contract_addresses = contract_instances.get_contract_addresses();
 
-    info!("deployed contract addresses: {:?}", contract_addresses);
+    info!(contract_addresses = ?contract_addresses, "deployed contract addresses");
 
     // Mint HOPR tokens
     let encoded_minter_role = keccak256(b"MINTER_ROLE");

--- a/tests/integration/tests/blokli_subscription_client.rs
+++ b/tests/integration/tests/blokli_subscription_client.rs
@@ -352,7 +352,7 @@ async fn subscribe_ticket_params(#[future(awt)] fixture: IntegrationFixture) -> 
 
         match tokio::time::timeout(wait_time, stream.next()).await {
             Ok(Some(Ok(output))) => {
-                tracing::info!("Received ticket parameters subscription event: {:?}", output);
+                tracing::info!(output = ?output, "received ticket parameters subscription event");
                 latest_output = Some(output);
             }
             Ok(Some(Err(error))) => return Err(error.into()),
@@ -363,11 +363,7 @@ async fn subscribe_ticket_params(#[future(awt)] fixture: IntegrationFixture) -> 
 
     let output = latest_output.ok_or_else(|| anyhow!("no ticket parameters received from subscription"))?;
 
-    tracing::info!(
-        "Received ticket parameters update: {:?}, expected: {:?}",
-        output,
-        new_win_prob
-    );
+    tracing::info!(output = ?output, new_win_prob, "received ticket parameters update");
 
     assert!((output.min_ticket_winning_probability - new_win_prob).abs() < EPSILON);
 


### PR DESCRIPTION
- Adds centralized tracing setup for `blokli-api`, including optional JSON log output via `BLOKLI_LOG_FORMAT=json` (was already used by `bloklid`. Applied to `blokli-api` and `blokli-contract-deployer`).
- Installs panic hooks for both `bloklid` and `blokli-api` so uncaught panics are emitted through tracing with payload, source location, thread metadata, and backtrace.
- Brings the contract deployer onto the same structured logging setup and panic reporting path.
- Normalizes logging call sites across the workspace to use structured fields instead of string interpolation in log messages.
- Improves RPC snapshot load/save errors by including the snapshot file path, with focused regression tests for those failure cases.

Closes #177
Closes #234
Closes #343