### PR TITLE
fix(ci): avoid scanning debug binaries during schema validation

### DIFF
--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -79,8 +79,7 @@ let
         --database-url "sqlite://$TMPDIR/blokli-schema.db" \
         --output "$out/share/blokli/schema.graphql"
       # Keep the output schema-only so Crane does not scan the large dev binaries for source references.
-      rm "$out/bin/blokli-api" "$out/bin/migration"
-      rmdir "$out/bin"
+      rm -rf "$out/bin"
     '';
   };
 in

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -78,6 +78,9 @@ let
       "$out/bin/blokli-api" export-schema \
         --database-url "sqlite://$TMPDIR/blokli-schema.db" \
         --output "$out/share/blokli/schema.graphql"
+      # Keep the output schema-only so Crane does not scan the large dev binaries for source references.
+      rm "$out/bin/blokli-api" "$out/bin/migration"
+      rmdir "$out/bin"
     '';
   };
 in


### PR DESCRIPTION
Remove the generated binaries after generating the schema, so that crane doesn't have to go through the two debug binaries. Makes the CI job more stable and slightly faster.