### PR TITLE
feat: Improve logging on tx failures

### DIFF
--- a/chain/api/src/rpc_adapter.rs
+++ b/chain/api/src/rpc_adapter.rs
@@ -43,7 +43,8 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
     /// Converts the raw transaction bytes to alloy Bytes format and submits to the RPC provider.
     /// Returns the transaction hash immediately without waiting for confirmation.
     async fn send_raw_transaction(&self, raw_tx: Vec<u8>) -> Result<Hash, String> {
-        debug!(length = raw_tx.len(), "sending raw transaction");
+        let raw_tx_len = raw_tx.len();
+        debug!(length = raw_tx_len, "sending raw transaction");
 
         // Convert Vec<u8> to alloy Bytes
         let bytes = Bytes::from(raw_tx);
@@ -59,7 +60,7 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
                 Ok(hash)
             }
             Err(e) => {
-                error!(error = %e, "failed to send raw transaction");
+                error!(raw_tx_len, error = %e, "failed to send raw transaction");
                 Err(format!("RPC error: {}", e))
             }
         }
@@ -75,8 +76,9 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
         confirmations: u64,
         timeout: Option<Duration>,
     ) -> Result<Hash, ConfirmationError> {
+        let raw_tx_len = raw_tx.len();
         debug!(
-            raw_tx_len = raw_tx.len(),
+            raw_tx_len,
             confirmations, "sending raw transaction and waiting for confirmations"
         );
 
@@ -125,7 +127,7 @@ impl<R: HttpRequestor + 'static + Clone> RpcClient for RpcAdapter<R> {
                 }
             }
             Err(e) => {
-                error!(error = %e, "failed to send raw transaction");
+                error!(raw_tx_len, error = %e, "failed to send raw transaction");
                 Err(ConfirmationError::SubmissionFailed(format!("RPC error: {}", e)))
             }
         }

--- a/chain/api/src/transaction_executor.rs
+++ b/chain/api/src/transaction_executor.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use hopr_types::crypto::types::Hash;
 use thiserror::Error;
+use tracing::{error, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -180,6 +181,7 @@ impl<R: RpcClient> RawTransactionExecutor<R> {
     pub async fn send_raw_transaction(&self, raw_tx: Vec<u8>) -> Result<Hash, TransactionExecutorError> {
         // Validate transaction
         if let Err(e) = self.validator.validate_raw_transaction(&raw_tx) {
+            warn!(error = %e, "Transaction validation failed");
             record_transaction_status(STATUS_VALIDATION_FAILED);
             return Err(e.into());
         }
@@ -207,6 +209,7 @@ impl<R: RpcClient> RawTransactionExecutor<R> {
     pub async fn send_raw_transaction_async(&self, raw_tx: Vec<u8>) -> Result<Uuid, TransactionExecutorError> {
         // Validate transaction
         if let Err(e) = self.validator.validate_raw_transaction(&raw_tx) {
+            warn!(error = %e, "Transaction validation failed");
             record_transaction_status(STATUS_VALIDATION_FAILED);
             return Err(e.into());
         }
@@ -233,7 +236,10 @@ impl<R: RpcClient> RawTransactionExecutor<R> {
             safe_execution: None,
         };
 
-        self.transaction_store.insert(record)?;
+        if let Err(e) = self.transaction_store.insert(record) {
+            error!(id = %id, tx_hash = %tx_hash, error = %e, "Failed to store submitted transaction");
+            return Err(e.into());
+        }
         Ok(id)
     }
 
@@ -251,6 +257,7 @@ impl<R: RpcClient> RawTransactionExecutor<R> {
     ) -> Result<TransactionRecord, TransactionExecutorError> {
         // Validate transaction
         if let Err(e) = self.validator.validate_raw_transaction(&raw_tx) {
+            warn!(error = %e, "Transaction validation failed");
             record_transaction_status(STATUS_VALIDATION_FAILED);
             return Err(e.into());
         }
@@ -298,7 +305,10 @@ impl<R: RpcClient> RawTransactionExecutor<R> {
                 enrich_safe_execution(&record, receipt_provider.as_ref(), safe_checker.as_ref()).await;
         }
 
-        self.transaction_store.insert(record.clone())?;
+        if let Err(e) = self.transaction_store.insert(record.clone()) {
+            error!(id = %record.id, tx_hash = %tx_hash, error = %e, "Failed to store confirmed transaction");
+            return Err(e.into());
+        }
         record_transaction_status(STATUS_CONFIRMED);
         Ok(record)
     }

--- a/chain/api/src/transaction_monitor.rs
+++ b/chain/api/src/transaction_monitor.rs
@@ -178,7 +178,12 @@ impl<R: ReceiptProvider, S: SafeAddressChecker> TransactionMonitor<R, S> {
                     TransactionStatus::Timeout,
                     Some("Transaction timed out waiting for confirmation".to_string()),
                 ) {
-                    error!(id = %record.id, tx_hash = %tx_hash, "Failed to update transaction status to Timeout: {e}");
+                    error!(
+                        id = %record.id,
+                        tx_hash = %tx_hash,
+                        error = %e,
+                        "Failed to update transaction status to Timeout"
+                    );
                 }
                 continue;
             }
@@ -196,7 +201,7 @@ impl<R: ReceiptProvider, S: SafeAddressChecker> TransactionMonitor<R, S> {
                         .transaction_store
                         .confirm_with_safe_execution(record.id, safe_execution)
                     {
-                        error!(id = %record.id, tx_hash = %tx_hash, "Failed to confirm transaction: {e}");
+                        error!(id = %record.id, tx_hash = %tx_hash, error = %e, "Failed to confirm transaction");
                     }
                 }
                 Ok(Some(false)) => {
@@ -206,7 +211,12 @@ impl<R: ReceiptProvider, S: SafeAddressChecker> TransactionMonitor<R, S> {
                         TransactionStatus::Reverted,
                         Some("Transaction reverted on-chain".to_string()),
                     ) {
-                        error!(id = %record.id, tx_hash = %tx_hash, "Failed to update transaction status to Reverted: {e}");
+                        error!(
+                            id = %record.id,
+                            tx_hash = %tx_hash,
+                            error = %e,
+                            "Failed to update transaction status to Reverted"
+                        );
                     }
                 }
                 Ok(None) => {
@@ -214,7 +224,7 @@ impl<R: ReceiptProvider, S: SafeAddressChecker> TransactionMonitor<R, S> {
                     debug!(id = %record.id, tx_hash = %tx_hash, "Transaction still pending");
                 }
                 Err(e) => {
-                    error!(id = %record.id, tx_hash = %tx_hash, "Error checking transaction: {e}");
+                    error!(id = %record.id, tx_hash = %tx_hash, error = %e, "Error checking transaction");
                 }
             }
 

--- a/chain/api/src/transaction_monitor.rs
+++ b/chain/api/src/transaction_monitor.rs
@@ -172,13 +172,13 @@ impl<R: ReceiptProvider, S: SafeAddressChecker> TransactionMonitor<R, S> {
             // Check if transaction has timed out
             let elapsed = chrono::Utc::now().signed_duration_since(record.submitted_at);
             if elapsed.to_std().ok() > Some(self.config.timeout) {
-                info!("Transaction {} timed out", record.id);
+                warn!(id = %record.id, tx_hash = %tx_hash, "Transaction timed out");
                 if let Err(e) = self.transaction_store.update_status(
                     record.id,
                     TransactionStatus::Timeout,
                     Some("Transaction timed out waiting for confirmation".to_string()),
                 ) {
-                    error!("Failed to update transaction {} status to Timeout: {}", record.id, e);
+                    error!(id = %record.id, tx_hash = %tx_hash, "Failed to update transaction status to Timeout: {e}");
                 }
                 continue;
             }
@@ -186,7 +186,7 @@ impl<R: ReceiptProvider, S: SafeAddressChecker> TransactionMonitor<R, S> {
             // Check confirmation status
             match self.receipt_provider.get_transaction_status(tx_hash).await {
                 Ok(Some(true)) => {
-                    info!("Transaction {} confirmed", record.id);
+                    info!(id = %record.id, tx_hash = %tx_hash, "Transaction confirmed");
 
                     // Collect Safe enrichment data before confirming, so that
                     // status and safe_execution are set atomically.
@@ -196,25 +196,25 @@ impl<R: ReceiptProvider, S: SafeAddressChecker> TransactionMonitor<R, S> {
                         .transaction_store
                         .confirm_with_safe_execution(record.id, safe_execution)
                     {
-                        error!("Failed to confirm transaction {}: {}", record.id, e);
+                        error!(id = %record.id, tx_hash = %tx_hash, "Failed to confirm transaction: {e}");
                     }
                 }
                 Ok(Some(false)) => {
-                    info!("Transaction {} reverted", record.id);
+                    warn!(id = %record.id, tx_hash = %tx_hash, "Transaction reverted");
                     if let Err(e) = self.transaction_store.update_status(
                         record.id,
                         TransactionStatus::Reverted,
                         Some("Transaction reverted on-chain".to_string()),
                     ) {
-                        error!("Failed to update transaction {} status to Reverted: {}", record.id, e);
+                        error!(id = %record.id, tx_hash = %tx_hash, "Failed to update transaction status to Reverted: {e}");
                     }
                 }
                 Ok(None) => {
                     // Still pending, continue monitoring
-                    debug!("Transaction {} still pending", record.id);
+                    debug!(id = %record.id, tx_hash = %tx_hash, "Transaction still pending");
                 }
                 Err(e) => {
-                    error!("Error checking transaction {}: {}", record.id, e);
+                    error!(id = %record.id, tx_hash = %tx_hash, "Error checking transaction: {e}");
                 }
             }
 

--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -621,7 +621,7 @@ where
                 },
                 Err(_err) => {
                     // Error details may contain sensitive URL information - avoid logging
-                    error!("RPC request failed");
+                    error!(?method_names, "RPC request failed");
                     method_names.iter().for_each(|_m| {
                         #[cfg(all(feature = "telemetry", not(test)))]
                         METRIC_COUNT_RPC_CALLS.increment(&[_m, "failure"]);


### PR DESCRIPTION
Logs the tx hash and elevates timeout/revert to WARN in the transaction monitor, so failures can be traced on-chain without a store lookup.