### PR TITLE
fix: bump nix-lib version to 1.2.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,16 +173,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1774276825,
-        "narHash": "sha256-IV3mmWG5VvrP823sn5MBprMOe3ONKdMr9mc6LzFgGYM=",
+        "lastModified": 1784545056,
+        "narHash": "sha256-XRH+8gjAYGu6dBxF/EZboZy4roTWUXtvkGUeqk2fWng=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "42a9dba36c23f39301cc0d8b1c13be871e1964c6",
+        "rev": "988ad8fa02c7d7a253ab47e7e9b8cfe381cdafc8",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
-        "ref": "v1.1.0",
+        "ref": "v1.2.0",
         "repo": "nix-lib",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/v1.1.0";
+    nix-lib.url = "github:hoprnet/nix-lib/v1.2.0";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";


### PR DESCRIPTION
Bumps the nix-lib vesrion to 1.2.0.
This should help to get the release workflow to work properly