### PR TITLE
fix(ci): remove old release workflow parameters

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,8 +76,6 @@ jobs:
       build_file: bloklid/Cargo.toml
       docker_image_name: bloklid
       docker_image_format: skopeo
-      deployment_namespace: blokli
-      deployment_label_selector: app.kubernetes.io/name=blokli
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       docker_hub_username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
When updating the release workflow, some parameter that were used before are not accepted by the shared workflow anymore. 