### PR TITLE
feat(ci): improve Nix caching and consolidate Rust checks

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -23,7 +23,7 @@ jobs:
       enable_unit_tests: false
       enable_integration_tests: false
       enable_unit_coverage: true
-      unit_coverage_command: "nix run .#coverage-unit"
+      unit_coverage_command: "nix build -L .#bloklid-coverage -o coverage.lcov"
       runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -105,7 +105,7 @@ jobs:
       enable_unit_tests: true
       unit_test_command: "nix build -L .#bloklid-nextest"
       enable_unit_coverage: true
-      unit_coverage_command: "nix run .#coverage-unit"
+      unit_coverage_command: "nix build -L .#bloklid-coverage -o coverage.lcov"
       runner_unit: depot-ubuntu-24.04-4
       test_timeout: 30
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -102,8 +102,7 @@ jobs:
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       cachix_cache_name: blokli
-      enable_unit_tests: true
-      unit_test_command: "nix build -L .#bloklid-nextest"
+      enable_unit_tests: false
       enable_unit_coverage: true
       unit_coverage_command: "nix build -L .#bloklid-coverage -o coverage.lcov"
       runner_unit: depot-ubuntu-24.04-4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       cachix_cache_name: blokli
-      lint_command: "nix develop --command just quick"
+      lint_command: "nix build -L .#bloklid-clippy"
       audit_command: "nix run -L .#audit"
       deps: true
       runner_small: depot-ubuntu-24.04-2
@@ -127,10 +127,8 @@ jobs:
         with:
           cachix_cache_name: blokli
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Generate GraphQL schema
-        run: nix develop --command just export-schema-sqlite
-      - name: Validate schema against target
-        run: nix develop --command uv run scripts/check_schema.py
+      - name: Validate GraphQL schema
+        run: nix build -L .#schema-validation
   # ── Build: binaries ─────────────────────────────────────────────────────────
   build-binaries:
     name: Binary ${{ matrix.architecture }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -103,7 +103,7 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       cachix_cache_name: blokli
       enable_unit_tests: true
-      unit_test_command: "nix run -L .#nextest"
+      unit_test_command: "nix build -L .#bloklid-nextest"
       enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
       runner_unit: depot-ubuntu-24.04-4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
       id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@ade4bbd75f7204255c61d19c23f67d3da221e7d2 # release-version-v5.1.1
+        uses: hoprnet/hopr-workflows/actions/release-version@711c81d05909e2482d74289084502fb70fecc97b # release-version-v5.3.0
         with:
           source_branch: ${{ github.ref_name }}
           file: bloklid/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,13 @@ strip         = true
 [profile.test]
 opt-level = 1
 
+# CI keeps line-level backtraces while avoiding large incremental and full
+# debug-info artifacts in the Nix binary cache.
+[profile.ci-test]
+debug       = 1
+incremental = false
+inherits    = "test"
+
 # this profile focuses on the best runtime performance and the smallest binary size
 [profile.release]
 codegen-units = 1

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -11,9 +11,6 @@
 //!
 //! Tests can use this shared setup to ensure consistency and reduce maintenance burden.
 
-#[cfg(test)]
-mod test_common;
-
 use std::{sync::Arc, time::Duration};
 
 use async_graphql::Schema;

--- a/api/tests/common_test.rs
+++ b/api/tests/common_test.rs
@@ -3,7 +3,11 @@
 //! These tests verify that the shared test setup functions work correctly
 //! and provide the expected components for API integration testing.
 
-use super::*;
+mod common;
+
+use std::time::Duration;
+
+use common::{TestEnvironmentConfig, setup_simple_test_environment, setup_test_environment};
 
 /// Test that setup_test_environment creates all required components
 #[test_log::test(tokio::test)]

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785330200,
-        "narHash": "sha256-bseaFE1mb7f5sgq137ow2TYUsArWsR5jZwY8mr1+jyo=",
+        "lastModified": 1785333146,
+        "narHash": "sha256-dOy1uXpfNeb6diunuAv8D1F8C6cqsOewi2WRv80MMXI=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "3730beb66a991585d08105be234e3720fcd268d2",
+        "rev": "2573ddf8f54a9b18c175ffc9cdd77f73dc9b092d",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "3730beb66a991585d08105be234e3720fcd268d2",
+        "rev": "2573ddf8f54a9b18c175ffc9cdd77f73dc9b092d",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785333146,
-        "narHash": "sha256-dOy1uXpfNeb6diunuAv8D1F8C6cqsOewi2WRv80MMXI=",
+        "lastModified": 1785336630,
+        "narHash": "sha256-xXOyWF8zHVcgGzwdiWDuDX1ki24qbHqZjNLrQkk39yM=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "2573ddf8f54a9b18c175ffc9cdd77f73dc9b092d",
+        "rev": "17ed79793f2e86570f9619555435d861473a5d91",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "2573ddf8f54a9b18c175ffc9cdd77f73dc9b092d",
+        "rev": "17ed79793f2e86570f9619555435d861473a5d91",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784545056,
-        "narHash": "sha256-XRH+8gjAYGu6dBxF/EZboZy4roTWUXtvkGUeqk2fWng=",
+        "lastModified": 1785313685,
+        "narHash": "sha256-TExMnh9PA8UjHSvrMmaueJmbFI/0KXTsn3pVKnzHwRM=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "988ad8fa02c7d7a253ab47e7e9b8cfe381cdafc8",
+        "rev": "6abec1485d0829971bf50a06347d54acd889c6b6",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
-        "ref": "v1.2.0",
         "repo": "nix-lib",
+        "rev": "6abec1485d0829971bf50a06347d54acd889c6b6",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785326491,
-        "narHash": "sha256-BYVzVEngTK2MwAv9gqiE8beDk82/pHhXnGjLw2h0un0=",
+        "lastModified": 1785330200,
+        "narHash": "sha256-bseaFE1mb7f5sgq137ow2TYUsArWsR5jZwY8mr1+jyo=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "e9c4ee91049da0f4abe7e11c4a70001da569428a",
+        "rev": "3730beb66a991585d08105be234e3720fcd268d2",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "e9c4ee91049da0f4abe7e11c4a70001da569428a",
+        "rev": "3730beb66a991585d08105be234e3720fcd268d2",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785316054,
-        "narHash": "sha256-h7ytTrjDYbvecUJw7hJ7ILiUaqlsTTd7an+jaU4+te0=",
+        "lastModified": 1785322375,
+        "narHash": "sha256-dbjOuoIJR56vYTr0ne+T0uE8E/+id4uXEPXuSIw8BLc=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "41b6b431e2d7f5605e6b2556bd7f8d8678b0c116",
+        "rev": "7f88b05c8375375eaff4bd4670ce45d47e0ccea7",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "41b6b431e2d7f5605e6b2556bd7f8d8678b0c116",
+        "rev": "7f88b05c8375375eaff4bd4670ce45d47e0ccea7",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785336630,
+        "lastModified": 1785412696,
         "narHash": "sha256-xXOyWF8zHVcgGzwdiWDuDX1ki24qbHqZjNLrQkk39yM=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "17ed79793f2e86570f9619555435d861473a5d91",
+        "rev": "e4d33e7c4ebc9ce3797a61b1e81fb06bab3dbac4",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
+        "ref": "v1.3.0",
         "repo": "nix-lib",
-        "rev": "17ed79793f2e86570f9619555435d861473a5d91",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785313685,
-        "narHash": "sha256-TExMnh9PA8UjHSvrMmaueJmbFI/0KXTsn3pVKnzHwRM=",
+        "lastModified": 1785316054,
+        "narHash": "sha256-h7ytTrjDYbvecUJw7hJ7ILiUaqlsTTd7an+jaU4+te0=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "6abec1485d0829971bf50a06347d54acd889c6b6",
+        "rev": "41b6b431e2d7f5605e6b2556bd7f8d8678b0c116",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "6abec1485d0829971bf50a06347d54acd889c6b6",
+        "rev": "41b6b431e2d7f5605e6b2556bd7f8d8678b0c116",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -173,17 +173,17 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785322375,
-        "narHash": "sha256-dbjOuoIJR56vYTr0ne+T0uE8E/+id4uXEPXuSIw8BLc=",
+        "lastModified": 1785326491,
+        "narHash": "sha256-BYVzVEngTK2MwAv9gqiE8beDk82/pHhXnGjLw2h0un0=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "7f88b05c8375375eaff4bd4670ce45d47e0ccea7",
+        "rev": "e9c4ee91049da0f4abe7e11c4a70001da569428a",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "7f88b05c8375375eaff4bd4670ce45d47e0ccea7",
+        "rev": "e9c4ee91049da0f4abe7e11c4a70001da569428a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/3730beb66a991585d08105be234e3720fcd268d2";
+    nix-lib.url = "github:hoprnet/nix-lib/2573ddf8f54a9b18c175ffc9cdd77f73dc9b092d";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/7f88b05c8375375eaff4bd4670ce45d47e0ccea7";
+    nix-lib.url = "github:hoprnet/nix-lib/e9c4ee91049da0f4abe7e11c4a70001da569428a";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/41b6b431e2d7f5605e6b2556bd7f8d8678b0c116";
+    nix-lib.url = "github:hoprnet/nix-lib/7f88b05c8375375eaff4bd4670ce45d47e0ccea7";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";
@@ -91,6 +91,8 @@
         let
           # Git revision for version tracking
           rev = toString (self.shortRev or self.dirtyShortRev);
+          buildVersionEnv = builtins.getEnv "BUILD_VERSION";
+          buildVersion = if buildVersionEnv == "" then null else buildVersionEnv;
 
           # Filesystem utilities for source filtering
           fs = lib.fileset;
@@ -173,6 +175,7 @@
               builders
               sources
               bloklidCrateInfo
+              buildVersion
               rev
               buildPlatform
               nixLib
@@ -543,7 +546,7 @@
               type = "app";
               program = toString (
                 pkgs.writeShellScript "coverage-unit" ''
-                  nix develop .#coverage -c cargo llvm-cov --workspace --lib --lcov --output-path coverage.lcov
+                  nix build -L .#bloklid-coverage -o coverage.lcov
                 ''
               );
             };

--- a/flake.nix
+++ b/flake.nix
@@ -145,7 +145,14 @@
               extraExtensions = [
                 "csv"
                 "graphql"
+                "pem"
+                "snap"
               ];
+            };
+            schema = nixLib.mkSrc {
+              inherit fs;
+              root = ./.;
+              extraExtensions = [ "csv" ];
             };
             deps = nixLib.mkDepsSrc {
               inherit fs;
@@ -162,6 +169,7 @@
           bloklidPackages = import ./nix/packages/bloklid.nix {
             inherit
               lib
+              pkgs
               builders
               sources
               bloklidCrateInfo

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/v1.2.0";
+    nix-lib.url = "github:hoprnet/nix-lib/6abec1485d0829971bf50a06347d54acd889c6b6";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/6abec1485d0829971bf50a06347d54acd889c6b6";
+    nix-lib.url = "github:hoprnet/nix-lib/41b6b431e2d7f5605e6b2556bd7f8d8678b0c116";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/2573ddf8f54a9b18c175ffc9cdd77f73dc9b092d";
+    nix-lib.url = "github:hoprnet/nix-lib/17ed79793f2e86570f9619555435d861473a5d91";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/e9c4ee91049da0f4abe7e11c4a70001da569428a";
+    nix-lib.url = "github:hoprnet/nix-lib/3730beb66a991585d08105be234e3720fcd268d2";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/17ed79793f2e86570f9619555435d861473a5d91";
+    nix-lib.url = "github:hoprnet/nix-lib/v1.3.0";
 
     # Rust build system
     crane.url = "github:ipetkov/crane";

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -148,7 +148,7 @@ in
     }
   );
 
-  bloklid-coverage = builders.local.callPackage nixLib.mkRustPackage (
+  bloklid-coverage = builders.localCoverage.callPackage nixLib.mkRustPackage (
     (mkbloklidBuildArgs {
       src = sources.test;
       depsSrc = sources.deps;

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -9,6 +9,7 @@
   builders,
   sources,
   bloklidCrateInfo,
+  buildVersion,
   rev,
   buildPlatform,
   nixLib,
@@ -18,7 +19,12 @@ let
   mkbloklidBuildArgs =
     { src, depsSrc }:
     {
-      inherit src depsSrc rev;
+      inherit
+        src
+        depsSrc
+        rev
+        buildVersion
+        ;
       cargoExtraArgs = "--bins"; # Build all binary targets
       cargoToml = ./../../bloklid/Cargo.toml;
     };
@@ -112,6 +118,7 @@ in
     })
     // {
       runNextest = true;
+      testCargoProfile = "ci-test";
       prependPackageName = false;
       cargoExtraArgs = "--workspace";
       extraNativeBuildInputs = [ pkgs.foundry-bin ];
@@ -138,6 +145,19 @@ in
       runClippy = true; # Run Clippy linter
       prependPackageName = false;
       cargoExtraArgs = "--workspace";
+    }
+  );
+
+  bloklid-coverage = builders.local.callPackage nixLib.mkRustPackage (
+    (mkbloklidBuildArgs {
+      src = sources.test;
+      depsSrc = sources.deps;
+    })
+    // {
+      runCoverage = true;
+      testCargoProfile = "ci-test";
+      cargoExtraArgs = "--lib";
+      extraNativeBuildInputs = [ pkgs.foundry-bin ];
     }
   );
 

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -86,6 +86,18 @@ in
     }
   );
 
+  bloklid-nextest = builders.local.callPackage nixLib.mkRustPackage (
+    (mkbloklidBuildArgs {
+      src = sources.test;
+      depsSrc = sources.deps;
+    })
+    // {
+      runNextest = true;
+      prependPackageName = false;
+      cargoExtraArgs = "--workspace";
+    }
+  );
+
   bloklid-test-nightly = builders.localNightly.callPackage nixLib.mkRustPackage (
     (mkbloklidBuildArgs {
       src = sources.test;

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -155,9 +155,13 @@ in
     })
     // {
       runCoverage = true;
+      cargoLlvmCovCommand = "nextest";
       testCargoProfile = "ci-test";
       cargoExtraArgs = "--lib";
-      extraNativeBuildInputs = [ pkgs.foundry-bin ];
+      extraNativeBuildInputs = [
+        pkgs.cargo-nextest
+        pkgs.foundry-bin
+      ];
     }
   );
 

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -63,11 +63,14 @@ let
     rev = "schema";
     cargoToml = ./../../api/Cargo.toml;
     CARGO_PROFILE = "dev";
-    cargoExtraArgs = "--bin blokli-api";
+    prependPackageName = false;
+    cargoExtraArgs = "-p blokli-api --bin blokli-api -p blokli-db-migration --bin migration";
     postInstall = ''
       mkdir -p "$out/share/blokli"
+      "$out/bin/migration" up \
+        -u "sqlite://$TMPDIR/blokli-schema.db?mode=rwc"
       "$out/bin/blokli-api" export-schema \
-        --database-url "sqlite::memory:" \
+        --database-url "sqlite://$TMPDIR/blokli-schema.db" \
         --output "$out/share/blokli/schema.graphql"
     '';
   };
@@ -111,6 +114,7 @@ in
       runNextest = true;
       prependPackageName = false;
       cargoExtraArgs = "--workspace";
+      extraNativeBuildInputs = [ pkgs.foundry-bin ];
     }
   );
 

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -158,7 +158,7 @@ in
       runCoverage = true;
       cargoLlvmCovCommand = "nextest";
       testCargoProfile = "ci-test";
-      cargoExtraArgs = "--lib";
+      cargoExtraArgs = "";
       extraNativeBuildInputs = [
         pkgs.cargo-nextest
         pkgs.foundry-bin

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -5,6 +5,7 @@
 
 {
   lib,
+  pkgs,
   builders,
   sources,
   bloklidCrateInfo,
@@ -55,6 +56,21 @@ let
       "aarch64-darwin"
     ]
   );
+
+  blokliSchema = builders.local.callPackage nixLib.mkRustPackage {
+    src = sources.schema;
+    depsSrc = sources.deps;
+    rev = "schema";
+    cargoToml = ./../../api/Cargo.toml;
+    CARGO_PROFILE = "dev";
+    cargoExtraArgs = "--bin blokli-api";
+    postInstall = ''
+      mkdir -p "$out/share/blokli"
+      "$out/bin/blokli-api" export-schema \
+        --database-url "sqlite::memory:" \
+        --output "$out/share/blokli/schema.graphql"
+    '';
+  };
 in
 {
   # Development builds - for local testing and debugging
@@ -116,6 +132,8 @@ in
     })
     // {
       runClippy = true; # Run Clippy linter
+      prependPackageName = false;
+      cargoExtraArgs = "--workspace";
     }
   );
 
@@ -128,6 +146,25 @@ in
       runBench = true; # Run benchmarks
     }
   );
+
+  blokli-schema = blokliSchema;
+
+  schema-validation =
+    pkgs.runCommand "schema-validation"
+      {
+        nativeBuildInputs = [
+          (pkgs.python3.withPackages (pythonPackages: [ pythonPackages.graphql-core ]))
+        ];
+      }
+      ''
+        mkdir -p work/design "$out"
+        cp ${./../../design/target-api-schema.graphql} work/design/target-api-schema.graphql
+        cp ${blokliSchema}/share/blokli/schema.graphql work/schema.graphql
+
+        cd work
+        python ${./../../scripts/check_schema.py}
+        cp schema.graphql "$out/schema.graphql"
+      '';
 
   # Candidate build - used for smoke testing before release
   # Builds as static binary on Linux x86_64 for better test coverage

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -148,6 +148,7 @@ in
     }
   );
 
+  # Coverage runs the unit-test suite through nextest and emits the LCOV report.
   bloklid-coverage = builders.localCoverage.callPackage nixLib.mkRustPackage (
     (mkbloklidBuildArgs {
       src = sources.test;


### PR DESCRIPTION
- Updates `nix-lib` to use stable dependency-only derivations that can be reused from Cachix across commits.
- Replaces development-shell linting with a cacheable Clippy derivation covering the Rust workspace.
- Adds a dedicated CI test profile with smaller debug artifacts and incremental compilation disabled.
- Runs the complete workspace unit-test suite through Nextest with LLVM coverage, avoiding a separate duplicate unit-test build.
- Adds the tools required by tests, including Foundry and `cargo-nextest`, to the relevant Nix derivations.
- Moves GraphQL schema generation and validation into Nix derivations.
- Applies all SQLite migrations before exporting the schema, preserving migration validation in CI.
- Expands filtered test sources to include snapshots, certificates, GraphQL files, and CSV fixtures.
- Supports an optional `BUILD_VERSION` for final artifacts without invalidating dependency caches.
- Fixes the API integration-test helper module wiring so the complete test suite is discovered and executed.
- Fixes the release pipeline by using an updated version of the shared workflow.