### PR TITLE
fix: Decouple gas estimate sanity threshold from fallback value

### DIFF
--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -1396,21 +1396,28 @@ impl QueryRoot {
 
             // The RPC endpoint's fee estimate (eth_gasPrice / eth_feeHistory) can occasionally return
             // a degenerate near-zero value (e.g. a misbehaving provider), which would produce a
-            // transaction that can never be mined. Floor against the configured gas oracle fallback,
-            // which is a known-reasonable value for this chain.
+            // transaction that can never be mined. Detection uses a sanity threshold far below any
+            // legitimate fee (even on a cheap chain like Gnosis); the replacement values are the
+            // separate, higher gas oracle fallback config. These must stay decoupled: using the
+            // fallback itself as the detection threshold would misfire on legitimate low-congestion
+            // prices, since Gnosis gas can normally be far below the fallback's "reasonable" value.
+            let sanity_threshold = rpc.config().gas_estimate_sanity_threshold;
             let max_fee_floor = rpc.config().gas_oracle_fallback_max_fee;
             let priority_fee_floor = rpc.config().gas_oracle_fallback_priority_fee;
 
             match gas_price_result {
                 Ok(estimated_gas_price) => {
-                    let floored = estimated_gas_price.max(max_fee_floor);
-                    if floored != estimated_gas_price {
+                    let floored = if estimated_gas_price < sanity_threshold {
                         warn!(
                             estimated_gas_price,
+                            sanity_threshold,
                             floor = max_fee_floor,
-                            "estimated gas price below sanity floor, using floor instead"
+                            "estimated gas price below sanity threshold, using fallback instead"
                         );
-                    }
+                        max_fee_floor
+                    } else {
+                        estimated_gas_price
+                    };
                     gas_price = Some(floored.to_string());
                 }
                 Err(e) => {
@@ -1420,19 +1427,30 @@ impl QueryRoot {
 
             match eip1559_result {
                 Ok(fees) => {
-                    let floored_priority_fee = fees.max_priority_fee_per_gas.max(priority_fee_floor);
-                    // max_fee_per_gas must be >= max_priority_fee_per_gas per EIP-1559
-                    let floored_max_fee = fees.max_fee_per_gas.max(max_fee_floor).max(floored_priority_fee);
-                    if floored_max_fee != fees.max_fee_per_gas || floored_priority_fee != fees.max_priority_fee_per_gas
-                    {
+                    let below_threshold =
+                        fees.max_fee_per_gas < sanity_threshold || fees.max_priority_fee_per_gas < sanity_threshold;
+                    if below_threshold {
                         warn!(
                             estimated_max_fee = fees.max_fee_per_gas,
                             estimated_priority_fee = fees.max_priority_fee_per_gas,
+                            sanity_threshold,
                             max_fee_floor,
                             priority_fee_floor,
-                            "eip1559 fee estimate below sanity floor, using floor instead"
+                            "eip1559 fee estimate below sanity threshold, using fallback instead"
                         );
                     }
+                    let floored_priority_fee = if below_threshold {
+                        priority_fee_floor
+                    } else {
+                        fees.max_priority_fee_per_gas
+                    };
+                    // max_fee_per_gas must be >= max_priority_fee_per_gas per EIP-1559
+                    let floored_max_fee = if below_threshold {
+                        max_fee_floor
+                    } else {
+                        fees.max_fee_per_gas
+                    }
+                    .max(floored_priority_fee);
                     max_fee_per_gas = Some(scale_wei_by_multiplier(floored_max_fee, gas_multiplier).to_string());
                     max_priority_fee_per_gas =
                         Some(scale_wei_by_multiplier(floored_priority_fee, gas_multiplier).to_string());

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -204,6 +204,35 @@ fn scale_wei_by_multiplier(value: u128, multiplier: f64) -> u128 {
         / denominator
 }
 
+/// Resolves a legacy gas price estimate, substituting `fallback` when `estimated` is below
+/// `sanity_threshold` (e.g. a misbehaving RPC endpoint returning a near-zero fee).
+fn resolve_gas_price(estimated: u128, sanity_threshold: u128, fallback: u128) -> u128 {
+    if estimated < sanity_threshold {
+        fallback
+    } else {
+        estimated
+    }
+}
+
+/// Resolves EIP-1559 fee estimates, substituting both fallback values together when either
+/// component is below `sanity_threshold`, and enforcing `max_fee >= priority_fee` per EIP-1559.
+fn resolve_eip1559_fees(
+    max_fee: u128,
+    priority_fee: u128,
+    sanity_threshold: u128,
+    max_fee_fallback: u128,
+    priority_fee_fallback: u128,
+) -> (u128, u128) {
+    let below_threshold = max_fee < sanity_threshold || priority_fee < sanity_threshold;
+    let resolved_priority_fee = if below_threshold {
+        priority_fee_fallback
+    } else {
+        priority_fee
+    };
+    let resolved_max_fee = if below_threshold { max_fee_fallback } else { max_fee }.max(resolved_priority_fee);
+    (resolved_max_fee, resolved_priority_fee)
+}
+
 fn safe_from_current_row(
     current: CurrentSafe,
     registered_nodes: Vec<String>,
@@ -1402,23 +1431,21 @@ impl QueryRoot {
             // fallback itself as the detection threshold would misfire on legitimate low-congestion
             // prices, since Gnosis gas can normally be far below the fallback's "reasonable" value.
             let sanity_threshold = rpc.config().gas_estimate_sanity_threshold;
-            let max_fee_floor = rpc.config().gas_oracle_fallback_max_fee;
-            let priority_fee_floor = rpc.config().gas_oracle_fallback_priority_fee;
+            let max_fee_fallback = rpc.config().gas_oracle_fallback_max_fee;
+            let priority_fee_fallback = rpc.config().gas_oracle_fallback_priority_fee;
 
             match gas_price_result {
                 Ok(estimated_gas_price) => {
-                    let floored = if estimated_gas_price < sanity_threshold {
+                    let resolved_gas_price = resolve_gas_price(estimated_gas_price, sanity_threshold, max_fee_fallback);
+                    if resolved_gas_price != estimated_gas_price {
                         warn!(
                             estimated_gas_price,
                             sanity_threshold,
-                            floor = max_fee_floor,
+                            fallback = max_fee_fallback,
                             "estimated gas price below sanity threshold, using fallback instead"
                         );
-                        max_fee_floor
-                    } else {
-                        estimated_gas_price
-                    };
-                    gas_price = Some(floored.to_string());
+                    }
+                    gas_price = Some(resolved_gas_price.to_string());
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to fetch gas price estimate for chain_info");
@@ -1427,33 +1454,28 @@ impl QueryRoot {
 
             match eip1559_result {
                 Ok(fees) => {
-                    let below_threshold =
-                        fees.max_fee_per_gas < sanity_threshold || fees.max_priority_fee_per_gas < sanity_threshold;
-                    if below_threshold {
+                    let (resolved_max_fee, resolved_priority_fee) = resolve_eip1559_fees(
+                        fees.max_fee_per_gas,
+                        fees.max_priority_fee_per_gas,
+                        sanity_threshold,
+                        max_fee_fallback,
+                        priority_fee_fallback,
+                    );
+                    if resolved_max_fee != fees.max_fee_per_gas
+                        || resolved_priority_fee != fees.max_priority_fee_per_gas
+                    {
                         warn!(
                             estimated_max_fee = fees.max_fee_per_gas,
                             estimated_priority_fee = fees.max_priority_fee_per_gas,
                             sanity_threshold,
-                            max_fee_floor,
-                            priority_fee_floor,
+                            max_fee_fallback,
+                            priority_fee_fallback,
                             "eip1559 fee estimate below sanity threshold, using fallback instead"
                         );
                     }
-                    let floored_priority_fee = if below_threshold {
-                        priority_fee_floor
-                    } else {
-                        fees.max_priority_fee_per_gas
-                    };
-                    // max_fee_per_gas must be >= max_priority_fee_per_gas per EIP-1559
-                    let floored_max_fee = if below_threshold {
-                        max_fee_floor
-                    } else {
-                        fees.max_fee_per_gas
-                    }
-                    .max(floored_priority_fee);
-                    max_fee_per_gas = Some(scale_wei_by_multiplier(floored_max_fee, gas_multiplier).to_string());
+                    max_fee_per_gas = Some(scale_wei_by_multiplier(resolved_max_fee, gas_multiplier).to_string());
                     max_priority_fee_per_gas =
-                        Some(scale_wei_by_multiplier(floored_priority_fee, gas_multiplier).to_string());
+                        Some(scale_wei_by_multiplier(resolved_priority_fee, gas_multiplier).to_string());
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to fetch eip1559 fee estimate for chain_info");
@@ -1765,8 +1787,8 @@ mod tests {
     };
 
     use super::{
-        QueryRoot, SAFES_BALANCE_MAX_SAFES, check_safes_balance_cap, owners_for_safe, safe_from_current_row,
-        scale_wei_by_multiplier,
+        QueryRoot, SAFES_BALANCE_MAX_SAFES, check_safes_balance_cap, owners_for_safe, resolve_eip1559_fees,
+        resolve_gas_price, safe_from_current_row, scale_wei_by_multiplier,
     };
     use crate::{
         errors,
@@ -1805,6 +1827,46 @@ mod tests {
     #[test]
     fn test_scale_wei_by_multiplier_rounds_up() {
         assert_eq!(scale_wei_by_multiplier(3, 1.5), 5);
+    }
+
+    #[test]
+    fn test_resolve_gas_price_below_threshold_uses_fallback() {
+        assert_eq!(resolve_gas_price(99, 100, 500), 500);
+    }
+
+    #[test]
+    fn test_resolve_gas_price_at_threshold_uses_estimate() {
+        assert_eq!(resolve_gas_price(100, 100, 500), 100);
+    }
+
+    #[test]
+    fn test_resolve_gas_price_above_threshold_uses_estimate() {
+        assert_eq!(resolve_gas_price(101, 100, 500), 101);
+    }
+
+    #[test]
+    fn test_resolve_eip1559_fees_max_fee_below_threshold_uses_both_fallbacks() {
+        assert_eq!(resolve_eip1559_fees(99, 200, 100, 500, 50), (500, 50));
+    }
+
+    #[test]
+    fn test_resolve_eip1559_fees_priority_fee_below_threshold_uses_both_fallbacks() {
+        assert_eq!(resolve_eip1559_fees(200, 99, 100, 500, 50), (500, 50));
+    }
+
+    #[test]
+    fn test_resolve_eip1559_fees_both_at_or_above_threshold_uses_estimates() {
+        assert_eq!(resolve_eip1559_fees(200, 150, 100, 500, 50), (200, 150));
+    }
+
+    #[test]
+    fn test_resolve_eip1559_fees_enforces_max_fee_invariant_when_priority_fallback_dominates() {
+        // Both estimates are below threshold, so both fallbacks apply. If priority_fee_fallback
+        // exceeds max_fee_fallback, the resolved max fee must still be raised to match it, since
+        // max_fee_per_gas >= max_priority_fee_per_gas per EIP-1559.
+        let (max_fee, priority_fee) = resolve_eip1559_fees(50, 50, 100, 50, 500);
+        assert_eq!((max_fee, priority_fee), (500, 500));
+        assert!(max_fee >= priority_fee);
     }
 
     #[test]

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -135,6 +135,18 @@ pub struct RpcOperationsConfig {
     /// low-congestion pricing.
     ///
     /// Defaults to 0.001 gwei (1,000,000 wei).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use blokli_chain_rpc::rpc::RpcOperationsConfig;
+    ///
+    /// let config = RpcOperationsConfig {
+    ///     gas_estimate_sanity_threshold: 500_000,
+    ///     ..Default::default()
+    /// };
+    /// assert_eq!(config.gas_estimate_sanity_threshold, 500_000);
+    /// ```
     #[default = 1_000_000]
     pub gas_estimate_sanity_threshold: u128,
     /// Maximum number of consecutive failures tolerated during log streaming before giving up.
@@ -348,6 +360,17 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
         cfg: RpcOperationsConfig,
         use_dummy_nr: Option<bool>,
     ) -> Result<Self> {
+        if cfg.gas_oracle_fallback_max_fee < cfg.gas_estimate_sanity_threshold
+            || cfg.gas_oracle_fallback_priority_fee < cfg.gas_estimate_sanity_threshold
+        {
+            return Err(RpcError::Other(
+                "gas_oracle_fallback_max_fee and gas_oracle_fallback_priority_fee must each be >= \
+                 gas_estimate_sanity_threshold, otherwise a degenerate estimate would be replaced with another \
+                 degenerate value"
+                    .to_string(),
+            ));
+        }
+
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .filler(ChainIdFiller::default())

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -126,6 +126,17 @@ pub struct RpcOperationsConfig {
     /// Defaults to 0.1 gwei (100,000,000 wei) which is suitable for Gnosis chain.
     #[default = 100_000_000]
     pub gas_oracle_fallback_priority_fee: u128,
+    /// Sanity threshold (in wei) below which a gas estimate is treated as degenerate
+    /// (e.g. a misbehaving RPC endpoint returning a near-zero fee history) and replaced
+    /// with the fallback values above.
+    ///
+    /// This is deliberately far below normal gas prices, even on a cheap chain like
+    /// Gnosis, so it only catches genuinely broken estimates rather than legitimate
+    /// low-congestion pricing.
+    ///
+    /// Defaults to 0.001 gwei (1,000,000 wei).
+    #[default = 1_000_000]
+    pub gas_estimate_sanity_threshold: u128,
     /// Maximum number of consecutive failures tolerated during log streaming before giving up.
     ///
     /// When the indexer encounters errors while fetching logs, it will retry up to this many times


### PR DESCRIPTION
## Summary

Follow-up to #453, which introduced a "sanity floor" for `chainInfo`'s gas price estimates but had a real bug: it reused `gas_oracle_fallback_max_fee`/`gas_oracle_fallback_priority_fee` (3 Gwei / 0.1 Gwei — meant as a "reasonable fallback for total RPC failure") as the *detection threshold* for "is this estimate degenerate", not just as the replacement value.

Confirmed live on `blokli-jura-dev`: Gnosis Chain's actual current gas price (verified independently against a public RPC, not just Tenderly) is in the few-thousand-wei range under low congestion — legitimately far below 3 Gwei, but still ~2-4x above the ~2,300 wei seen during the original incident. So the floor fired on **every single** `chainInfo` call and always substituted the static fallback instead of the real (and perfectly valid) RPC estimate.

Fix: added a separate `gas_estimate_sanity_threshold` config (default 0.001 Gwei / 1,000,000 wei) used purely for detecting a degenerate estimate — comfortably below observed healthy prices, comfortably above the incident value. The existing 3 Gwei / 0.1 Gwei fallback values are now used only as the replacement once something is actually flagged as degenerate.

## Test plan

- [x] `just quick` (fmt, clippy, check) passes
- [x] `blokli-api` chain_info integration tests pass (11/11)
- [x] `blokli-chain-rpc` tests pass