### PR TITLE
fix: Apply statement logging settings to the SQLite connection path

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -32,7 +32,10 @@ use blokli_chain_rpc::{
     rpc::{RpcOperations, RpcOperationsConfig},
     transport::ReqwestClient,
 };
-use blokli_db::utils::redact_database_url;
+use blokli_db::{
+    db::{BlokliDbConfig, build_connect_options},
+    utils::redact_database_url,
+};
 use config::ApiConfig;
 use errors::{ApiError, ApiResult};
 use hopr_bindings::exports::alloy::{
@@ -82,7 +85,7 @@ pub async fn start_server(network: String, finality: u16, config: ApiConfig) -> 
     info!("Connecting to database: {}", redact_database_url(&config.database_url));
 
     // Connect to database
-    let db = Database::connect(&config.database_url).await?;
+    let db = Database::connect(build_connect_options(&config.database_url, &BlokliDbConfig::default())).await?;
     info!("Database connection established");
 
     // Create a default IndexerState for standalone API server

--- a/bloklid/src/main.rs
+++ b/bloklid/src/main.rs
@@ -17,7 +17,7 @@ use async_signal::{Signal, Signals};
 use blokli_chain_api::BlokliChain;
 use blokli_chain_indexer::{snapshot::SnapshotManager, startup, utils::redact_url};
 use blokli_db::{
-    db::{BlokliDb, BlokliDbConfig},
+    db::{BlokliDb, BlokliDbConfig, build_connect_options},
     utils::redact_database_url,
 };
 use clap::Parser;
@@ -256,7 +256,7 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
         let db = if is_in_memory {
             BlokliDb::new_in_memory().await?
         } else {
-            BlokliDb::new(&database_path, logs_database_path.as_deref(), db_config).await?
+            BlokliDb::new(&database_path, logs_database_path.as_deref(), db_config.clone()).await?
         };
 
         // Initialize singleton entries for chain_info and node_info
@@ -295,7 +295,7 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
             tracing::info!("Starting blokli-api server on {}", api_config.bind_address);
 
             // Connect to database for API server
-            let api_db = Database::connect(&database_path)
+            let api_db = Database::connect(build_connect_options(&database_path, &db_config))
                 .await
                 .map_err(|e| BloklidError::NonSpecific(format!("Failed to connect API database: {}", e)))?;
 

--- a/db/core/src/db.rs
+++ b/db/core/src/db.rs
@@ -6,7 +6,10 @@ use blokli_db_entity::{
 };
 use migration::{Migrator, MigratorChainLogs, MigratorIndex, MigratorTrait};
 use sea_orm::{ConnectOptions, Database, EntityTrait, Set, SqlxSqliteConnector, sea_query::OnConflict};
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{
+    ConnectOptions as _,
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+};
 use tracing::log::LevelFilter;
 use validator::Validate;
 
@@ -146,9 +149,13 @@ impl BlokliDb {
             // Helper to create SQLite pool
             let create_sqlite_pool = |url: String| async move {
                 // Parse URL to extract path and mode
-                let connect_opts: SqliteConnectOptions = url
+                let mut connect_opts: SqliteConnectOptions = url
                     .parse()
                     .map_err(|e| DbSqlError::Construction(format!("invalid SQLite URL: {e}")))?;
+                connect_opts = connect_opts.log_statements(LevelFilter::Debug);
+                if !cfg.log_slow_queries.is_zero() {
+                    connect_opts = connect_opts.log_slow_statements(LevelFilter::Warn, cfg.log_slow_queries);
+                }
 
                 let pool = SqlitePoolOptions::new()
                     .max_connections(cfg.max_connections)

--- a/db/core/src/db.rs
+++ b/db/core/src/db.rs
@@ -32,6 +32,30 @@ pub struct BlokliDbConfig {
     pub network_name: String,
 }
 
+/// Build [`ConnectOptions`] for a PostgreSQL connection with consistent pool sizing and
+/// statement logging settings.
+///
+/// Used by [`BlokliDb::new`] for its own connection(s), and by any other caller that opens
+/// a separate connection to the same database (e.g. the API server's own connection pool)
+/// so that all connections share the same logging behavior instead of falling back to
+/// SeaORM's own defaults (which log every statement at `INFO`, not `DEBUG`).
+pub fn build_connect_options(url: &str, cfg: &BlokliDbConfig) -> ConnectOptions {
+    let mut opt = ConnectOptions::new(url.to_string());
+    opt.max_connections(cfg.max_connections)
+        .min_connections(1)
+        .connect_timeout(Duration::from_secs(8))
+        .idle_timeout(Duration::from_secs(300))
+        .max_lifetime(Duration::from_secs(1800))
+        .sqlx_logging(true)
+        .sqlx_logging_level(LevelFilter::Debug);
+    // A zero duration means slow-query warnings are disabled; leave the setting at
+    // its default (Off) rather than warning on every statement.
+    if !cfg.log_slow_queries.is_zero() {
+        opt.sqlx_slow_statements_logging_settings(LevelFilter::Warn, cfg.log_slow_queries);
+    }
+    opt
+}
+
 /// Main database handle for HOPR node operations.
 ///
 /// For PostgreSQL: Uses a single database connection for all tables.
@@ -127,22 +151,7 @@ impl BlokliDb {
         }
 
         // Helper function to create connection options for PostgreSQL
-        let create_connection_opts = |url: &str| -> ConnectOptions {
-            let mut opt = ConnectOptions::new(url.to_string());
-            opt.max_connections(cfg.max_connections)
-                .min_connections(1)
-                .connect_timeout(Duration::from_secs(8))
-                .idle_timeout(Duration::from_secs(300))
-                .max_lifetime(Duration::from_secs(1800))
-                .sqlx_logging(true)
-                .sqlx_logging_level(LevelFilter::Debug);
-            // A zero duration means slow-query warnings are disabled; leave the setting at
-            // its default (Off) rather than warning on every statement.
-            if !cfg.log_slow_queries.is_zero() {
-                opt.sqlx_slow_statements_logging_settings(LevelFilter::Warn, cfg.log_slow_queries);
-            }
-            opt
-        };
+        let create_connection_opts = |url: &str| -> ConnectOptions { build_connect_options(url, &cfg) };
 
         // Create database connections
         let (db, logs_db) = if is_sqlite {


### PR DESCRIPTION
## Summary

PR #453's sqlx logging fix only touched `create_connection_opts`, which is used for the PostgreSQL connection path in `BlokliDb::new`. The SQLite path builds `SqliteConnectOptions` directly via `url.parse()` and calls `SqlitePoolOptions::connect_with()` without ever going through that closure — so SQLite deployments never got the fix at all.

Confirmed on `blokli-jura-dev`: its ConfigMap has no `database_url` at all, only `data_directory`, meaning it derives a SQLite path internally. Verified the running pod's image tag (`0.12.1-pr.453`) does contain #453's changes, yet `sqlx::query` entries for normal statements were still appearing at a level our PostgreSQL-side fix never touches, since this deployment never executes that code path in the first place.

Wires the same `log_statements(Debug)` / `log_slow_statements(Warn, log_slow_queries)` calls directly onto the SQLite `ConnectOptions`, matching what the PostgreSQL path already does.

## Test plan

- [x] `just quick` (fmt, clippy, check) passes
- [x] `blokli-db` db module tests pass (5/5)