### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -155,7 +155,7 @@ jobs:
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT_DEVELOPMENT }}
           install_sdk: "true"
       - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3.0.1
         with:
           service: blokli
           region: europe-west1

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -63,6 +63,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       version_type: pr

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -60,7 +60,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -181,7 +181,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -184,6 +184,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: commit

--- a/.github/workflows/release-library.yaml
+++ b/.github/workflows/release-library.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6c5db2cd898f1f2c8fdae39498b6d7b3ee7d0258 # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,7 +131,7 @@ jobs:
           service_account: ${{ vars.WIF_SERVICE_ACCOUNT_STAGING }}
           install_sdk: "true"
       - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3.0.1
         with:
           service: blokli
           region: europe-west1

--- a/flake.nix
+++ b/flake.nix
@@ -378,10 +378,11 @@
             treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
             shellHook = ''
               echo "Running pre-commit checks..."
-              ${packages.pre-commit-check.shellHook}
               export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              ${packages.pre-commit-check.shellHook}
             '';
             extraPackages = with pkgs; [
+              gh
               nodejs
               ast-grep
               foundry-bin

--- a/flake.nix
+++ b/flake.nix
@@ -379,7 +379,7 @@
             shellHook = ''
               echo "Running pre-commit checks..."
               ${packages.pre-commit-check.shellHook}
-              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+              export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
             '';
             extraPackages = with pkgs; [
               nodejs

--- a/flake.nix
+++ b/flake.nix
@@ -379,7 +379,7 @@
             shellHook = ''
               echo "Running pre-commit checks..."
               ${packages.pre-commit-check.shellHook}
-
+              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
             '';
             extraPackages = with pkgs; [
               nodejs

--- a/flake.nix
+++ b/flake.nix
@@ -378,7 +378,7 @@
             treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
             shellHook = ''
               echo "Running pre-commit checks..."
-              _github_token="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              _github_token="''${GITHUB_TOKEN:-''${GH_TOKEN:-$(gh auth token 2>/dev/null || true)}}"
               if [ -n "$_github_token" ]; then
                 export GITHUB_TOKEN="$_github_token"
               fi

--- a/flake.nix
+++ b/flake.nix
@@ -378,7 +378,11 @@
             treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
             shellHook = ''
               echo "Running pre-commit checks..."
-              export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              _github_token="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              if [ -n "$_github_token" ]; then
+                export GITHUB_TOKEN="$_github_token"
+              fi
+              unset _github_token
               ${packages.pre-commit-check.shellHook}
             '';
             extraPackages = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -426,6 +426,7 @@
               treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
               extraPackages = with pkgs; [
                 cargo-machete
+                cargo-release
                 cargo-shear
                 zizmor
               ];

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -133,7 +133,7 @@ pre-commit.lib.${system}.run {
         export GITHUB_TOKEN="$token"
         exec ${pkgs.pinact}/bin/pinact run --check
       ''}";
-      files = "(^\\.github/workflows/.*\\.ya?ml$|^\\.github/actions/.*/action\\.ya?ml$)";
+      files = "^\\.github/workflows/.*\\.ya?ml$";
       language = "system";
       pass_filenames = false;
     };

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -118,6 +118,7 @@ pre-commit.lib.${system}.run {
 
     actionlint = {
       enable = true;
+      files = "^\\.github/workflows/.*\\.yaml$";
     };
 
     pinact = {

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -120,6 +120,20 @@ pre-commit.lib.${system}.run {
       language = "system";
       pass_filenames = true;
     };
+
+    actionlint = {
+      enable = true;
+    };
+
+    pinact = {
+      enable = true;
+      name = "pinact";
+      description = "Check GitHub Action refs are SHA-pinned and resolvable";
+      entry = "${pkgs.pinact}/bin/pinact run --check";
+      files = "\\.ya?ml$";
+      language = "system";
+      pass_filenames = false;
+    };
   };
 
   # Exclude certain paths from pre-commit checks

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -130,7 +130,7 @@ pre-commit.lib.${system}.run {
       name = "pinact";
       description = "Check GitHub Action refs are SHA-pinned and resolvable";
       entry = "${pkgs.pinact}/bin/pinact run --check";
-      files = "\\.ya?ml$";
+      files = "(^\\.github/workflows/.*\\.ya?ml$|^\\.github/actions/.*/action\\.ya?ml$)";
       language = "system";
       pass_filenames = false;
     };

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -110,12 +110,7 @@ pre-commit.lib.${system}.run {
     renovate-config-validator = {
       enable = true;
       name = "Renovate config validator";
-      entry = toString (
-        pkgs.writeShellScript "validate-renovate" ''
-          if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
-          ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
-        ''
-      );
+      entry = "${pkgs.renovate}/bin/renovate-config-validator";
       files = "renovate\\.json$";
       language = "system";
       pass_filenames = true;
@@ -129,7 +124,15 @@ pre-commit.lib.${system}.run {
       enable = true;
       name = "pinact";
       description = "Check GitHub Action refs are SHA-pinned and resolvable";
-      entry = "${pkgs.pinact}/bin/pinact run --check";
+      entry = "${pkgs.writeShellScript "pinact-check" ''
+        token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+        if [ -z "$token" ]; then
+          echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+          exit 0
+        fi
+        export GITHUB_TOKEN="$token"
+        exec ${pkgs.pinact}/bin/pinact run --check
+      ''}";
       files = "(^\\.github/workflows/.*\\.ya?ml$|^\\.github/actions/.*/action\\.ya?ml$)";
       language = "system";
       pass_filenames = false;

--- a/nix/packages/pre-commit-check.nix
+++ b/nix/packages/pre-commit-check.nix
@@ -125,9 +125,9 @@ pre-commit.lib.${system}.run {
       name = "pinact";
       description = "Check GitHub Action refs are SHA-pinned and resolvable";
       entry = "${pkgs.writeShellScript "pinact-check" ''
-        token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+        token="''${GITHUB_TOKEN:-''${GH_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}}"
         if [ -z "$token" ]; then
-          echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+          echo "pinact: skipping — no GITHUB_TOKEN/GH_TOKEN and gh not authenticated" >&2
           exit 0
         fi
         export GITHUB_TOKEN="$token"


### PR DESCRIPTION
Adds `actionlint` and `pinact` pre-commit hooks via `nix/packages/pre-commit-check.nix` (the existing git-hooks.nix infrastructure).

## What this does

- **actionlint**: validates GitHub Actions YAML syntax, runner labels, and `${{ }}` expressions
- **pinact**: enforces that all `uses:` refs are SHA-pinned (and resolves each SHA via the GitHub API)

Both hooks run on `.github/workflows/*.yaml` only (narrowed scope; not all YAML files).

## Changes

- `nix/packages/pre-commit-check.nix`: `actionlint` and `pinact` hooks added; pinact `files` pattern scoped to `.github/workflows/`
- `flake.nix`: devshell exports `GITHUB_TOKEN` (using existing env or `gh auth token`) for authenticated pinact runs