### PR TITLE
fix: schema validation incorrectly requires database fields when existingSecret is set

### DIFF
--- a/charts/blokli/Chart.yaml
+++ b/charts/blokli/Chart.yaml
@@ -4,7 +4,7 @@ name: blokli
 description: Helm chart for Blokli - HOPR on-chain indexer with GraphQL API
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.10.1"
 keywords:
   - blokli

--- a/charts/blokli/templates/configmap.yaml
+++ b/charts/blokli/templates/configmap.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   name: {{ include "blokli.fullname" . }}
   labels:
     {{- include "blokli.labels" . | nindent 4 }}

--- a/charts/blokli/templates/deployment.yaml
+++ b/charts/blokli/templates/deployment.yaml
@@ -49,15 +49,15 @@ spec:
           value: {{ .Values.config.logging.backtrace | quote }}
         - name: BLOKLI_LOG_FORMAT
           value: {{ .Values.config.logging.format | quote }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "blokli.fullname" . }}
         {{- if .Values.database.existingSecret }}
         - secretRef:
             name: {{ .Values.database.existingSecret }}
-        {{- end }}
-        {{- with .Values.extraEnv }}
-        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:

--- a/charts/blokli/templates/deployment.yaml
+++ b/charts/blokli/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "blokli.fullname" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   labels:
     {{- include "blokli.labels" . | nindent 4 }}
 spec:

--- a/charts/blokli/templates/ingress.yaml
+++ b/charts/blokli/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     {{- include "blokli.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "3"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/blokli/templates/ingress.yaml
+++ b/charts/blokli/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "blokli.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-wave: "4"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/blokli/templates/ingress.yaml
+++ b/charts/blokli/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "blokli.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
     argocd.argoproj.io/sync-wave: "4"
+  {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/blokli/templates/pvc.yaml
+++ b/charts/blokli/templates/pvc.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ include "blokli.fullname" . }}
   labels:
     {{- include "blokli.labels" . | nindent 4 }}
-  {{- with .Values.persistence.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  {{- with .Values.persistence.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/blokli/templates/pvc.yaml
+++ b/charts/blokli/templates/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "blokli.labels" . | nindent 4 }}
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "3"
   {{- with .Values.persistence.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/blokli/templates/secret.yaml
+++ b/charts/blokli/templates/secret.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "blokli.fullname" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   labels:
     {{- include "blokli.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/blokli/templates/secret.yaml
+++ b/charts/blokli/templates/secret.yaml
@@ -8,10 +8,12 @@ metadata:
     {{- include "blokli.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if and (eq .Values.database.type "postgresql") (not ( default false .Values.database.existingSecret)) }}
-  BLOKLI_DATABASE_TYPE: {{ required "You must set .Values.database.type " .Values.database.type | b64enc | quote }}
+{{- if eq .Values.database.type "postgresql" }}
+  BLOKLI_DATABASE_TYPE: {{ .Values.database.type | b64enc | quote }}
+{{- if not ( default false .Values.database.existingSecret) }}
   BLOKLI_DATABASE_URL: {{ include "blokli.databaseUrl" . | b64enc | quote }}
   BLOKLI_DATABASE_MAX_CONNECTIONS: "{{ .Values.database.maxConnections | toString | b64enc }}"
+{{- end }}
 {{- end }}
   BLOKLI_RPC_URL: {{ required "config.rpcUrl is required" .Values.config.rpcUrl | b64enc | quote }}
 

--- a/charts/blokli/templates/secret.yaml
+++ b/charts/blokli/templates/secret.yaml
@@ -10,9 +10,9 @@ type: Opaque
 data:
 {{- if eq .Values.database.type "postgresql" }}
   BLOKLI_DATABASE_TYPE: {{ .Values.database.type | b64enc | quote }}
+  BLOKLI_DATABASE_MAX_CONNECTIONS: "{{ .Values.database.maxConnections | toString | b64enc }}"
 {{- if not ( default false .Values.database.existingSecret) }}
   BLOKLI_DATABASE_URL: {{ include "blokli.databaseUrl" . | b64enc | quote }}
-  BLOKLI_DATABASE_MAX_CONNECTIONS: "{{ .Values.database.maxConnections | toString | b64enc }}"
 {{- end }}
 {{- end }}
   BLOKLI_RPC_URL: {{ required "config.rpcUrl is required" .Values.config.rpcUrl | b64enc | quote }}

--- a/charts/blokli/templates/service.yaml
+++ b/charts/blokli/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "blokli.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "3"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/blokli/templates/service.yaml
+++ b/charts/blokli/templates/service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ include "blokli.fullname" . }}
   labels:
     {{- include "blokli.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
   annotations:
     argocd.argoproj.io/sync-wave: "3"
+  {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/blokli/templates/serviceaccount.yaml
+++ b/charts/blokli/templates/serviceaccount.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ include "blokli.serviceAccountName" . }}-sa
   labels:
     {{- include "blokli.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/blokli/templates/servicemonitor.yaml
+++ b/charts/blokli/templates/servicemonitor.yaml
@@ -13,6 +13,8 @@ metadata:
     {{- with .Values.monitoring.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
 spec:
   selector:
     matchLabels:

--- a/charts/blokli/values.schema.json
+++ b/charts/blokli/values.schema.json
@@ -32,11 +32,24 @@
     },
     "database": {
       "type": "object",
-      "required": ["host", "port", "database", "username"],
+      "if": {
+        "properties": {
+          "existingSecret": { "type": "string", "minLength": 1 }
+        },
+        "required": ["existingSecret"]
+      },
+      "then": {},
+      "else": {
+        "required": ["host", "port", "database", "username"],
+        "properties": {
+          "host": { "type": "string", "minLength": 1 },
+          "database": { "type": "string", "minLength": 1 },
+          "username": { "type": "string", "minLength": 1 }
+        }
+      },
       "properties": {
         "host": {
           "type": "string",
-          "minLength": 1,
           "description": "PostgreSQL host"
         },
         "port": {
@@ -47,12 +60,10 @@
         },
         "database": {
           "type": "string",
-          "minLength": 1,
           "description": "PostgreSQL database name"
         },
         "username": {
           "type": "string",
-          "minLength": 1,
           "description": "PostgreSQL username"
         },
         "password": {

--- a/charts/blokli/values.schema.json
+++ b/charts/blokli/values.schema.json
@@ -40,11 +40,12 @@
       },
       "then": {},
       "else": {
-        "required": ["host", "port", "database", "username"],
+        "required": ["host", "port", "database", "username", "password"],
         "properties": {
           "host": { "type": "string", "minLength": 1 },
           "database": { "type": "string", "minLength": 1 },
-          "username": { "type": "string", "minLength": 1 }
+          "username": { "type": "string", "minLength": 1 },
+          "password": { "type": "string", "minLength": 1 }
         }
       },
       "properties": {

--- a/charts/blokli/values.schema.json
+++ b/charts/blokli/values.schema.json
@@ -32,23 +32,13 @@
     },
     "database": {
       "type": "object",
-      "if": {
-        "properties": {
-          "existingSecret": { "type": "string", "minLength": 1 }
-        },
-        "required": ["existingSecret"]
-      },
-      "then": {},
-      "else": {
-        "required": ["host", "port", "database", "username", "password"],
-        "properties": {
-          "host": { "type": "string", "minLength": 1 },
-          "database": { "type": "string", "minLength": 1 },
-          "username": { "type": "string", "minLength": 1 },
-          "password": { "type": "string", "minLength": 1 }
-        }
-      },
+      "required": ["type"],
       "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["postgresql", "sqlite"],
+          "description": "Database type"
+        },
         "host": {
           "type": "string",
           "description": "PostgreSQL host"
@@ -71,6 +61,14 @@
           "type": "string",
           "description": "PostgreSQL password"
         },
+        "index_path": {
+          "type": "string",
+          "description": "Sqlite database file path"
+        },
+        "logs_path": {
+          "type": "string",
+          "description": "Sqlite logs database file path"
+        },
         "existingSecret": {
           "type": "string",
           "description": "Name of existing secret containing database credentials"
@@ -80,7 +78,44 @@
           "minimum": 1,
           "description": "Maximum number of database connections"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "postgresql" } },
+            "required": ["type"]
+          },
+          "then": {
+            "if": {
+              "properties": { "existingSecret": { "type": "string", "minLength": 1 } },
+              "required": ["existingSecret"]
+            },
+            "then": {},
+            "else": {
+              "required": ["host", "port", "database", "username", "password"],
+              "properties": {
+                "host": { "minLength": 1 },
+                "database": { "minLength": 1 },
+                "username": { "minLength": 1 },
+                "password": { "minLength": 1 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "type": { "const": "sqlite" } },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["index_path", "logs_path"],
+            "properties": {
+              "index_path": { "minLength": 1 },
+              "logs_path": { "minLength": 1 }
+            }
+          }
+        }
+      ]
     },
     "config": {
       "type": "object",

--- a/charts/blokli/values.schema.json
+++ b/charts/blokli/values.schema.json
@@ -87,7 +87,9 @@
           },
           "then": {
             "if": {
-              "properties": { "existingSecret": { "type": "string", "minLength": 1 } },
+              "properties": {
+                "existingSecret": { "type": "string", "minLength": 1 }
+              },
               "required": ["existingSecret"]
             },
             "then": {},


### PR DESCRIPTION
## Summary

- The `values.schema.json` unconditionally required `host`, `database`, and `username` with `minLength: 1`, even when `existingSecret` is provided
- The chart's `_helpers.tpl` already handled `existingSecret` correctly (skipping the individual field validation), but the JSON Schema was never updated to match
- Fixed by replacing the unconditional `required` + `minLength` constraints with an `if/then/else` conditional: fields are only required when `existingSecret` is not set
- Aligns argocd sync-wave with sibling helm-chart crossplane-postgresql

## Root cause

When `existingSecret` support was added to the `blokli.databaseUrl` helper, the `values.schema.json` was not updated to reflect the conditional logic, causing schema validation to fail before templates even render.