### PR TITLE
fix: wipe the db completly to fix migrations mis-alignement

### DIFF
--- a/db/core/src/version.rs
+++ b/db/core/src/version.rs
@@ -28,8 +28,8 @@ use crate::errors::{DbSqlError, Result};
 /// Version history:
 /// - `"1.1.0"`: Initial schema (consolidated from prior migration stack)
 /// - `"1.2.0"`:
-/// - `"1.3.0"`: SC set updated through a binding update.
-pub const SCHEMA_VERSION: &str = "1.3.0";
+/// - `"2.0.0"`: SC set updated through a binding update.
+pub const SCHEMA_VERSION: &str = "2.0.0";
 
 /// The singleton ID used for the schema_version table.
 const SCHEMA_VERSION_TABLE_ID: i64 = 1;


### PR DESCRIPTION
Upon deployment of the new version of blokli, the migrations needs to be wiped completely actually, to get rid of the inconsistency between the migrations from the release branch, and the one from the main branch.
