### PR TITLE
fix: harden API defaults and local dev exposure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-api"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-chain-indexer"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-db-entity"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "blokli-db-migration",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-api"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.23.2"
+version     = "0.23.3"
 
 [lints]
 workspace = true

--- a/api/README.md
+++ b/api/README.md
@@ -8,7 +8,7 @@ GraphQL API server for HOPR blokli indexer built with Axum and async-graphql.
 - **Subscriptions**: Real-time subscriptions using Server-Sent Events (SSE)
 - **HTTP/2**: High-performance HTTP/2 support
 - **TLS 1.3**: Secure connections with TLS 1.3 (when configured)
-- **GraphQL Playground**: Interactive GraphQL IDE for development
+- **GraphQL Playground**: Interactive GraphQL IDE for development when explicitly enabled
 - **CORS**: Configured for cross-origin requests
 - **Compression**: Zstandard (zstd) compression only for responses >1KB
 - **Logging**: Structured logging with tracing
@@ -62,8 +62,8 @@ use std::path::PathBuf;
 
 // Without TLS
 let config = ApiConfig {
-    bind_address: "0.0.0.0:8080".parse().unwrap(),
-    playground_enabled: true,
+    bind_address: "127.0.0.1:8080".parse().unwrap(),
+    playground_enabled: false,
     gas_multiplier: 1.0,
     tls: None,
     ..Default::default()
@@ -71,8 +71,8 @@ let config = ApiConfig {
 
 // With TLS 1.3
 let config = ApiConfig {
-    bind_address: "0.0.0.0:8443".parse().unwrap(),
-    playground_enabled: true,
+    bind_address: "127.0.0.1:8443".parse().unwrap(),
+    playground_enabled: false,
     gas_multiplier: 1.0,
     tls: Some(TlsConfig {
         cert_path: PathBuf::from("/path/to/cert.pem"),

--- a/api/src/tls.rs
+++ b/api/src/tls.rs
@@ -8,6 +8,7 @@ use pem_rfc7468::decode_vec;
 use rustls::{
     ServerConfig,
     pki_types::{CertificateDer, PrivateKeyDer},
+    version::TLS13,
 };
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{TlsAcceptor, server::TlsStream};
@@ -23,7 +24,7 @@ pub fn create_tls_acceptor(config: &TlsConfig) -> ApiResult<TlsAcceptor> {
     let (certs, key) = read_cert_and_key(config)?;
 
     // Configure rustls for TLS 1.3 only
-    let mut server_config = ServerConfig::builder()
+    let mut server_config = ServerConfig::builder_with_protocol_versions(&[&TLS13])
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .map_err(|e| ApiError::ConfigError(format!("Invalid TLS configuration: {}", e)))?;

--- a/bloklid/README.md
+++ b/bloklid/README.md
@@ -30,7 +30,7 @@ bloklid -vv   # trace level
 
 See `example-config.toml` for a complete configuration example. Key settings include:
 
-- `api.bind_address`: API server bind address (default: "0.0.0.0:8080")
+- `api.bind_address`: API server bind address (default: "127.0.0.1:8080")
 - `database_path`: Path to SQLite database file
 - `private_key`: Ethereum private key for chain operations
 - `rpc_url`: Ethereum JSON-RPC endpoint

--- a/bloklid/example-config.toml
+++ b/bloklid/example-config.toml
@@ -130,11 +130,11 @@ batch_size = 100
 # Enable or disable the GraphQL API server (default: true)
 enabled = true
 
-# Address and port for the API server to bind to (default: "0.0.0.0:8080")
-bind_address = "0.0.0.0:8080"
+# Address and port for the API server to bind to (default: "127.0.0.1:8080")
+bind_address = "127.0.0.1:8080"
 
-# Enable GraphQL Playground for development and testing (default: true)
-playground_enabled = true
+# Enable the GraphQL Playground for local development only (default: false)
+playground_enabled = false
 
 # Multiplier applied to EIP-1559 gas estimates exposed by chainInfo
 # A value of 1.0 keeps RPC values unchanged; 1.5 increases maxFeePerGas and

--- a/bloklid/src/config.rs
+++ b/bloklid/src/config.rs
@@ -450,8 +450,8 @@ pub struct ApiConfig {
     #[serde(default = "default_api_bind_address")]
     pub bind_address: std::net::SocketAddr,
 
-    #[default(true)]
-    #[serde(default = "default_true")]
+    #[default(false)]
+    #[serde(default = "default_false")]
     pub playground_enabled: bool,
 
     #[default(1.0)]
@@ -509,7 +509,7 @@ pub struct HealthConfig {
 }
 
 fn default_api_bind_address() -> std::net::SocketAddr {
-    "0.0.0.0:8080".parse().unwrap()
+    "127.0.0.1:8080".parse().unwrap()
 }
 
 // Helper functions for serde defaults that respect SmartDefault values
@@ -792,7 +792,7 @@ mod tests {
 
         // Check API config
         assert!(config.api.enabled);
-        assert_eq!(config.api.bind_address.to_string(), "0.0.0.0:8080");
+        assert_eq!(config.api.bind_address.to_string(), "127.0.0.1:8080");
         assert_eq!(config.api.gas_multiplier, 1.0);
         assert_eq!(config.api.max_query_depth, 8);
         assert_eq!(config.api.max_query_complexity, 500);
@@ -840,8 +840,8 @@ mod tests {
 
         let cfg = res.unwrap();
         assert!(!cfg.api.enabled);
-        assert!(cfg.api.playground_enabled); // Default
-        assert_eq!(cfg.api.bind_address.to_string(), "0.0.0.0:8080"); // Default
+        assert!(!cfg.api.playground_enabled); // Default
+        assert_eq!(cfg.api.bind_address.to_string(), "127.0.0.1:8080"); // Default
         assert_eq!(cfg.api.gas_multiplier, 1.0); // Default
         assert_eq!(cfg.api.health.max_indexer_lag, 10); // Default
         assert_eq!(cfg.api.health.timeout, Duration::from_millis(5000)); // Default

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0"
 name        = "blokli-chain-indexer"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.16.4"
+version     = "0.16.5"
 
 [lib]
 crate-type = ["rlib"]

--- a/chain/indexer/src/handlers/mod.rs
+++ b/chain/indexer/src/handlers/mod.rs
@@ -223,10 +223,7 @@ where
                 Ok(res) => Ok(res),
                 Err(CoreEthereumIndexerError::ChannelDoesNotExist) => {
                     // This is not an error, just a log that we don't have the channel in the DB
-                    debug!(
-                        ?log,
-                        "channel didn't exist in the db. Created a corrupted channel entry and ignored event"
-                    );
+                    debug!(?log, "channel didn't exist in the db. Ignored event");
                     Ok(vec![])
                 }
                 Err(e) => Err(e),

--- a/db/entity/Cargo.toml
+++ b/db/entity/Cargo.toml
@@ -5,7 +5,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "blokli-db-entity"
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.6.1"
+version     = "0.6.2"
 
 [lints]
 workspace = true

--- a/db/entity/build.rs
+++ b/db/entity/build.rs
@@ -1,6 +1,6 @@
 //! Creates a build specification for the ORM codegen.
 
-use std::{env, path::Path};
+use std::{env, path::Path, process};
 
 use anyhow::Context;
 use clap::Parser;
@@ -88,7 +88,7 @@ fn main() -> anyhow::Result<()> {
 
     // Use temporary SQLite database for entity generation (no external dependencies needed)
     // The generated entities work with PostgreSQL at runtime since SeaORM abstracts DB differences
-    let tmp_db = std::env::temp_dir().join("blokli_entity_codegen.db");
+    let tmp_db = std::env::temp_dir().join(format!("blokli_entity_codegen-{}.db", process::id()));
 
     // Clean up any existing temp database
     let _ = std::fs::remove_file(&tmp_db);

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,9 +7,7 @@ services:
       POSTGRES_USER: bloklid
       POSTGRES_PASSWORD: bloklid_dev_password
       POSTGRES_DB: bloklid
-    ports:
-      - "5432:5432"
-
+    volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
     healthcheck:


### PR DESCRIPTION
Fixes a subset of the remaining low-hanging items from #9
- `#11` Disable the GraphQL playground by default
- `#12` Bind the embedded API to localhost by default
- `#24` Remove unnecessary host exposure of the local Postgres container
- `#25` Enforce TLS 1.3 explicitly
- `#26` Avoid temp SQLite filename collisions during entity codegen

Also fixes one related correctness issue:
- correct the misleading missing-channel log message in the indexer