### PR TITLE
chore: bump bloklid version manually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/bloklid/Cargo.toml
+++ b/bloklid/Cargo.toml
@@ -6,7 +6,7 @@ homepage    = "https://hoprnet.org/"
 license     = "GPL-3.0-only"
 name        = "bloklid"
 repository  = "https://github.com/hoprnet/hoprnet"
-version     = "0.12.0"
+version     = "0.12.1"
 
 [features]
 default = ["runtime-tokio"]


### PR DESCRIPTION
Bump the version manually after the failing last step of the release workflow.