### PR TITLE
chore: bump quinn-proto to 0.11.15

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -34,7 +34,8 @@ ignore = [
 
   # RUSTSEC-2026-0173: proc-macro-error2 unmaintained
   # Crate: proc-macro-error2 2.0.1
-  # Transitive: alloy -> alloy/hopr-bindings
+  # Transitive: hopr-bindings -> alloy -> alloy-sol-macro (proc-macro-error2)
+  # Status: Build-time proc-macro only; no runtime impact. Track upstream for a maintained replacement.
   # Review by: 2026-06-30
   "RUSTSEC-2026-0173",
 

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -31,4 +31,11 @@ ignore = [
   # Status: Macro library for Solidity type generation. No runtime impact.
   # Review by: 2026-06-30
   "RUSTSEC-2024-0436",
+
+  # RUSTSEC-2026-0173: proc-macro-error2 unmaintained
+  # Crate: proc-macro-error2 2.0.1
+  # Transitive: alloy -> alloy/hopr-bindings
+  # Review by: 2026-06-30
+  "RUSTSEC-2026-0173",
+
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,7 +2440,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2970,7 +2970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6007,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -8768,7 +8768,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Bump quinn-proto to 0.11.15 and ignore a `dependency unmaintained` warning