### PR TITLE
fix(revert): remove chainInfo gas estimate sanity threshold/floor (#453, #454)

### DIFF
--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -204,35 +204,6 @@ fn scale_wei_by_multiplier(value: u128, multiplier: f64) -> u128 {
         / denominator
 }
 
-/// Resolves a legacy gas price estimate, substituting `fallback` when `estimated` is below
-/// `sanity_threshold` (e.g. a misbehaving RPC endpoint returning a near-zero fee).
-fn resolve_gas_price(estimated: u128, sanity_threshold: u128, fallback: u128) -> u128 {
-    if estimated < sanity_threshold {
-        fallback
-    } else {
-        estimated
-    }
-}
-
-/// Resolves EIP-1559 fee estimates, substituting both fallback values together when either
-/// component is below `sanity_threshold`, and enforcing `max_fee >= priority_fee` per EIP-1559.
-fn resolve_eip1559_fees(
-    max_fee: u128,
-    priority_fee: u128,
-    sanity_threshold: u128,
-    max_fee_fallback: u128,
-    priority_fee_fallback: u128,
-) -> (u128, u128) {
-    let below_threshold = max_fee < sanity_threshold || priority_fee < sanity_threshold;
-    let resolved_priority_fee = if below_threshold {
-        priority_fee_fallback
-    } else {
-        priority_fee
-    };
-    let resolved_max_fee = if below_threshold { max_fee_fallback } else { max_fee }.max(resolved_priority_fee);
-    (resolved_max_fee, resolved_priority_fee)
-}
-
 fn safe_from_current_row(
     current: CurrentSafe,
     registered_nodes: Vec<String>,
@@ -1423,29 +1394,9 @@ impl QueryRoot {
                 HoprRpcOperations::estimate_eip1559_fees(&**rpc)
             );
 
-            // The RPC endpoint's fee estimate (eth_gasPrice / eth_feeHistory) can occasionally return
-            // a degenerate near-zero value (e.g. a misbehaving provider), which would produce a
-            // transaction that can never be mined. Detection uses a sanity threshold far below any
-            // legitimate fee (even on a cheap chain like Gnosis); the replacement values are the
-            // separate, higher gas oracle fallback config. These must stay decoupled: using the
-            // fallback itself as the detection threshold would misfire on legitimate low-congestion
-            // prices, since Gnosis gas can normally be far below the fallback's "reasonable" value.
-            let sanity_threshold = rpc.config().gas_estimate_sanity_threshold;
-            let max_fee_fallback = rpc.config().gas_oracle_fallback_max_fee;
-            let priority_fee_fallback = rpc.config().gas_oracle_fallback_priority_fee;
-
             match gas_price_result {
                 Ok(estimated_gas_price) => {
-                    let resolved_gas_price = resolve_gas_price(estimated_gas_price, sanity_threshold, max_fee_fallback);
-                    if resolved_gas_price != estimated_gas_price {
-                        warn!(
-                            estimated_gas_price,
-                            sanity_threshold,
-                            fallback = max_fee_fallback,
-                            "estimated gas price below sanity threshold, using fallback instead"
-                        );
-                    }
-                    gas_price = Some(resolved_gas_price.to_string());
+                    gas_price = Some(estimated_gas_price.to_string());
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to fetch gas price estimate for chain_info");
@@ -1454,28 +1405,9 @@ impl QueryRoot {
 
             match eip1559_result {
                 Ok(fees) => {
-                    let (resolved_max_fee, resolved_priority_fee) = resolve_eip1559_fees(
-                        fees.max_fee_per_gas,
-                        fees.max_priority_fee_per_gas,
-                        sanity_threshold,
-                        max_fee_fallback,
-                        priority_fee_fallback,
-                    );
-                    if resolved_max_fee != fees.max_fee_per_gas
-                        || resolved_priority_fee != fees.max_priority_fee_per_gas
-                    {
-                        warn!(
-                            estimated_max_fee = fees.max_fee_per_gas,
-                            estimated_priority_fee = fees.max_priority_fee_per_gas,
-                            sanity_threshold,
-                            max_fee_fallback,
-                            priority_fee_fallback,
-                            "eip1559 fee estimate below sanity threshold, using fallback instead"
-                        );
-                    }
-                    max_fee_per_gas = Some(scale_wei_by_multiplier(resolved_max_fee, gas_multiplier).to_string());
+                    max_fee_per_gas = Some(scale_wei_by_multiplier(fees.max_fee_per_gas, gas_multiplier).to_string());
                     max_priority_fee_per_gas =
-                        Some(scale_wei_by_multiplier(resolved_priority_fee, gas_multiplier).to_string());
+                        Some(scale_wei_by_multiplier(fees.max_priority_fee_per_gas, gas_multiplier).to_string());
                 }
                 Err(e) => {
                     warn!(error = %e, "failed to fetch eip1559 fee estimate for chain_info");
@@ -1787,8 +1719,8 @@ mod tests {
     };
 
     use super::{
-        QueryRoot, SAFES_BALANCE_MAX_SAFES, check_safes_balance_cap, owners_for_safe, resolve_eip1559_fees,
-        resolve_gas_price, safe_from_current_row, scale_wei_by_multiplier,
+        QueryRoot, SAFES_BALANCE_MAX_SAFES, check_safes_balance_cap, owners_for_safe, safe_from_current_row,
+        scale_wei_by_multiplier,
     };
     use crate::{
         errors,
@@ -1827,46 +1759,6 @@ mod tests {
     #[test]
     fn test_scale_wei_by_multiplier_rounds_up() {
         assert_eq!(scale_wei_by_multiplier(3, 1.5), 5);
-    }
-
-    #[test]
-    fn test_resolve_gas_price_below_threshold_uses_fallback() {
-        assert_eq!(resolve_gas_price(99, 100, 500), 500);
-    }
-
-    #[test]
-    fn test_resolve_gas_price_at_threshold_uses_estimate() {
-        assert_eq!(resolve_gas_price(100, 100, 500), 100);
-    }
-
-    #[test]
-    fn test_resolve_gas_price_above_threshold_uses_estimate() {
-        assert_eq!(resolve_gas_price(101, 100, 500), 101);
-    }
-
-    #[test]
-    fn test_resolve_eip1559_fees_max_fee_below_threshold_uses_both_fallbacks() {
-        assert_eq!(resolve_eip1559_fees(99, 200, 100, 500, 50), (500, 50));
-    }
-
-    #[test]
-    fn test_resolve_eip1559_fees_priority_fee_below_threshold_uses_both_fallbacks() {
-        assert_eq!(resolve_eip1559_fees(200, 99, 100, 500, 50), (500, 50));
-    }
-
-    #[test]
-    fn test_resolve_eip1559_fees_both_at_or_above_threshold_uses_estimates() {
-        assert_eq!(resolve_eip1559_fees(200, 150, 100, 500, 50), (200, 150));
-    }
-
-    #[test]
-    fn test_resolve_eip1559_fees_enforces_max_fee_invariant_when_priority_fallback_dominates() {
-        // Both estimates are below threshold, so both fallbacks apply. If priority_fee_fallback
-        // exceeds max_fee_fallback, the resolved max fee must still be raised to match it, since
-        // max_fee_per_gas >= max_priority_fee_per_gas per EIP-1559.
-        let (max_fee, priority_fee) = resolve_eip1559_fees(50, 50, 100, 50, 500);
-        assert_eq!((max_fee, priority_fee), (500, 500));
-        assert!(max_fee >= priority_fee);
     }
 
     #[test]

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -126,29 +126,6 @@ pub struct RpcOperationsConfig {
     /// Defaults to 0.1 gwei (100,000,000 wei) which is suitable for Gnosis chain.
     #[default = 100_000_000]
     pub gas_oracle_fallback_priority_fee: u128,
-    /// Sanity threshold (in wei) below which a gas estimate is treated as degenerate
-    /// (e.g. a misbehaving RPC endpoint returning a near-zero fee history) and replaced
-    /// with the fallback values above.
-    ///
-    /// This is deliberately far below normal gas prices, even on a cheap chain like
-    /// Gnosis, so it only catches genuinely broken estimates rather than legitimate
-    /// low-congestion pricing.
-    ///
-    /// Defaults to 0.001 gwei (1,000,000 wei).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use blokli_chain_rpc::rpc::RpcOperationsConfig;
-    ///
-    /// let config = RpcOperationsConfig {
-    ///     gas_estimate_sanity_threshold: 500_000,
-    ///     ..Default::default()
-    /// };
-    /// assert_eq!(config.gas_estimate_sanity_threshold, 500_000);
-    /// ```
-    #[default = 1_000_000]
-    pub gas_estimate_sanity_threshold: u128,
     /// Maximum number of consecutive failures tolerated during log streaming before giving up.
     ///
     /// When the indexer encounters errors while fetching logs, it will retry up to this many times
@@ -360,17 +337,6 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
         cfg: RpcOperationsConfig,
         use_dummy_nr: Option<bool>,
     ) -> Result<Self> {
-        if cfg.gas_oracle_fallback_max_fee < cfg.gas_estimate_sanity_threshold
-            || cfg.gas_oracle_fallback_priority_fee < cfg.gas_estimate_sanity_threshold
-        {
-            return Err(RpcError::Other(
-                "gas_oracle_fallback_max_fee and gas_oracle_fallback_priority_fee must each be >= \
-                 gas_estimate_sanity_threshold, otherwise a degenerate estimate would be replaced with another \
-                 degenerate value"
-                    .to_string(),
-            ));
-        }
-
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .filler(ChainIdFiller::default())
@@ -402,11 +368,6 @@ impl<R: HttpRequestor + 'static + Clone> RpcOperations<R> {
             cfg,
             provider: Arc::new(provider),
         })
-    }
-
-    /// Get the configuration this instance was created with
-    pub fn config(&self) -> &RpcOperationsConfig {
-        &self.cfg
     }
 
     /// Get the current block number from the RPC endpoint, adjusted for finality


### PR DESCRIPTION
## Summary

Reverts the `chainInfo` gas estimation changes from #453 and #454. The deployed fix was found to actively impact real node transactions in production and was rolled back — see #457 for the full investigation, timeline, and handoff notes.

**Scope:** only the gas estimation logic is reverted (`api/src/query.rs`, `chain/rpc/src/rpc.rs` — the sanity threshold field, its validation, the fallback substitution logic, and the `RpcOperations::config()` getter that existed solely to support it).

**Not reverted:** the sqlx statement logging changes also introduced in #453 (`db/core/src/db.rs`) are unrelated to the gas issue and are kept, along with #455's follow-up fix to the same logging mechanism.

After this merges, `chainInfo`'s `gasPrice`/`maxFeePerGas`/`maxPriorityFeePerGas` return the RPC's estimate unmodified again, with no sanity threshold or fallback substitution — matching pre-#453 behavior.

## Test plan

- [x] `just quick` (fmt, clippy, check) passes
- [x] `blokli-api` chain_info integration tests pass (11/11)
- [x] `blokli-chain-rpc` tests pass
- [x] `blokli-db` db module tests pass (unaffected, confirming `db.rs`'s logging changes are untouched)

Closes the immediate need in #457; the underlying stuck-transaction root cause (degenerate RPC fee estimates) remains open for further investigation per that issue.