### PR TITLE
fix: optimize channel and account queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "blokli-db-migration"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "hopr-types",
  "sea-orm",

--- a/db/migration/Cargo.toml
+++ b/db/migration/Cargo.toml
@@ -6,7 +6,7 @@ license     = "GPL-3.0-only"
 name        = "blokli-db-migration"
 publish     = false
 repository  = "https://github.com/hoprnet/blokli"
-version     = "0.12.1"
+version     = "0.12.2"
 
 [features]
 default = ["sqlite"]

--- a/db/migration/src/lib.rs
+++ b/db/migration/src/lib.rs
@@ -5,6 +5,7 @@ mod m001_initial_schema;
 mod m002_initial_log_schema;
 mod m003_safe_history_schema;
 mod m004_safe_redeemed_stats_rejections;
+mod m005_optimize_current_views;
 
 /// This is a special block ID that even pre-dates the v3 contract deployment on Gnosis chain,
 /// and therefore could be safely used to mark data added via the migration.
@@ -39,6 +40,7 @@ impl<const NETWORK: u8> Migrator<NETWORK> {
             Box::new(m002_initial_log_schema::Migration),
             Box::new(m003_safe_history_schema::Migration),
             Box::new(m004_safe_redeemed_stats_rejections::Migration),
+            Box::new(m005_optimize_current_views::Migration),
         ]
     }
 }
@@ -70,6 +72,7 @@ impl<const NETWORK: u8> MigratorIndex<NETWORK> {
             Box::new(m001_initial_schema::Migration),
             Box::new(m003_safe_history_schema::Migration),
             Box::new(m004_safe_redeemed_stats_rejections::Migration),
+            Box::new(m005_optimize_current_views::Migration),
         ]
     }
 }

--- a/db/migration/src/m005_optimize_current_views.rs
+++ b/db/migration/src/m005_optimize_current_views.rs
@@ -1,0 +1,180 @@
+use sea_orm_migration::prelude::*;
+
+/// Rewrites the `channel_current` and `account_current` views to use a
+/// correlated `ORDER BY ... LIMIT 1` subquery instead of a
+/// `ROW_NUMBER() OVER (PARTITION BY ...)` window function.
+///
+/// The window-function form acts as an optimization fence: a predicate such as
+/// `WHERE concrete_channel_id = $1` cannot be pushed into the windowed subquery,
+/// so PostgreSQL scans and sorts the *entire* `channel_state` / `account_state`
+/// table on every single-row lookup. As those tables grow this shows up as
+/// multi-second "slow statement" warnings.
+///
+/// The correlated form (mirroring `safe_contract_current`) lets the planner
+/// resolve the parent row via its unique index and satisfy the subquery with an
+/// index scan on `idx_channel_state_position` / `idx_account_state_position`,
+/// turning full-table sorts into O(log n) lookups. It is portable across
+/// PostgreSQL and SQLite.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+
+        // SQLite does not support `CREATE OR REPLACE VIEW`, so drop first.
+        if backend != sea_orm::DatabaseBackend::Postgres {
+            manager
+                .get_connection()
+                .execute_unprepared("DROP VIEW IF EXISTS channel_current")
+                .await?;
+            manager
+                .get_connection()
+                .execute_unprepared("DROP VIEW IF EXISTS account_current")
+                .await?;
+        }
+
+        let create_view = if backend == sea_orm::DatabaseBackend::Postgres {
+            "CREATE OR REPLACE VIEW"
+        } else {
+            "CREATE VIEW IF NOT EXISTS"
+        };
+
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "{create_view} channel_current AS
+                SELECT
+                    cs.id,
+                    c.id AS channel_id,
+                    c.concrete_channel_id,
+                    c.source,
+                    c.destination,
+                    cs.balance,
+                    cs.status,
+                    cs.epoch,
+                    cs.ticket_index,
+                    cs.closure_time,
+                    cs.corrupted_state,
+                    cs.published_block,
+                    cs.published_tx_index,
+                    cs.published_log_index,
+                    cs.reorg_correction
+                FROM channel c
+                JOIN channel_state cs ON cs.channel_id = c.id
+                WHERE cs.id = (
+                    SELECT s2.id FROM channel_state s2
+                    WHERE s2.channel_id = c.id
+                    ORDER BY s2.published_block DESC, s2.published_tx_index DESC, s2.published_log_index DESC
+                    LIMIT 1
+                )"
+            ))
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "{create_view} account_current AS
+                SELECT
+                    acs.id,
+                    a.id AS account_id,
+                    a.chain_key,
+                    a.packet_key,
+                    acs.safe_address,
+                    acs.published_block,
+                    acs.published_tx_index,
+                    acs.published_log_index
+                FROM account a
+                JOIN account_state acs ON acs.account_id = a.id
+                WHERE acs.id = (
+                    SELECT s2.id FROM account_state s2
+                    WHERE s2.account_id = a.id
+                    ORDER BY s2.published_block DESC, s2.published_tx_index DESC, s2.published_log_index DESC
+                    LIMIT 1
+                )"
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+
+        if backend != sea_orm::DatabaseBackend::Postgres {
+            manager
+                .get_connection()
+                .execute_unprepared("DROP VIEW IF EXISTS channel_current")
+                .await?;
+            manager
+                .get_connection()
+                .execute_unprepared("DROP VIEW IF EXISTS account_current")
+                .await?;
+        }
+
+        let create_view = if backend == sea_orm::DatabaseBackend::Postgres {
+            "CREATE OR REPLACE VIEW"
+        } else {
+            "CREATE VIEW IF NOT EXISTS"
+        };
+
+        // Restore the original window-function definitions from m001.
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "{create_view} channel_current AS
+                SELECT
+                    s.id,
+                    c.id AS channel_id,
+                    c.concrete_channel_id,
+                    c.source,
+                    c.destination,
+                    s.balance,
+                    s.status,
+                    s.epoch,
+                    s.ticket_index,
+                    s.closure_time,
+                    s.corrupted_state,
+                    s.published_block,
+                    s.published_tx_index,
+                    s.published_log_index,
+                    s.reorg_correction
+                FROM channel c
+                JOIN (
+                    SELECT cs.*, ROW_NUMBER() OVER (
+                        PARTITION BY cs.channel_id
+                        ORDER BY cs.published_block DESC, cs.published_tx_index DESC, cs.published_log_index DESC
+                    ) AS rn
+                    FROM channel_state cs
+                ) s ON s.channel_id = c.id AND s.rn = 1"
+            ))
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "{create_view} account_current AS
+                SELECT
+                    s.id,
+                    a.id AS account_id,
+                    a.chain_key,
+                    a.packet_key,
+                    s.safe_address,
+                    s.published_block,
+                    s.published_tx_index,
+                    s.published_log_index
+                FROM account a
+                JOIN (
+                    SELECT acs.*, ROW_NUMBER() OVER (
+                        PARTITION BY acs.account_id
+                        ORDER BY acs.published_block DESC, acs.published_tx_index DESC, acs.published_log_index DESC
+                    ) AS rn
+                    FROM account_state acs
+                ) s ON s.account_id = a.id AND s.rn = 1"
+            ))
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
*Porting the changes from https://github.com/hoprnet/blokli/pull/402*

Production logs showed frequent `slow statement` warnings for a simple single-row lookup, with times climbing over time (1.75s → 3.05s):

```sql
SELECT ... FROM channel_current WHERE concrete_channel_id = $1
```

### Root cause

Not a missing index — the relevant indexes already exist (`concrete_channel_id` unique, `idx_channel_state_position`).

The views selected the latest state per row using `ROW_NUMBER() OVER (PARTITION BY ...)`. A window function is an **optimization fence**: PostgreSQL can't push the `WHERE concrete_channel_id = $1` predicate into the windowed subquery, so every lookup scans + sorts the **entire** `channel_state` table before filtering to one row. Cost scales with table size, not the row fetched.

### Fix

New migration `m005_optimize_current_views` rewrites both views with a correlated `ORDER BY ... LIMIT 1` subquery (the pattern already used by `safe_contract_current`):

```sql
FROM channel c
JOIN channel_state cs ON cs.channel_id = c.id
WHERE cs.id = (
    SELECT s2.id FROM channel_state s2
    WHERE s2.channel_id = c.id
    ORDER BY s2.published_block DESC, s2.published_tx_index DESC, s2.published_log_index DESC
    LIMIT 1
)
```

The planner now resolves the parent via its unique index and hits `idx_channel_state_position` for the subquery — O(log n) instead of a full-table sort.
