### PR TITLE
fix: Floor chainInfo gas estimates and quiet sqlx statement logging

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -98,7 +98,7 @@ jobs:
   # ── Shared tests (unit) ─────────────────────────────────────────────────────
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@3ee95c480962bb3c1fc0061887da9ba735f537c7 # workflow-tests-v6.1.1
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@2f28adfb7c34a9f18087d8646e190b6aafcd4b52 # workflow-tests-v6.1.2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       cachix_cache_name: blokli

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -1394,9 +1394,24 @@ impl QueryRoot {
                 HoprRpcOperations::estimate_eip1559_fees(&**rpc)
             );
 
+            // The RPC endpoint's fee estimate (eth_gasPrice / eth_feeHistory) can occasionally return
+            // a degenerate near-zero value (e.g. a misbehaving provider), which would produce a
+            // transaction that can never be mined. Floor against the configured gas oracle fallback,
+            // which is a known-reasonable value for this chain.
+            let max_fee_floor = rpc.config().gas_oracle_fallback_max_fee;
+            let priority_fee_floor = rpc.config().gas_oracle_fallback_priority_fee;
+
             match gas_price_result {
                 Ok(estimated_gas_price) => {
-                    gas_price = Some(estimated_gas_price.to_string());
+                    let floored = estimated_gas_price.max(max_fee_floor);
+                    if floored != estimated_gas_price {
+                        warn!(
+                            estimated_gas_price,
+                            floor = max_fee_floor,
+                            "estimated gas price below sanity floor, using floor instead"
+                        );
+                    }
+                    gas_price = Some(floored.to_string());
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to fetch gas price estimate for chain_info");
@@ -1405,9 +1420,22 @@ impl QueryRoot {
 
             match eip1559_result {
                 Ok(fees) => {
-                    max_fee_per_gas = Some(scale_wei_by_multiplier(fees.max_fee_per_gas, gas_multiplier).to_string());
+                    let floored_priority_fee = fees.max_priority_fee_per_gas.max(priority_fee_floor);
+                    // max_fee_per_gas must be >= max_priority_fee_per_gas per EIP-1559
+                    let floored_max_fee = fees.max_fee_per_gas.max(max_fee_floor).max(floored_priority_fee);
+                    if floored_max_fee != fees.max_fee_per_gas || floored_priority_fee != fees.max_priority_fee_per_gas
+                    {
+                        warn!(
+                            estimated_max_fee = fees.max_fee_per_gas,
+                            estimated_priority_fee = fees.max_priority_fee_per_gas,
+                            max_fee_floor,
+                            priority_fee_floor,
+                            "eip1559 fee estimate below sanity floor, using floor instead"
+                        );
+                    }
+                    max_fee_per_gas = Some(scale_wei_by_multiplier(floored_max_fee, gas_multiplier).to_string());
                     max_priority_fee_per_gas =
-                        Some(scale_wei_by_multiplier(fees.max_priority_fee_per_gas, gas_multiplier).to_string());
+                        Some(scale_wei_by_multiplier(floored_priority_fee, gas_multiplier).to_string());
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to fetch eip1559 fee estimate for chain_info");

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -370,6 +370,11 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
         })
     }
 
+    /// Get the configuration this instance was created with
+    pub fn config(&self) -> &RpcOperationsConfig {
+        &self.cfg
+    }
+
     /// Get the current block number from the RPC endpoint, adjusted for finality
     ///
     /// This method returns the block number minus the configured finality window

--- a/db/core/src/db.rs
+++ b/db/core/src/db.rs
@@ -131,9 +131,13 @@ impl BlokliDb {
                 .connect_timeout(Duration::from_secs(8))
                 .idle_timeout(Duration::from_secs(300))
                 .max_lifetime(Duration::from_secs(1800))
-                .sqlx_logging(cfg.log_slow_queries.as_secs() > 0)
-                .sqlx_logging_level(LevelFilter::Debug)
-                .sqlx_slow_statements_logging_settings(LevelFilter::Warn, cfg.log_slow_queries);
+                .sqlx_logging(true)
+                .sqlx_logging_level(LevelFilter::Debug);
+            // A zero duration means slow-query warnings are disabled; leave the setting at
+            // its default (Off) rather than warning on every statement.
+            if !cfg.log_slow_queries.is_zero() {
+                opt.sqlx_slow_statements_logging_settings(LevelFilter::Warn, cfg.log_slow_queries);
+            }
             opt
         };
 

--- a/db/core/src/db.rs
+++ b/db/core/src/db.rs
@@ -132,7 +132,8 @@ impl BlokliDb {
                 .idle_timeout(Duration::from_secs(300))
                 .max_lifetime(Duration::from_secs(1800))
                 .sqlx_logging(cfg.log_slow_queries.as_secs() > 0)
-                .sqlx_logging_level(LevelFilter::Warn);
+                .sqlx_logging_level(LevelFilter::Debug)
+                .sqlx_slow_statements_logging_settings(LevelFilter::Warn, cfg.log_slow_queries);
             opt
         };
 


### PR DESCRIPTION
## Summary

Two related fixes found while investigating stuck HOPR node transactions on Gnosis Chain:

**1. Sanity floor for `chainInfo` gas estimates**

Root-caused stuck-forever pending transactions (real, valid tx hashes that never got mined) to the RPC endpoint's `eth_gasPrice`/`eth_feeHistory` occasionally returning a near-zero fee (observed with a Tenderly RPC endpoint — e.g. `maxFeePerGas` of ~2,300 wei, vs. the ~1 Gwei minimum Gnosis Chain validators need). hoprd trusts blokli's `chainInfo` fee estimate as-is with no client-side sanity check, so a bad estimate produces a transaction that can never be included in a block.

`chainInfo` now floors `gasPrice`/`maxFeePerGas`/`maxPriorityFeePerGas` against the existing `gas_oracle_fallback_max_fee`/`gas_oracle_fallback_priority_fee` config (already documented as suitable defaults for Gnosis Chain) before returning them, and logs at `warn` when the floor kicks in. Also enforces the EIP-1559 invariant `max_fee_per_gas >= max_priority_fee_per_gas` after flooring each independently.

**2. Quiet sqlx statement logging**

`db/core/src/db.rs` was setting SeaORM's `sqlx_logging_level` to `Warn` for *every* SQL statement regardless of duration, flooding logs enough that it had to be filtered out entirely (`sqlx::query=error`). The `log_slow_queries` config field (a `Duration`) was only ever used as an on/off toggle (`> 0`) — never actually wired up as a duration threshold.

Statements now log at `debug` by default, with `log_slow_queries` properly passed to SeaORM's `sqlx_slow_statements_logging_settings`, so genuinely slow queries still surface at `warn`.

## Test plan

- [x] `just quick` (fmt, clippy, check) passes
- [x] `blokli-api` chain_info integration tests pass (11/11)
- [x] `blokli-chain-rpc` tests pass
- [x] `blokli-db` db module tests pass