### PR TITLE
fix: redact db password in `PostgreSqlConfig`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "validator",
 ]
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -32,6 +32,7 @@ use blokli_chain_rpc::{
     rpc::{RpcOperations, RpcOperationsConfig},
     transport::ReqwestClient,
 };
+use blokli_db::utils::redact_database_url;
 use config::ApiConfig;
 use errors::{ApiError, ApiResult};
 use hopr_bindings::exports::alloy::{
@@ -78,7 +79,7 @@ pub async fn start_server(network: String, finality: u16, config: ApiConfig) -> 
         .map_err(|error| ApiError::ConfigError(format!("Failed to initialize tracing: {error}")))?;
 
     info!("Starting blokli API server on {}", config.bind_address);
-    info!("Connecting to database: {}", redact_url(&config.database_url));
+    info!("Connecting to database: {}", redact_database_url(&config.database_url));
 
     // Connect to database
     let db = Database::connect(&config.database_url).await?;

--- a/bloklid/src/config.rs
+++ b/bloklid/src/config.rs
@@ -2,10 +2,37 @@ use std::{fmt, time::Duration};
 
 use blokli_chain_indexer::utils::redact_url;
 use blokli_chain_types::{ChainConfig, ContractAddresses};
+use url::Url;
 
 use crate::network::Network;
 
-/// Redacts username and password from database URLs while keeping host, port, and database visible
+fn is_sensitive_database_parameter(key: &str, value: &str) -> bool {
+    let normalized_key = key
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    let normalized_value = value.to_ascii_lowercase();
+
+    matches!(normalized_key.as_str(), "pass" | "pwd")
+        || [
+            "password",
+            "passwd",
+            "secret",
+            "token",
+            "apikey",
+            "credential",
+            "privatekey",
+            "sslkey",
+        ]
+        .iter()
+        .any(|marker| normalized_key.contains(marker))
+        || ["password=", "passwd=", "secret=", "token=", "api_key=", "apikey="]
+            .iter()
+            .any(|marker| normalized_value.contains(marker))
+}
+
+/// Redacts credentials from database URLs while keeping non-sensitive connection details visible.
 ///
 /// # Examples
 /// ```
@@ -20,24 +47,49 @@ use crate::network::Network;
 /// );
 /// ```
 pub fn redact_database_url(url: &str) -> String {
-    // Parse the URL to extract components
-    if let Some(scheme_end) = url.find("://") {
-        let scheme = &url[..scheme_end + 3];
-        let rest = &url[scheme_end + 3..];
+    const REDACTED: &str = "REDACTED";
 
-        // Check if there's an @ sign indicating credentials
-        if let Some(at_pos) = rest.find('@') {
-            let after_at = &rest[at_pos..];
-            // Redact credentials but keep everything else
-            format!("{}REDACTED:REDACTED{}", scheme, after_at)
-        } else {
-            // No credentials, return as-is
-            url.to_string()
-        }
-    } else {
-        // Not a URL format, return as-is
-        url.to_string()
+    let mut parsed = match Url::parse(url) {
+        Ok(parsed) => parsed,
+        Err(_) => return REDACTED.to_string(),
+    };
+
+    match parsed.scheme() {
+        "postgres" | "postgresql" if parsed.host_str().is_some() => {}
+        "sqlite" => {}
+        _ => return REDACTED.to_string(),
     }
+
+    if (!parsed.username().is_empty() || parsed.password().is_some())
+        && (parsed.set_username(REDACTED).is_err() || parsed.set_password(Some(REDACTED)).is_err())
+    {
+        return REDACTED.to_string();
+    }
+
+    if parsed.query().is_some() {
+        let query_pairs = parsed
+            .query_pairs()
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+
+        parsed
+            .query_pairs_mut()
+            .clear()
+            .extend_pairs(query_pairs.iter().map(|(key, value)| {
+                let value = if is_sensitive_database_parameter(key, value) {
+                    REDACTED
+                } else {
+                    value
+                };
+                (key.as_str(), value)
+            }));
+    }
+
+    if parsed.fragment().is_some() {
+        parsed.set_fragment(Some(REDACTED));
+    }
+
+    parsed.to_string()
 }
 
 fn default_rpc_url() -> String {
@@ -990,10 +1042,41 @@ mod tests {
     }
 
     #[test]
-    fn test_redact_non_url_string() {
-        // Non-URL string should remain unchanged for database URLs
-        let not_url = "just-a-string";
-        assert_eq!(redact_database_url(not_url), not_url);
+    fn test_redact_database_url_with_at_sign_in_password() {
+        let url = "postgresql://blokli:secret@fragment@localhost:5432/blokli";
+        let redacted = redact_database_url(url);
+
+        assert_eq!(redacted, "postgresql://REDACTED:REDACTED@localhost:5432/blokli");
+        assert!(!redacted.contains("secret"));
+        assert!(!redacted.contains("fragment"));
+    }
+
+    #[test]
+    fn test_redact_database_url_does_not_treat_path_at_sign_as_userinfo() {
+        let url = "postgresql://localhost:5432/blokli@archive";
+
+        assert_eq!(redact_database_url(url), url);
+    }
+
+    #[test]
+    fn test_redact_database_url_with_password_query_parameter() {
+        let url = "postgresql://localhost:5432/blokli?password=secret&sslmode=require";
+        let redacted = redact_database_url(url);
+
+        assert_eq!(
+            redacted,
+            "postgresql://localhost:5432/blokli?password=REDACTED&sslmode=require"
+        );
+        assert!(!redacted.contains("secret"));
+    }
+
+    #[test]
+    fn test_redact_unsupported_database_url() {
+        assert_eq!(redact_database_url("password=secret"), "REDACTED");
+        assert_eq!(
+            redact_database_url("postgresql:host=localhost password=secret"),
+            "REDACTED"
+        );
     }
 
     #[test]
@@ -1030,5 +1113,23 @@ mod tests {
 
         assert!(!debug_output.contains("do-not-log-this-password"));
         assert!(debug_output.contains("postgresql://REDACTED:REDACTED@localhost:5432/blokli"));
+    }
+
+    #[test]
+    fn test_postgres_config_debug_redacts_password_in_url_query() {
+        let config = PostgreSqlConfig {
+            url: Some("postgresql://localhost:5432/blokli?password=do-not-log-this-password".to_string()),
+            host: None,
+            port: None,
+            username: None,
+            password: None,
+            database: None,
+            max_connections: 10,
+        };
+
+        let debug_output = format!("{config:?}");
+
+        assert!(!debug_output.contains("do-not-log-this-password"));
+        assert!(debug_output.contains("password=REDACTED"));
     }
 }

--- a/bloklid/src/config.rs
+++ b/bloklid/src/config.rs
@@ -2,95 +2,9 @@ use std::{fmt, time::Duration};
 
 use blokli_chain_indexer::utils::redact_url;
 use blokli_chain_types::{ChainConfig, ContractAddresses};
-use url::Url;
+use blokli_db::utils::redact_database_url;
 
 use crate::network::Network;
-
-fn is_sensitive_database_parameter(key: &str, value: &str) -> bool {
-    let normalized_key = key
-        .chars()
-        .filter(|character| character.is_ascii_alphanumeric())
-        .flat_map(char::to_lowercase)
-        .collect::<String>();
-    let normalized_value = value.to_ascii_lowercase();
-
-    matches!(normalized_key.as_str(), "pass" | "pwd")
-        || [
-            "password",
-            "passwd",
-            "secret",
-            "token",
-            "apikey",
-            "credential",
-            "privatekey",
-            "sslkey",
-        ]
-        .iter()
-        .any(|marker| normalized_key.contains(marker))
-        || ["password=", "passwd=", "secret=", "token=", "api_key=", "apikey="]
-            .iter()
-            .any(|marker| normalized_value.contains(marker))
-}
-
-/// Redacts credentials from database URLs while keeping non-sensitive connection details visible.
-///
-/// # Examples
-/// ```
-/// # use bloklid::config::redact_database_url;
-/// assert_eq!(
-///     redact_database_url("postgres://user:pass@localhost:5432/mydb"),
-///     "postgres://REDACTED:REDACTED@localhost:5432/mydb"
-/// );
-/// assert_eq!(
-///     redact_database_url("postgresql://localhost:5432/mydb"),
-///     "postgresql://localhost:5432/mydb"
-/// );
-/// ```
-pub fn redact_database_url(url: &str) -> String {
-    const REDACTED: &str = "REDACTED";
-
-    let mut parsed = match Url::parse(url) {
-        Ok(parsed) => parsed,
-        Err(_) => return REDACTED.to_string(),
-    };
-
-    match parsed.scheme() {
-        "postgres" | "postgresql" if parsed.host_str().is_some() => {}
-        "sqlite" => {}
-        _ => return REDACTED.to_string(),
-    }
-
-    if (!parsed.username().is_empty() || parsed.password().is_some())
-        && (parsed.set_username(REDACTED).is_err() || parsed.set_password(Some(REDACTED)).is_err())
-    {
-        return REDACTED.to_string();
-    }
-
-    if parsed.query().is_some() {
-        let query_pairs = parsed
-            .query_pairs()
-            .map(|(key, value)| (key.into_owned(), value.into_owned()))
-            .collect::<Vec<_>>();
-
-        parsed
-            .query_pairs_mut()
-            .clear()
-            .extend_pairs(query_pairs.iter().map(|(key, value)| {
-                let value = if is_sensitive_database_parameter(key, value) {
-                    REDACTED
-                } else {
-                    value
-                };
-                (key.as_str(), value)
-            }));
-    }
-
-    if parsed.fragment().is_some() {
-        parsed.set_fragment(Some(REDACTED));
-    }
-
-    parsed.to_string()
-}
 
 fn default_rpc_url() -> String {
     "http://localhost:8545".to_string()
@@ -1018,68 +932,6 @@ mod tests {
     }
 
     #[test]
-    fn test_redact_database_url_with_credentials() {
-        // URL with username and password should redact only credentials
-        let url = "postgres://user:password@localhost:5432/mydb";
-        let redacted = redact_database_url(url);
-        assert_eq!(redacted, "postgres://REDACTED:REDACTED@localhost:5432/mydb");
-    }
-
-    #[test]
-    fn test_redact_database_url_without_credentials() {
-        // URL without credentials should remain unchanged
-        let url = "postgresql://localhost:5432/mydb";
-        let redacted = redact_database_url(url);
-        assert_eq!(redacted, "postgresql://localhost:5432/mydb");
-    }
-
-    #[test]
-    fn test_redact_database_url_with_port() {
-        // URL with custom port
-        let url = "postgres://admin:secret@db.example.com:9876/production";
-        let redacted = redact_database_url(url);
-        assert_eq!(redacted, "postgres://REDACTED:REDACTED@db.example.com:9876/production");
-    }
-
-    #[test]
-    fn test_redact_database_url_with_at_sign_in_password() {
-        let url = "postgresql://blokli:secret@fragment@localhost:5432/blokli";
-        let redacted = redact_database_url(url);
-
-        assert_eq!(redacted, "postgresql://REDACTED:REDACTED@localhost:5432/blokli");
-        assert!(!redacted.contains("secret"));
-        assert!(!redacted.contains("fragment"));
-    }
-
-    #[test]
-    fn test_redact_database_url_does_not_treat_path_at_sign_as_userinfo() {
-        let url = "postgresql://localhost:5432/blokli@archive";
-
-        assert_eq!(redact_database_url(url), url);
-    }
-
-    #[test]
-    fn test_redact_database_url_with_password_query_parameter() {
-        let url = "postgresql://localhost:5432/blokli?password=secret&sslmode=require";
-        let redacted = redact_database_url(url);
-
-        assert_eq!(
-            redacted,
-            "postgresql://localhost:5432/blokli?password=REDACTED&sslmode=require"
-        );
-        assert!(!redacted.contains("secret"));
-    }
-
-    #[test]
-    fn test_redact_unsupported_database_url() {
-        assert_eq!(redact_database_url("password=secret"), "REDACTED");
-        assert_eq!(
-            redact_database_url("postgresql:host=localhost password=secret"),
-            "REDACTED"
-        );
-    }
-
-    #[test]
     fn test_postgres_config_debug_redacts_password_field() {
         let config = PostgreSqlConfig {
             url: None,
@@ -1130,6 +982,6 @@ mod tests {
         let debug_output = format!("{config:?}");
 
         assert!(!debug_output.contains("do-not-log-this-password"));
-        assert!(debug_output.contains("password=REDACTED"));
+        assert!(debug_output.contains("?REDACTED"));
     }
 }

--- a/bloklid/src/config.rs
+++ b/bloklid/src/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use blokli_chain_indexer::utils::redact_url;
 use blokli_chain_types::{ChainConfig, ContractAddresses};
@@ -61,7 +61,7 @@ fn default_max_block_range() -> u32 {
 /// Supports two formats:
 /// 1. Simple URL: `url = "postgresql://user:pass@host:port/database"`
 /// 2. Detailed components with individual fields (host, port, username, password, database)
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PostgreSqlConfig {
     /// Connection URL (Option 1: simple URL format)
@@ -85,6 +85,24 @@ pub struct PostgreSqlConfig {
     /// Maximum number of connections
     #[serde(default = "default_max_connections")]
     pub max_connections: u32,
+}
+
+impl fmt::Debug for PostgreSqlConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let url = self.url.as_deref().map(redact_database_url);
+        let password = self.password.as_ref().map(|_| "REDACTED");
+
+        formatter
+            .debug_struct("PostgreSqlConfig")
+            .field("url", &url)
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("username", &self.username)
+            .field("password", &password)
+            .field("database", &self.database)
+            .field("max_connections", &self.max_connections)
+            .finish()
+    }
 }
 
 /// SQLite database configuration
@@ -976,5 +994,41 @@ mod tests {
         // Non-URL string should remain unchanged for database URLs
         let not_url = "just-a-string";
         assert_eq!(redact_database_url(not_url), not_url);
+    }
+
+    #[test]
+    fn test_postgres_config_debug_redacts_password_field() {
+        let config = PostgreSqlConfig {
+            url: None,
+            host: Some("localhost".to_string()),
+            port: Some(5432),
+            username: Some("blokli".to_string()),
+            password: Some("do-not-log-this-password".to_string()),
+            database: Some("blokli".to_string()),
+            max_connections: 10,
+        };
+
+        let debug_output = format!("{config:?}");
+
+        assert!(!debug_output.contains("do-not-log-this-password"));
+        assert!(debug_output.contains("REDACTED"));
+    }
+
+    #[test]
+    fn test_postgres_config_debug_redacts_password_in_url() {
+        let config = PostgreSqlConfig {
+            url: Some("postgresql://blokli:do-not-log-this-password@localhost:5432/blokli".to_string()),
+            host: None,
+            port: None,
+            username: None,
+            password: None,
+            database: None,
+            max_connections: 10,
+        };
+
+        let debug_output = format!("{config:?}");
+
+        assert!(!debug_output.contains("do-not-log-this-password"));
+        assert!(debug_output.contains("postgresql://REDACTED:REDACTED@localhost:5432/blokli"));
     }
 }

--- a/bloklid/src/main.rs
+++ b/bloklid/src/main.rs
@@ -16,14 +16,17 @@ use args::{Args, Command, generate_config_template, peek_verbosity_from_env_args
 use async_signal::{Signal, Signals};
 use blokli_chain_api::BlokliChain;
 use blokli_chain_indexer::{snapshot::SnapshotManager, startup, utils::redact_url};
-use blokli_db::db::{BlokliDb, BlokliDbConfig};
+use blokli_db::{
+    db::{BlokliDb, BlokliDbConfig},
+    utils::redact_database_url,
+};
 use clap::Parser;
 use futures::TryStreamExt;
 use sea_orm::Database;
 use tokio::net::TcpListener;
 
 use crate::{
-    config::{Config, DatabaseConfig, redact_database_url},
+    config::{Config, DatabaseConfig},
     errors::BloklidError,
 };
 

--- a/db/core/Cargo.toml
+++ b/db/core/Cargo.toml
@@ -37,6 +37,7 @@ sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 validator = { workspace = true }
 
 blokli-db-entity = { workspace = true }

--- a/db/core/src/lib.rs
+++ b/db/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod safe_history;
 pub mod safe_redeemed_stats;
 pub mod snapshot;
 pub mod state_queries;
+pub mod utils;
 pub mod version;
 
 use std::{path::PathBuf, time::Instant};

--- a/db/core/src/utils.rs
+++ b/db/core/src/utils.rs
@@ -1,0 +1,94 @@
+//! Utilities for safely displaying database connection details.
+
+use url::Url;
+
+/// Redacts credentials from a database URL while keeping non-sensitive connection details visible.
+///
+/// User information, query strings, and fragments can all carry credentials. Query strings and
+/// fragments are therefore redacted in full rather than filtered using a denylist. Inputs that
+/// are not supported database URLs are also redacted in full.
+pub fn redact_database_url(url: &str) -> String {
+    const REDACTED: &str = "REDACTED";
+
+    let mut parsed = match Url::parse(url) {
+        Ok(parsed) => parsed,
+        Err(_) => return REDACTED.to_string(),
+    };
+
+    match parsed.scheme() {
+        "postgres" | "postgresql" if parsed.host_str().is_some() => {}
+        "sqlite" => {}
+        _ => return REDACTED.to_string(),
+    }
+
+    if (!parsed.username().is_empty() || parsed.password().is_some())
+        && (parsed.set_username(REDACTED).is_err() || parsed.set_password(Some(REDACTED)).is_err())
+    {
+        return REDACTED.to_string();
+    }
+
+    if parsed.query().is_some() {
+        parsed.set_query(Some(REDACTED));
+    }
+
+    if parsed.fragment().is_some() {
+        parsed.set_fragment(Some(REDACTED));
+    }
+
+    parsed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_database_url;
+
+    #[test]
+    fn test_redact_database_url_with_credentials() {
+        let redacted = redact_database_url("postgres://user:password@localhost:5432/mydb");
+
+        assert_eq!(redacted, "postgres://REDACTED:REDACTED@localhost:5432/mydb");
+    }
+
+    #[test]
+    fn test_redact_database_url_without_credentials() {
+        let url = "postgresql://localhost:5432/mydb";
+
+        assert_eq!(redact_database_url(url), url);
+    }
+
+    #[test]
+    fn test_redact_database_url_with_at_sign_in_password() {
+        let redacted = redact_database_url("postgresql://blokli:secret@fragment@localhost:5432/blokli");
+
+        assert_eq!(redacted, "postgresql://REDACTED:REDACTED@localhost:5432/blokli");
+        assert!(!redacted.contains("secret"));
+        assert!(!redacted.contains("fragment"));
+    }
+
+    #[test]
+    fn test_redact_database_url_does_not_treat_path_at_sign_as_userinfo() {
+        let url = "postgresql://localhost:5432/blokli@archive";
+
+        assert_eq!(redact_database_url(url), url);
+    }
+
+    #[test]
+    fn test_redact_database_url_redacts_entire_query() {
+        let password = redact_database_url("postgresql://localhost/blokli?password=secret&sslmode=require");
+        let unknown = redact_database_url("postgresql://localhost/blokli?auth=hunter2");
+        let secret_in_key = redact_database_url("postgresql://localhost/blokli?password%3Dhunter2");
+
+        assert_eq!(password, "postgresql://localhost/blokli?REDACTED");
+        assert_eq!(unknown, "postgresql://localhost/blokli?REDACTED");
+        assert_eq!(secret_in_key, "postgresql://localhost/blokli?REDACTED");
+    }
+
+    #[test]
+    fn test_redact_unsupported_database_url() {
+        assert_eq!(redact_database_url("password=secret"), "REDACTED");
+        assert_eq!(
+            redact_database_url("postgresql:host=localhost password=secret"),
+            "REDACTED"
+        );
+    }
+}


### PR DESCRIPTION
Redacts the password of the `PostgreSqlConfig` object.

Closes #426 