### PR TITLE
feat: Make rpc logs block range adaptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ You can override any configuration setting using environment variables.
 | `network`                  | `BLOKLI_NETWORK`                  |
 | `rpc_url`                  | `BLOKLI_RPC_URL`                  |
 | `max_rpc_requests_per_sec` | `BLOKLI_MAX_RPC_REQUESTS_PER_SEC` |
+| `max_block_range`          | `BLOKLI_MAX_BLOCK_RANGE`          |
+
+`max_block_range` is the ceiling for adaptive `eth_getLogs` block ranges. Set it to `0` to auto-discover with the default 10000-block
+ceiling.
 
 #### Database Configuration
 

--- a/bloklid/example-config.toml
+++ b/bloklid/example-config.toml
@@ -18,9 +18,10 @@ rpc_url = "http://localhost:8545"
 # If omitted, defaults to 100 req/sec. Set to 0 for unlimited, or a positive value to override the default.
 max_rpc_requests_per_sec = 0
 
-# Maximum block range for RPC queries when fetching logs (default: 10000)
-# Must be greater than 0. Lower values may be needed for some RPC providers
-# that impose limits on the number of blocks per query
+# Maximum block range ceiling for adaptive RPC log queries (default: 10000)
+# The effective range is learned from real eth_getLogs requests and reused
+# until the RPC endpoint rejects it. Set to 0 to auto-discover with the
+# default 10000-block ceiling.
 max_block_range = 10000
 
 # Optional contract address overrides

--- a/bloklid/src/args.rs
+++ b/bloklid/src/args.rs
@@ -1067,6 +1067,35 @@ mod tests {
     }
 
     #[test]
+    fn test_max_block_range_zero_enables_auto_mode() {
+        let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
+        writeln!(
+            file,
+            r#"
+            network = "rotsee"
+            rpc_url = "http://localhost:8545"
+            max_block_range = 0
+            [database]
+            type = "postgresql"
+            url = "postgres://file:5432/db"
+        "#
+        )
+        .unwrap();
+        let path = file.path().to_path_buf();
+
+        temp_env::with_var("BLOKLI_MAX_BLOCK_RANGE", None::<&str>, || {
+            let args = Args {
+                verbose: 0,
+                config: Some(path),
+                command: None,
+            };
+
+            let config = args.load_config(false).expect("Failed to load config");
+            assert_eq!(config.max_block_range, 0, "max_block_range=0 should be accepted");
+        });
+    }
+
+    #[test]
     fn test_max_rpc_requests_per_sec_zero_from_config() {
         let mut file = tempfile::Builder::new().suffix(".toml").tempfile().unwrap();
         writeln!(

--- a/bloklid/src/config.rs
+++ b/bloklid/src/config.rs
@@ -277,7 +277,6 @@ pub struct Config {
     #[serde(default)]
     pub max_rpc_requests_per_sec: Option<u32>,
 
-    #[validate(range(min = 1))]
     #[default(10000)]
     #[serde(default = "default_max_block_range")]
     pub max_block_range: u32,

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -28,7 +28,7 @@ use tracing::{debug, error, trace, warn};
 use crate::{
     BlockWithLogs, FilterSet, HoprIndexerRpcOperations, Log,
     errors::{Result, RpcError, RpcError::FilterIsEmpty},
-    rpc::{HoprModule, RpcOperations, SafeSingleton},
+    rpc::{HoprModule, RpcOperations, SafeSingleton, is_log_block_range_limit_error},
     transport::HttpRequestor,
 };
 
@@ -55,6 +55,7 @@ lazy_static::lazy_static! {
 ///
 /// # Returns
 /// * `impl Stream<Item = Vec<Filter>>` - Stream of filter vectors, one per chunk
+#[cfg(test)]
 fn split_range<'a>(
     filters: Vec<Filter>,
     from_block: u64,
@@ -110,20 +111,44 @@ where
     results
 }
 
+fn contains_log_block_range_limit_error(results: &[Result<Log>]) -> Option<&RpcError> {
+    results.iter().find_map(|result| match result {
+        Err(error) if is_log_block_range_limit_error(error) => Some(error),
+        _ => None,
+    })
+}
+
+fn contains_rpc_fetch_error(results: &[Result<Log>]) -> bool {
+    results
+        .iter()
+        .any(|result| matches!(result, Err(RpcError::AlloyRpcError(_))))
+}
+
 // impl<P: JsonRpcClient + 'static, R: HttpRequestor + 'static> RpcOperations<P, R> {
 impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
     /// Retrieves logs in the given range (`from_block` and `to_block` are inclusive).
     fn stream_logs(&self, filters: Vec<Filter>, from_block: u64, to_block: u64) -> BoxStream<'_, Result<Log>> {
-        let fetch_ranges = split_range(filters, from_block, to_block, self.cfg.max_block_range_fetch_size);
+        stream! {
+            let mut next_block = from_block;
 
-        debug!(
-            "polling logs from blocks #{from_block} - #{to_block} (via {:?} chunks)",
-            (to_block - from_block) / self.cfg.max_block_range_fetch_size + 1
-        );
+            while next_block <= to_block {
+                let attempted_limit = self.log_block_range_limit();
+                let end_block = to_block.min(next_block.saturating_add(attempted_limit.saturating_sub(1)));
+                let requested_span = end_block - next_block + 1;
+                let ranged_filters = filters
+                    .iter()
+                    .cloned()
+                    .map(|filter| filter.from_block(next_block).to_block(end_block))
+                    .collect::<Vec<_>>();
 
-        fetch_ranges
-            .then(move |subrange_filters| async move {
-                let results = fetch_subrange_logs_concurrently(subrange_filters, |filter| async move {
+                debug!(
+                    from_block = next_block,
+                    to_block = end_block,
+                    attempted_block_range = attempted_limit,
+                    "polling logs from block subrange"
+                );
+
+                let results = fetch_subrange_logs_concurrently(ranged_filters, |filter| async move {
                     let prov_clone = self.provider.clone();
 
                     match prov_clone.get_logs(&filter).await {
@@ -135,16 +160,30 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
                                 error = %error,
                                 "failed to fetch logs in block subrange"
                             );
-                            Err(RpcError::from(error))
+                            let rpc_error = RpcError::from(error);
+                            Err(rpc_error)
                         }
                     }
                 })
                 .await;
 
-                futures::stream::iter(results)
-            })
-            .flatten()
-            .boxed()
+                if let Some(error) = contains_log_block_range_limit_error(&results) {
+                    let update = self.record_log_block_range_failure(requested_span, error);
+                    if update.retry {
+                        continue;
+                    }
+                } else if !contains_rpc_fetch_error(&results) {
+                    self.record_log_block_range_success(requested_span, attempted_limit);
+                }
+
+                for result in results {
+                    yield result;
+                }
+
+                next_block = end_block + 1;
+            }
+        }
+        .boxed()
     }
 }
 
@@ -344,19 +383,44 @@ impl<R: HttpRequestor + 'static + Clone> HoprIndexerRpcOperations for RpcOperati
         from_block: u64,
         to_block: u64,
     ) -> Result<Vec<Log>> {
-        let filter = Filter::new()
-            .address(AlloyAddress::from_hopr_address(address))
-            .event_signature(topics)
-            .from_block(from_block)
-            .to_block(to_block);
+        let mut logs = Vec::new();
+        let mut next_block = from_block;
 
-        let mut logs = self
-            .provider
-            .get_logs(&filter)
-            .await?
-            .into_iter()
-            .map(Log::try_from)
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+        while next_block <= to_block {
+            let attempted_limit = self.log_block_range_limit();
+            let end_block = to_block.min(next_block.saturating_add(attempted_limit.saturating_sub(1)));
+            let requested_span = end_block - next_block + 1;
+            let filter = Filter::new()
+                .address(AlloyAddress::from_hopr_address(address))
+                .event_signature(topics.clone())
+                .from_block(next_block)
+                .to_block(end_block);
+
+            match self.provider.get_logs(&filter).await {
+                Ok(chunk_logs) => {
+                    self.record_log_block_range_success(requested_span, attempted_limit);
+
+                    let mut converted_logs = chunk_logs
+                        .into_iter()
+                        .map(Log::try_from)
+                        .collect::<std::result::Result<Vec<_>, _>>()?;
+                    logs.append(&mut converted_logs);
+                    next_block = end_block + 1;
+                }
+                Err(error) => {
+                    let rpc_error = RpcError::from(error);
+
+                    if is_log_block_range_limit_error(&rpc_error) {
+                        let update = self.record_log_block_range_failure(requested_span, &rpc_error);
+                        if update.retry {
+                            continue;
+                        }
+                    }
+
+                    return Err(rpc_error);
+                }
+            }
+        }
 
         logs.sort();
         Ok(logs)
@@ -489,11 +553,13 @@ mod tests {
         },
         transports::http::ReqwestTransport,
     };
+    use hopr_types::primitive::prelude::Address;
     use serde_json::json;
     use tokio::time::sleep;
     use url::Url;
 
     use crate::{
+        HoprIndexerRpcOperations,
         errors::{HttpRequestError, RpcError},
         indexer::{fetch_subrange_logs_concurrently, split_range},
         rpc::{RpcOperations, RpcOperationsConfig},
@@ -511,17 +577,64 @@ mod tests {
     }
 
     fn create_test_rpc_operations(server_url: &str) -> anyhow::Result<RpcOperations<TestRequestor>> {
+        create_test_rpc_operations_with_max_range(server_url, 10)
+    }
+
+    fn create_test_rpc_operations_with_max_range(
+        server_url: &str,
+        max_block_range_fetch_size: u64,
+    ) -> anyhow::Result<RpcOperations<TestRequestor>> {
         let transport_client = ReqwestTransport::new(Url::parse(server_url)?);
         let rpc_client = ClientBuilder::default().transport(transport_client.clone(), transport_client.guess_local());
         let cfg = RpcOperationsConfig {
             contract_addrs: ContractAddresses::default(),
             gas_oracle_url: None,
             tx_polling_interval: Duration::from_secs(1),
-            max_block_range_fetch_size: 10,
+            max_block_range_fetch_size,
             ..RpcOperationsConfig::default()
         };
 
         RpcOperations::new(rpc_client, TestRequestor, cfg, Some(true)).map_err(Into::into)
+    }
+
+    fn empty_logs_response() -> String {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": []
+        })
+        .to_string()
+    }
+
+    fn range_limit_error_response() -> String {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32005,
+                "message": "eth_getLogs block range limit exceeded"
+            }
+        })
+        .to_string()
+    }
+
+    fn mock_get_logs_range(
+        server: &mut mockito::ServerGuard,
+        from_block: u64,
+        to_block: u64,
+        body: String,
+    ) -> mockito::Mock {
+        server
+            .mock("POST", "/")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex(r#""method"\s*:\s*"eth_getLogs""#.to_string()),
+                mockito::Matcher::Regex(format!(r#""fromBlock"\s*:\s*"0x{from_block:x}""#)),
+                mockito::Matcher::Regex(format!(r#""toBlock"\s*:\s*"0x{to_block:x}""#)),
+            ]))
+            .with_status(200)
+            .with_body(body)
+            .expect(1)
+            .create()
     }
 
     fn filter_bounds(filters: &[Filter]) -> anyhow::Result<(u64, u64)> {
@@ -699,6 +812,51 @@ mod tests {
         mock.assert();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].as_ref().expect("log fetch should succeed").block_number, 5);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stream_logs_discovers_block_range_limit_from_request_failures() -> anyhow::Result<()> {
+        let mut server = mockito::Server::new_async().await;
+        let rpc = create_test_rpc_operations_with_max_range(&server.url(), 8)?;
+        let range_limit_error = range_limit_error_response();
+        let empty_logs = empty_logs_response();
+
+        let failed_cap = mock_get_logs_range(&mut server, 0, 7, range_limit_error.clone());
+        let failed_midpoint = mock_get_logs_range(&mut server, 0, 3, range_limit_error);
+        let working_low = mock_get_logs_range(&mut server, 0, 1, empty_logs.clone());
+        let working_limit = mock_get_logs_range(&mut server, 2, 4, empty_logs.clone());
+        let stable_reuse = mock_get_logs_range(&mut server, 5, 7, empty_logs);
+
+        let results = rpc.stream_logs(vec![Filter::new()], 0, 7).collect::<Vec<_>>().await;
+
+        failed_cap.assert();
+        failed_midpoint.assert();
+        working_low.assert();
+        working_limit.assert();
+        stable_reuse.assert();
+        assert!(results.is_empty());
+        assert_eq!(rpc.log_block_range_limit(), 3);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_logs_for_address_uses_adaptive_block_range_limit() -> anyhow::Result<()> {
+        let mut server = mockito::Server::new_async().await;
+        let rpc = create_test_rpc_operations_with_max_range(&server.url(), 3)?;
+        let first_range = mock_get_logs_range(&mut server, 5, 7, empty_logs_response());
+        let second_range = mock_get_logs_range(&mut server, 8, 9, empty_logs_response());
+
+        let logs = rpc
+            .get_logs_for_address(Address::from([0_u8; 20]), vec![B256::ZERO], 5, 9)
+            .await?;
+
+        first_range.assert();
+        second_range.assert();
+        assert!(logs.is_empty());
+        assert_eq!(rpc.log_block_range_limit(), 3);
 
         Ok(())
     }

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -124,27 +124,44 @@ fn contains_rpc_fetch_error(results: &[Result<Log>]) -> bool {
         .any(|result| matches!(result, Err(RpcError::AlloyRpcError(_))))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AdaptiveLogSubrange {
+    end_block: u64,
+    requested_span: u64,
+    attempted_limit: u64,
+}
+
 // impl<P: JsonRpcClient + 'static, R: HttpRequestor + 'static> RpcOperations<P, R> {
 impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
+    fn next_adaptive_subrange(&self, next_block: u64, to_block: u64) -> AdaptiveLogSubrange {
+        let attempted_limit = self.log_block_range_limit();
+        let end_block = to_block.min(next_block.saturating_add(attempted_limit.saturating_sub(1)));
+        let requested_span = end_block - next_block + 1;
+
+        AdaptiveLogSubrange {
+            end_block,
+            requested_span,
+            attempted_limit,
+        }
+    }
+
     /// Retrieves logs in the given range (`from_block` and `to_block` are inclusive).
     fn stream_logs(&self, filters: Vec<Filter>, from_block: u64, to_block: u64) -> BoxStream<'_, Result<Log>> {
         stream! {
             let mut next_block = from_block;
 
             while next_block <= to_block {
-                let attempted_limit = self.log_block_range_limit();
-                let end_block = to_block.min(next_block.saturating_add(attempted_limit.saturating_sub(1)));
-                let requested_span = end_block - next_block + 1;
+                let subrange = self.next_adaptive_subrange(next_block, to_block);
                 let ranged_filters = filters
                     .iter()
                     .cloned()
-                    .map(|filter| filter.from_block(next_block).to_block(end_block))
+                    .map(|filter| filter.from_block(next_block).to_block(subrange.end_block))
                     .collect::<Vec<_>>();
 
                 debug!(
                     from_block = next_block,
-                    to_block = end_block,
-                    attempted_block_range = attempted_limit,
+                    to_block = subrange.end_block,
+                    attempted_block_range = subrange.attempted_limit,
                     "polling logs from block subrange"
                 );
 
@@ -168,19 +185,19 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
                 .await;
 
                 if let Some(error) = contains_log_block_range_limit_error(&results) {
-                    let update = self.record_log_block_range_failure(requested_span, error);
+                    let update = self.record_log_block_range_failure(subrange.requested_span, error);
                     if update.retry {
                         continue;
                     }
                 } else if !contains_rpc_fetch_error(&results) {
-                    self.record_log_block_range_success(requested_span, attempted_limit);
+                    self.record_log_block_range_success(subrange.requested_span, subrange.attempted_limit);
                 }
 
                 for result in results {
                     yield result;
                 }
 
-                next_block = end_block + 1;
+                next_block = subrange.end_block + 1;
             }
         }
         .boxed()
@@ -387,31 +404,29 @@ impl<R: HttpRequestor + 'static + Clone> HoprIndexerRpcOperations for RpcOperati
         let mut next_block = from_block;
 
         while next_block <= to_block {
-            let attempted_limit = self.log_block_range_limit();
-            let end_block = to_block.min(next_block.saturating_add(attempted_limit.saturating_sub(1)));
-            let requested_span = end_block - next_block + 1;
+            let subrange = self.next_adaptive_subrange(next_block, to_block);
             let filter = Filter::new()
                 .address(AlloyAddress::from_hopr_address(address))
                 .event_signature(topics.clone())
                 .from_block(next_block)
-                .to_block(end_block);
+                .to_block(subrange.end_block);
 
             match self.provider.get_logs(&filter).await {
                 Ok(chunk_logs) => {
-                    self.record_log_block_range_success(requested_span, attempted_limit);
+                    self.record_log_block_range_success(subrange.requested_span, subrange.attempted_limit);
 
                     let mut converted_logs = chunk_logs
                         .into_iter()
                         .map(Log::try_from)
                         .collect::<std::result::Result<Vec<_>, _>>()?;
                     logs.append(&mut converted_logs);
-                    next_block = end_block + 1;
+                    next_block = subrange.end_block + 1;
                 }
                 Err(error) => {
                     let rpc_error = RpcError::from(error);
 
                     if is_log_block_range_limit_error(&rpc_error) {
-                        let update = self.record_log_block_range_failure(requested_span, &rpc_error);
+                        let update = self.record_log_block_range_failure(subrange.requested_span, &rpc_error);
                         if update.retry {
                             continue;
                         }
@@ -665,6 +680,23 @@ mod tests {
         })?;
 
         Ok(bounds)
+    }
+
+    #[test]
+    fn test_next_adaptive_subrange_uses_current_limit() -> anyhow::Result<()> {
+        let rpc = create_test_rpc_operations_with_max_range("http://localhost:8545", 3)?;
+
+        let subrange = rpc.next_adaptive_subrange(5, 9);
+        assert_eq!(subrange.end_block, 7);
+        assert_eq!(subrange.requested_span, 3);
+        assert_eq!(subrange.attempted_limit, 3);
+
+        let final_subrange = rpc.next_adaptive_subrange(8, 9);
+        assert_eq!(final_subrange.end_block, 9);
+        assert_eq!(final_subrange.requested_span, 2);
+        assert_eq!(final_subrange.attempted_limit, 3);
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -280,20 +280,23 @@ fn next_probe(last_working: u64, first_failing: u64) -> u64 {
     }
 }
 
-fn message_indicates_log_range_limit(message: &str) -> bool {
+fn message_indicates_known_log_range_limit(message: &str) -> bool {
     let message = message.to_ascii_lowercase();
-    let mentions_limit = message.contains("limit")
-        || message.contains("exceed")
-        || message.contains("too many")
-        || message.contains("too large")
-        || message.contains("too wide")
-        || message.contains("more than")
-        || message.contains("maximum")
-        || message.contains("response size");
-    let mentions_logs_or_blocks = message.contains("log") || message.contains("block") || message.contains("result");
-    let mentions_range = message.contains("range") || message.contains("block") || message.contains("eth_getlogs");
 
-    mentions_limit && mentions_logs_or_blocks && mentions_range
+    message.contains("exceed maximum block range")
+        || message.contains("block range limit exceeded")
+        || message.contains("query exceeds max block range")
+        || message.contains("query block range exceeds server limit")
+        || (message.contains("block range")
+            && message.contains("exceeds the maximum of")
+            && message.contains("blocks per logs request"))
+        || message.contains("too many logs requested. max logs per response is")
+        || (message.contains("query exceeds max results") && message.contains("retry with the range"))
+        || message.contains("query returns too many logs, narrow your filter")
+}
+
+fn is_known_log_range_limit_code(code: i64) -> bool {
+    matches!(code, -32602 | -32005)
 }
 
 pub(crate) fn is_log_block_range_limit_error(error: &RpcError) -> bool {
@@ -302,13 +305,11 @@ pub(crate) fn is_log_block_range_limit_error(error: &RpcError) -> bool {
     };
 
     if let Some(error_payload) = error.as_error_resp() {
-        let known_range_limit_code = matches!(error_payload.code, -32005 | -32016 | 429);
-
-        return message_indicates_log_range_limit(&error_payload.message)
-            || (known_range_limit_code && message_indicates_log_range_limit(&error_payload.to_string()));
+        return is_known_log_range_limit_code(error_payload.code)
+            && message_indicates_known_log_range_limit(&error_payload.message);
     }
 
-    message_indicates_log_range_limit(&error.to_string())
+    message_indicates_known_log_range_limit(&error.to_string())
 }
 
 /// Implementation of `HoprRpcOperations` and `HoprIndexerRpcOperations` trait via `alloy`
@@ -731,7 +732,23 @@ impl<R: HttpRequestor + 'static + Clone> HoprRpcOperations for RpcOperations<R> 
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP, LogBlockRangeLimit};
+    use std::borrow::Cow;
+
+    use hopr_bindings::exports::alloy::{
+        rpc::json_rpc::ErrorPayload,
+        transports::{RpcError as AlloyRpcError, TransportErrorKind},
+    };
+
+    use super::{DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP, LogBlockRangeLimit, is_log_block_range_limit_error};
+    use crate::errors::RpcError;
+
+    fn rpc_error_response(code: i64, message: &'static str) -> RpcError {
+        RpcError::AlloyRpcError(AlloyRpcError::<TransportErrorKind>::ErrorResp(ErrorPayload {
+            code,
+            message: Cow::Borrowed(message),
+            data: None,
+        }))
+    }
 
     fn converge_limit(cap: u64, allowed_limit: u64) -> LogBlockRangeLimit {
         let mut range_limit = LogBlockRangeLimit::new(cap);
@@ -806,6 +823,78 @@ mod tests {
         assert!(!update.retry);
         assert!(update.warn_single_block);
         assert_eq!(range_limit.current(), 1);
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_matches_geth_response() {
+        // Message source:
+        // https://github.com/ethereum/go-ethereum/blob/7e625dd54822499d7fece76de9850377d65957c4/eth/filters/filter.go#L148-L149
+        // Error code source:
+        // https://github.com/ethereum/go-ethereum/blob/7e625dd54822499d7fece76de9850377d65957c4/eth/filters/api.go#L54-L55
+        let error = rpc_error_response(-32602, "exceed maximum block range 5000");
+
+        assert!(is_log_block_range_limit_error(&error));
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_matches_nethermind_response() {
+        // Message source:
+        // https://github.com/NethermindEth/nethermind/blob/5de23f52669f8ef08a67e2ff4a2c87bf75b5a66c/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs#L1193-L1206
+        // Error code source:
+        // https://github.com/NethermindEth/nethermind/blob/5de23f52669f8ef08a67e2ff4a2c87bf75b5a66c/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs#L30-L33
+        let error = rpc_error_response(
+            -32602,
+            "Block range 1001 exceeds the maximum of 1000 blocks per logs request. Use a narrower fromBlock/toBlock \
+             range or increase Receipt.MaxBlockDepth.",
+        );
+
+        assert!(is_log_block_range_limit_error(&error));
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_matches_reth_response() {
+        // Limit check source:
+        // https://github.com/paradigmxyz/reth/blob/3d76b93c243f8896f13a39ee865f87241fcd649b/crates/rpc/rpc/src/eth/filter.rs#L638-L642
+        // Message and error code source:
+        // https://github.com/paradigmxyz/reth/blob/3d76b93c243f8896f13a39ee865f87241fcd649b/crates/rpc/rpc/src/eth/filter.rs#L958-L995
+        let error = rpc_error_response(-32602, "query exceeds max block range 1000");
+
+        assert!(is_log_block_range_limit_error(&error));
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_matches_erigon_response() {
+        // Message source:
+        // https://github.com/erigontech/erigon/blob/f1d79d699ed4b809abc0d177dcb539d8605edc41/rpc/jsonrpc/eth_receipts.go#L298-L305
+        // Error code source:
+        // https://github.com/erigontech/erigon/blob/f1d79d699ed4b809abc0d177dcb539d8605edc41/rpc/errors.go#L51-L103
+        let error = rpc_error_response(
+            -32602,
+            "query block range exceeds server limit, narrow your filter: 1000",
+        );
+
+        assert!(is_log_block_range_limit_error(&error));
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_rejects_unrelated_limit_errors() {
+        for error in [
+            rpc_error_response(-32602, "Block gas limit exceeded"),
+            rpc_error_response(-32005, "Too many requests"),
+            rpc_error_response(-32602, "block range extends beyond current head block"),
+        ] {
+            assert!(!is_log_block_range_limit_error(&error));
+        }
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_rejects_unexpected_error_codes() {
+        for error in [
+            rpc_error_response(-32000, "query exceeds max block range 1000"),
+            rpc_error_response(429, "query exceeds max block range 1000"),
+        ] {
+            assert!(!is_log_block_range_limit_error(&error));
+        }
     }
 
     // NOTE: This test is commented out because check_node_safe_module_status() method is commented out

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -2,7 +2,10 @@
 //!
 //! The purpose of this module is to give implementation of the [HoprRpcOperations] trait:
 //! [RpcOperations] type, which is the main API exposed by this crate.
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use blokli_chain_types::{AlloyAddressExt, ContractAddresses, ContractInstances};
@@ -24,7 +27,7 @@ use hopr_types::{
     primitive::prelude::*,
 };
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::{debug, warn};
 use url::Url;
 use validator::Validate;
 
@@ -60,6 +63,9 @@ sol!(
 /// Default gas oracle URL for Gnosis chain.
 pub const DEFAULT_GAS_ORACLE_URL: &str = "https://ggnosis.blockscan.com/gasapi.ashx?apikey=key&method=gasoracle";
 
+/// Default upper bound for adaptive `eth_getLogs` block range discovery.
+pub const DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP: u64 = 10_000;
+
 /// Configuration of the RPC related parameters.
 #[derive(Clone, Debug, PartialEq, Eq, smart_default::SmartDefault, Serialize, Deserialize, Validate)]
 pub struct RpcOperationsConfig {
@@ -77,12 +83,13 @@ pub struct RpcOperationsConfig {
     /// Defaults to 5 seconds
     #[default(Duration::from_secs(5))]
     pub expected_block_time: Duration,
-    /// The largest amount of blocks to fetch at once when fetching a range of blocks.
+    /// The upper bound for adaptive log block range fetching.
     ///
-    /// If the requested block range size is N, then the client will always fetch `min(N, max_block_range_fetch_size)`
+    /// The RPC layer learns the effective value from real `eth_getLogs` requests and never requests more than this
+    /// configured ceiling. A value of `0` uses [`DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP`] as the ceiling.
     ///
     /// Defaults to 2000 blocks
-    #[validate(range(min = 1))]
+    #[validate(range(min = 0))]
     #[default = 2000]
     pub max_block_range_fetch_size: u64,
     /// Interval for polling on TX submission
@@ -150,12 +157,167 @@ pub(crate) type HoprProvider<R> = FillProvider<
     RootProvider,
 >;
 
+#[derive(Debug)]
+pub(crate) struct LogBlockRangeLimit {
+    cap: u64,
+    candidate: u64,
+    last_working: u64,
+    first_failing: Option<u64>,
+    stable: Option<u64>,
+    warned_single_block: bool,
+}
+
+impl LogBlockRangeLimit {
+    fn new(configured_cap: u64) -> Self {
+        let cap = sanitize_log_block_range_cap(configured_cap);
+
+        Self {
+            cap,
+            candidate: cap,
+            last_working: 0,
+            first_failing: None,
+            stable: None,
+            warned_single_block: false,
+        }
+    }
+
+    fn current(&self) -> u64 {
+        self.stable.unwrap_or(self.candidate).clamp(1, self.cap)
+    }
+
+    fn record_success(&mut self, requested_span: u64, attempted_limit: u64) -> Option<u64> {
+        if requested_span == 0 {
+            return self.stable;
+        }
+
+        match self.first_failing {
+            Some(first_failing) if requested_span < first_failing => {
+                self.last_working = self.last_working.max(requested_span);
+
+                if self.last_working + 1 >= first_failing {
+                    let stable = self.last_working.max(1);
+                    self.stable = Some(stable);
+                    self.candidate = stable;
+                } else if requested_span == attempted_limit {
+                    self.candidate = next_probe(self.last_working, first_failing);
+                }
+            }
+            Some(_) => {}
+            None if requested_span == attempted_limit && attempted_limit >= self.cap => {
+                self.last_working = self.cap;
+                self.stable = Some(self.cap);
+                self.candidate = self.cap;
+            }
+            None => {
+                self.last_working = self.last_working.max(requested_span);
+            }
+        }
+
+        self.stable
+    }
+
+    fn record_failure(&mut self, requested_span: u64) -> LogBlockRangeFailureUpdate {
+        let failed_span = requested_span.max(1).min(self.cap);
+
+        if failed_span <= 1 {
+            self.first_failing = Some(1);
+            self.stable = Some(1);
+            self.candidate = 1;
+            self.last_working = 0;
+
+            let warn_single_block = !self.warned_single_block;
+            self.warned_single_block = true;
+
+            return LogBlockRangeFailureUpdate {
+                next_limit: 1,
+                retry: false,
+                warn_single_block,
+            };
+        }
+
+        if self.stable.is_some() || self.last_working >= failed_span {
+            self.last_working = 0;
+        }
+
+        self.stable = None;
+        self.first_failing = Some(
+            self.first_failing
+                .map_or(failed_span, |first_failing| first_failing.min(failed_span)),
+        );
+
+        if let Some(first_failing) = self.first_failing {
+            self.candidate = next_probe(self.last_working, first_failing);
+        }
+
+        LogBlockRangeFailureUpdate {
+            next_limit: self.current(),
+            retry: self.current() < failed_span,
+            warn_single_block: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LogBlockRangeFailureUpdate {
+    pub next_limit: u64,
+    pub retry: bool,
+    pub warn_single_block: bool,
+}
+
+fn sanitize_log_block_range_cap(configured_cap: u64) -> u64 {
+    if configured_cap == 0 {
+        DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP
+    } else {
+        configured_cap
+    }
+}
+
+fn next_probe(last_working: u64, first_failing: u64) -> u64 {
+    if last_working + 1 >= first_failing {
+        last_working.max(1)
+    } else {
+        (last_working + ((first_failing - last_working) / 2)).max(1)
+    }
+}
+
+fn message_indicates_log_range_limit(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    let mentions_limit = message.contains("limit")
+        || message.contains("exceed")
+        || message.contains("too many")
+        || message.contains("too large")
+        || message.contains("too wide")
+        || message.contains("more than")
+        || message.contains("maximum")
+        || message.contains("response size");
+    let mentions_logs_or_blocks = message.contains("log") || message.contains("block") || message.contains("result");
+    let mentions_range = message.contains("range") || message.contains("block") || message.contains("eth_getlogs");
+
+    mentions_limit && mentions_logs_or_blocks && mentions_range
+}
+
+pub(crate) fn is_log_block_range_limit_error(error: &RpcError) -> bool {
+    let RpcError::AlloyRpcError(error) = error else {
+        return false;
+    };
+
+    if let Some(error_payload) = error.as_error_resp() {
+        let known_range_limit_code = matches!(error_payload.code, -32005 | -32016 | 429);
+
+        return message_indicates_log_range_limit(&error_payload.message)
+            || (known_range_limit_code && message_indicates_log_range_limit(&error_payload.to_string()));
+    }
+
+    message_indicates_log_range_limit(&error.to_string())
+}
+
 /// Implementation of `HoprRpcOperations` and `HoprIndexerRpcOperations` trait via `alloy`
 #[derive(Debug, Clone)]
 pub struct RpcOperations<R: HttpRequestor + 'static + Clone> {
     pub provider: Arc<HoprProvider<R>>,
     pub(crate) cfg: RpcOperationsConfig,
     contract_instances: Arc<ContractInstances<HoprProvider<R>>>,
+    log_block_range_limit: Arc<Mutex<LogBlockRangeLimit>>,
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -193,6 +355,7 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
                 provider.clone(),
                 use_dummy_nr.unwrap_or(cfg!(test)),
             )),
+            log_block_range_limit: Arc::new(Mutex::new(LogBlockRangeLimit::new(cfg.max_block_range_fetch_size))),
             cfg,
             provider: Arc::new(provider),
         })
@@ -381,6 +544,63 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
     }
 }
 
+impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
+    pub(crate) fn log_block_range_limit(&self) -> u64 {
+        self.with_log_block_range_limit(|range_limit| range_limit.current())
+    }
+
+    pub(crate) fn record_log_block_range_success(&self, requested_span: u64, attempted_limit: u64) {
+        let stable =
+            self.with_log_block_range_limit(|range_limit| range_limit.record_success(requested_span, attempted_limit));
+
+        if let Some(stable) = stable {
+            debug!(
+                stable_block_range = stable,
+                configured_cap = sanitize_log_block_range_cap(self.cfg.max_block_range_fetch_size),
+                "using stable RPC log block range limit"
+            );
+        }
+    }
+
+    pub(crate) fn record_log_block_range_failure(
+        &self,
+        requested_span: u64,
+        error: &RpcError,
+    ) -> LogBlockRangeFailureUpdate {
+        let update = self.with_log_block_range_limit(|range_limit| range_limit.record_failure(requested_span));
+
+        if update.warn_single_block {
+            warn!(
+                error = %error,
+                "RPC rejected a single-block eth_getLogs request; continuing in single-block mode, but this mode of \
+                 operation is very slow"
+            );
+        } else {
+            warn!(
+                failed_block_range = requested_span,
+                next_block_range = update.next_limit,
+                error = %error,
+                "RPC rejected eth_getLogs block range; adapting block range limit"
+            );
+        }
+
+        update
+    }
+
+    fn with_log_block_range_limit<T, F>(&self, action: F) -> T
+    where
+        F: FnOnce(&mut LogBlockRangeLimit) -> T,
+    {
+        match self.log_block_range_limit.lock() {
+            Ok(mut guard) => action(&mut guard),
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                action(&mut guard)
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl<R: HttpRequestor + 'static + Clone> HoprRpcOperations for RpcOperations<R> {
     async fn get_timestamp(&self, block_number: u64) -> Result<Option<u64>> {
@@ -511,6 +731,83 @@ impl<R: HttpRequestor + 'static + Clone> HoprRpcOperations for RpcOperations<R> 
 
 #[cfg(test)]
 mod tests {
+    use super::{DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP, LogBlockRangeLimit};
+
+    fn converge_limit(cap: u64, allowed_limit: u64) -> LogBlockRangeLimit {
+        let mut range_limit = LogBlockRangeLimit::new(cap);
+
+        for _ in 0..64 {
+            let candidate = range_limit.current();
+
+            if candidate <= allowed_limit {
+                range_limit.record_success(candidate, candidate);
+            } else {
+                range_limit.record_failure(candidate);
+            }
+
+            if range_limit.stable == Some(allowed_limit) {
+                return range_limit;
+            }
+        }
+
+        panic!("range limit did not converge to {allowed_limit}");
+    }
+
+    #[test]
+    fn test_log_block_range_limit_uses_default_cap_for_zero_config() {
+        let range_limit = LogBlockRangeLimit::new(0);
+
+        assert_eq!(range_limit.current(), DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP);
+    }
+
+    #[test]
+    fn test_log_block_range_limit_converges_to_allowed_limits() {
+        for allowed_limit in [10_000, 5_000, 1_024, 100, 1] {
+            let range_limit = converge_limit(10_000, allowed_limit);
+
+            assert_eq!(range_limit.current(), allowed_limit);
+            assert_eq!(range_limit.stable, Some(allowed_limit));
+        }
+    }
+
+    #[test]
+    fn test_log_block_range_limit_downshifts_after_stable_failure() {
+        let mut range_limit = converge_limit(10_000, 100);
+
+        assert_eq!(range_limit.current(), 100);
+
+        let update = range_limit.record_failure(100);
+        assert!(update.retry);
+        assert!(update.next_limit < 100);
+
+        for _ in 0..64 {
+            let candidate = range_limit.current();
+
+            if candidate <= 50 {
+                range_limit.record_success(candidate, candidate);
+            } else {
+                range_limit.record_failure(candidate);
+            }
+
+            if range_limit.stable == Some(50) {
+                break;
+            }
+        }
+
+        assert_eq!(range_limit.current(), 50);
+        assert_eq!(range_limit.stable, Some(50));
+    }
+
+    #[test]
+    fn test_log_block_range_limit_single_block_failure_keeps_single_block_mode() {
+        let mut range_limit = LogBlockRangeLimit::new(10_000);
+        let update = range_limit.record_failure(1);
+
+        assert!(!update.retry);
+        assert!(update.warn_single_block);
+        assert_eq!(range_limit.current(), 1);
+    }
+
     // NOTE: This test is commented out because check_node_safe_module_status() method is commented out
     // and the helper functions deploy_one_safe_one_module_and_setup_for_testing and include_node_to_module_by_safe
     // are no longer available in blokli_chain_types

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -186,8 +186,10 @@ impl LogBlockRangeLimit {
     }
 
     fn record_success(&mut self, requested_span: u64, attempted_limit: u64) -> Option<u64> {
+        let previous_stable = self.stable;
+
         if requested_span == 0 {
-            return self.stable;
+            return None;
         }
 
         match self.first_failing {
@@ -213,7 +215,11 @@ impl LogBlockRangeLimit {
             }
         }
 
-        self.stable
+        if self.stable != previous_stable {
+            self.stable
+        } else {
+            None
+        }
     }
 
     fn record_failure(&mut self, requested_span: u64) -> LogBlockRangeFailureUpdate {
@@ -293,6 +299,8 @@ fn message_indicates_known_log_range_limit(message: &str) -> bool {
         || message.contains("too many logs requested. max logs per response is")
         || (message.contains("query exceeds max results") && message.contains("retry with the range"))
         || message.contains("query returns too many logs, narrow your filter")
+        || message.contains("query returned more than 10000 results")
+        || message.contains("log response size exceeded")
 }
 
 fn is_known_log_range_limit_code(code: i64) -> bool {
@@ -788,6 +796,14 @@ mod tests {
     }
 
     #[test]
+    fn test_log_block_range_limit_reports_stable_limit_once() {
+        let mut range_limit = LogBlockRangeLimit::new(10_000);
+
+        assert_eq!(range_limit.record_success(10_000, 10_000), Some(10_000));
+        assert_eq!(range_limit.record_success(10_000, 10_000), None);
+    }
+
+    #[test]
     fn test_log_block_range_limit_downshifts_after_stable_failure() {
         let mut range_limit = converge_limit(10_000, 100);
 
@@ -872,6 +888,20 @@ mod tests {
             -32602,
             "query block range exceeds server limit, narrow your filter: 1000",
         );
+
+        assert!(is_log_block_range_limit_error(&error));
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_matches_infura_response() {
+        let error = rpc_error_response(-32005, "query returned more than 10000 results");
+
+        assert!(is_log_block_range_limit_error(&error));
+    }
+
+    #[test]
+    fn test_log_block_range_limit_error_matches_alchemy_response() {
+        let error = rpc_error_response(-32602, "Log response size exceeded");
 
         assert!(is_log_block_range_limit_error(&error));
     }

--- a/chain/types/src/lib.rs
+++ b/chain/types/src/lib.rs
@@ -81,7 +81,7 @@ pub struct ChainConfig {
     pub tx_polling_interval: u64,
     /// Number of confirmations required (finality)
     pub confirmations: u16,
-    /// Maximum block range for RPC queries
+    /// Maximum block range ceiling for adaptive RPC log queries
     pub max_block_range: u32,
     /// Starting block number for channel contract (where indexing should begin)
     pub channel_contract_deploy_block: u32,

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -353,7 +353,13 @@ transaction signatures are verified by Ethereum consensus—only successfully mi
 recovered from the transaction's ECDSA signature by the blockchain itself.
 
 **Configuration Parameters**: The RPC layer is configured with network-specific parameters including chain ID, contract addresses, expected
-block time for polling intervals, transaction polling configuration, finality depth, and maximum block range for batch fetching.
+block time for polling intervals, transaction polling configuration, finality depth, and a maximum block range ceiling for log fetching.
+
+**Adaptive Log Range Discovery**: The configured log block range is a ceiling, not a fixed request size. The RPC layer treats real
+`eth_getLogs` requests as observations: it starts with the ceiling, records successful ranges, records rejected ranges, and uses binary
+search to converge on the largest working range. Once a stable range is found, it is reused continuously. If the endpoint later rejects that
+stable range, the previous result is discarded and the same request-driven search moves downward again. If even single-block log requests
+are rejected, the RPC layer stays in single-block mode and surfaces the underlying RPC error while warning that this mode is very slow.
 
 **Retry Strategy**: Implements exponential backoff with jitter for transient failures, distinguishes between retryable errors (network, rate
 limit) and non-retryable errors (invalid transaction), and respects rate limits through request throttling.
@@ -1198,7 +1204,8 @@ Lightweight deployment using SQLite with separated databases:
 **Optimization Strategies**:
 
 - **Fast Sync via Snapshots**: Reduces initial sync from hours to minutes by importing pre-indexed logs database
-- **Batch Log Fetching**: Configurable block range size balances memory usage with RPC call overhead
+- **Adaptive Batch Log Fetching**: Configurable block range ceiling bounds RPC load while request-driven discovery learns the endpoint's
+  current usable range
 - **Dual Database Mode**: Separates high-volume log writes from indexed state reads (SQLite)
 - **Async Event Processing**: Pipeline stages run concurrently where possible
 - **Position-based Deduplication**: Prevents reprocessing same events after restart


### PR DESCRIPTION
Fixes #98 

This PR turns the static block range into an adaptive block range which uses the user-configured value as the max ceiling. The algorithm uses existing get logs calls to find the optimal, highest range the RPC supports.