### PR TITLE
chore: add renovate-config-validator pre-commit hook

### DIFF
--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -110,10 +110,12 @@ pre-commit.lib.${system}.run {
     renovate-config-validator = {
       enable = true;
       name = "Renovate config validator";
-      entry = toString (pkgs.writeShellScript "validate-renovate" ''
-        if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
-        ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
-      '');
+      entry = toString (
+        pkgs.writeShellScript "validate-renovate" ''
+          if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
+          ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
+        ''
+      );
       files = "renovate\\.json$";
       language = "system";
       pass_filenames = true;

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -111,6 +111,7 @@ pre-commit.lib.${system}.run {
       enable = true;
       name = "Renovate config validator";
       entry = toString (pkgs.writeShellScript "validate-renovate" ''
+        if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
         ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
       '');
       files = "renovate\\.json$";

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -106,6 +106,17 @@ pre-commit.lib.${system}.run {
       files = "";
       language = "system";
     };
+
+    renovate-config-validator = {
+      enable = true;
+      name = "Renovate config validator";
+      entry = toString (pkgs.writeShellScript "validate-renovate" ''
+        ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
+      '');
+      files = "renovate\\.json$";
+      language = "system";
+      pass_filenames = true;
+    };
   };
 
   # Exclude certain paths from pre-commit checks


### PR DESCRIPTION
Validates renovate.json on every commit via renovate-config-validator, using pkgs.nodejs/npx pinned through the flake's nixpkgs input.

Invalid configurations led to some components not being triggered (nix update et al.)