### PR TITLE
chore: bump cargo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/bloklid/Cargo.toml
+++ b/bloklid/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "bloklid"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.11.1"
+version     = "0.12.0"
 
 [features]
 default = ["runtime-tokio"]


### PR DESCRIPTION
Bumps the version of blokli before cutting a new release.