### PR TITLE
feat: Remove darwin compilation in Blokli as the server side is primarily intended to run in Linux

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -28,9 +28,6 @@ jobs:
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-4
             build_command: nix build -L .#binary-bloklid-aarch64-linux
-          - architecture: aarch64-darwin
-            runner: depot-macos-15
-            build_command: nix build -L .#binary-bloklid-aarch64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@45221eb1aadfc5c46751306c5c7d6d291c8a24b3 # build-binaries-v3.1.2
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,6 @@ jobs:
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-4
             build_command: nix build -L .#binary-bloklid-aarch64-linux
-          - architecture: aarch64-darwin
-            runner: depot-macos-15
-            build_command: nix build -L .#binary-bloklid-aarch64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@45221eb1aadfc5c46751306c5c7d6d291c8a24b3 # build-binaries-v3.1.2
     permissions:
       contents: read


### PR DESCRIPTION
The darwin compilation takes 42 minutes which is 4x times the arm in linux. As the blokli server side is not intended to run in Darwin platforms there's no need to build them.