### PR TITLE
fix(ci): migrate codecov to OIDC and bump to workflow-tests-v6

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: branches-${{ github.ref_name }}
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # 0.7.2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false
@@ -26,4 +27,3 @@ jobs:
       runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: branches-${{ github.ref_name }}
@@ -17,6 +16,8 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,6 @@ on:
       - ready_for_review
 permissions:
   contents: read
-  id-token: write
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -97,6 +96,8 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -96,8 +97,6 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
-  id-token: write
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,6 @@ on:
       - ready_for_review
 permissions:
   contents: read
-  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,6 +96,8 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
+    permissions:
+      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -96,7 +97,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # 0.7.2
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b17431137fb50edf6a7b5fcfd4e3d17e9e9ea33a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -107,7 +108,6 @@ jobs:
       test_timeout: 30
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   # ── Repo-specific: schema validation ────────────────────────────────────────
   schema-validation:
     name: Schema Validation

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -96,8 +97,6 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    permissions:
-      id-token: write
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}


### PR DESCRIPTION
## Summary

- Migrate Codecov upload from global upload token to GitHub Actions OIDC (`use_oidc: true`)
- Bump `tests.yaml` pin to `workflow-tests-v6` (`798d791de5c5485c3043049781dfd0938539a36a`)
- Remove `CODECOV_TOKEN` secret passthrough — no longer needed with OIDC
- Move `id-token: write` from workflow-level to only the `tests`/`coverage` job to avoid overly broad permissions (Zizmor fix)

Depends on: https://github.com/hoprnet/hopr-workflows/pull/88