### PR TITLE
fix: use separate signers for local contract deployment

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -31,4 +31,14 @@ ignore = [
   # Status: Insufficient archive validation can cause out-of-bounds reads in archives containing Rc/Arc
   # Review by: 2026-06-30
   "RUSTSEC-2026-0235",
+
+  # RUSTSEC-2026-0253
+  # Crate: lru 0.16.4
+  # Status: unsound  
+  "RUSTSEC-2026-0253",
+
+  # RUSTSEC-2026-0249
+  # Crate: smartstrings 1.0.1
+  # Status: unmaintained
+  "RUSTSEC-2026-0249",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,7 +2476,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2977,7 +2977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3432,7 +3432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3857,9 +3857,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5195,7 +5195,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6133,7 +6133,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6673,7 +6673,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6732,7 +6732,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7973,7 +7973,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8860,7 +8860,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ just docker-run-anvil trace
 | `ANVIL_ACCOUNTS`                      | `10`                      | Number of accounts to create                             |
 | `ANVIL_BALANCE`                       | `10000`                   | Initial balance per account in ETH                       |
 | `ANVIL_RPC_URL`                       | derived from `ANVIL_PORT` | URL used for readiness checks, deployment, and `bloklid` |
-| `ANVIL_DEPLOYER_PRIVATE_KEY`          | Anvil's first account     | Private key for contract deployment                      |
+| `ANVIL_DEPLOYER_PRIVATE_KEY`          | Anvil's first account     | Private key for HOPR contract deployment                 |
+| `ANVIL_COMMON_DEPLOYER_PRIVATE_KEY`   | Anvil's second account    | Private key for common contract deployment               |
 | `BLOKLI_DEPLOYER_TICKET_PRICE`        | `100 wei wxHOPR`          | Initial ticket price oracle value                        |
 | `BLOKLI_DEPLOYER_WINNING_PROBABILITY` | `0.000125`                | Initial winning probability oracle value                 |
 | `BLOKLI_DATA_DIRECTORY`               | `/data`                   | Data directory for SQLite databases                      |
@@ -344,9 +345,10 @@ xhopr_token = "0x0000000000000000000000000000000000000000"
 
 These variables configure `blokli-contract-deployer` when it is run directly. Command-line options take precedence.
 
-| Environment Variable                  | Default                   | Description                       |
-| ------------------------------------- | ------------------------- | --------------------------------- |
-| `BLOKLI_DEPLOYER_RPC_URL`             | `http://127.0.0.1:8545`   | Deployment RPC endpoint           |
-| `ANVIL_DEPLOYER_PRIVATE_KEY`          | Anvil's first account key | Contract deployer private key     |
-| `BLOKLI_DEPLOYER_TICKET_PRICE`        | `100 wei wxHOPR`          | Initial ticket price oracle value |
-| `BLOKLI_DEPLOYER_WINNING_PROBABILITY` | `0.000125`                | Initial winning probability       |
+| Environment Variable                  | Default                    | Description                       |
+| ------------------------------------- | -------------------------- | --------------------------------- |
+| `BLOKLI_DEPLOYER_RPC_URL`             | `http://127.0.0.1:8545`    | Deployment RPC endpoint           |
+| `ANVIL_DEPLOYER_PRIVATE_KEY`          | Anvil's first account key  | HOPR contract deployer key        |
+| `ANVIL_COMMON_DEPLOYER_PRIVATE_KEY`   | Anvil's second account key | Common contract deployer key      |
+| `BLOKLI_DEPLOYER_TICKET_PRICE`        | `100 wei wxHOPR`           | Initial ticket price oracle value |
+| `BLOKLI_DEPLOYER_WINNING_PROBABILITY` | `0.000125`                 | Initial winning probability       |

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -5,10 +5,11 @@ use std::{
 
 use blokli_chain_types::ContractAddresses as BlokliContractAddresses;
 use clap::Parser;
-use hopli_lib::utils::{a2h, h2a};
+use hopli_lib::utils::h2a;
 use hopr_bindings::{
     config::ContractInstances,
     exports::alloy::{
+        network::EthereumWallet,
         primitives::{U256, aliases::U56},
         providers::ProviderBuilder,
         rpc::client::ClientBuilder,
@@ -18,7 +19,6 @@ use hopr_bindings::{
 };
 use hopr_types::{
     chain::ContractAddresses,
-    crypto::keypairs::{ChainKeypair, Keypair},
     internal::prelude::WinningProbability,
     primitive::{prelude::HoprBalance, traits::IntoEndian},
 };
@@ -26,7 +26,10 @@ use serde::Serialize;
 use tracing_subscriber::{Layer as _, prelude::*};
 use url::Url;
 
-const DEFAULT_ANVIL_PRIVATE_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const DEFAULT_ANVIL_HOPR_DEPLOYER_PRIVATE_KEY: &str =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const DEFAULT_ANVIL_COMMON_DEPLOYER_PRIVATE_KEY: &str =
+    "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 static PANIC_HOOK_INSTALLED: Once = Once::new();
 
 #[derive(Debug, Parser)]
@@ -39,9 +42,21 @@ struct Args {
     #[arg(long, env = "BLOKLI_DEPLOYER_RPC_URL", default_value = "http://127.0.0.1:8545")]
     rpc_url: String,
 
-    /// Private key used to deploy contracts
-    #[arg(long, env = "ANVIL_DEPLOYER_PRIVATE_KEY", default_value = DEFAULT_ANVIL_PRIVATE_KEY)]
+    /// Private key used to deploy HOPR contracts
+    #[arg(
+        long,
+        env = "ANVIL_DEPLOYER_PRIVATE_KEY",
+        default_value = DEFAULT_ANVIL_HOPR_DEPLOYER_PRIVATE_KEY
+    )]
     private_key: String,
+
+    /// Private key used to deploy common contracts such as ERC1820 and the Safe suite
+    #[arg(
+        long,
+        env = "ANVIL_COMMON_DEPLOYER_PRIVATE_KEY",
+        default_value = DEFAULT_ANVIL_COMMON_DEPLOYER_PRIVATE_KEY
+    )]
+    common_private_key: String,
 
     /// Minimum ticket price to set on the deployed HoprTicketPriceOracle.
     /// Defaults to the live jura-dev value so the local cluster behaves like jura-dev.
@@ -74,17 +89,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let args = Args::parse();
 
-    let signer = PrivateKeySigner::from_str(&args.private_key)?;
-    let signer_chain_key = ChainKeypair::from_secret(signer.to_bytes().as_ref())?;
-    let signer_address = signer.address();
+    let common_deployer_signer = PrivateKeySigner::from_str(&args.common_private_key)?;
+    let hopr_deployer_signer = PrivateKeySigner::from_str(&args.private_key)?;
+    let common_deployer_address = common_deployer_signer.address();
+    let hopr_deployer_address = hopr_deployer_signer.address();
+    let mut wallet = EthereumWallet::from(common_deployer_signer);
+    wallet.register_default_signer(hopr_deployer_signer);
 
     let rpc_url = Url::parse(&args.rpc_url)?;
     let rpc_client = ClientBuilder::default().http(rpc_url);
-    let provider = ProviderBuilder::new().wallet(signer).connect_client(rpc_client);
+    let provider = ProviderBuilder::new().wallet(wallet).connect_client(rpc_client);
 
-    // The local deployment uses a single signer for both the HOPR and common contract deployers.
-    let deployer_address = a2h(signer_chain_key.public().to_address());
-    let instances = ContractInstances::deploy_for_testing(provider, deployer_address, deployer_address).await?;
+    let instances =
+        ContractInstances::deploy_for_testing(provider, hopr_deployer_address, common_deployer_address).await?;
     let contracts = ContractAddresses::from(&instances);
     let output = ContractsOutput {
         contracts: BlokliContractAddresses {
@@ -106,18 +123,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let minter_role = instances.token.MINTER_ROLE().call().await?;
     instances
         .token
-        .grantRole(minter_role, signer_address)
+        .grantRole(minter_role, hopr_deployer_address)
         .send()
         .await?
         .watch()
         .await?;
-    tracing::info!(%signer_address, "granted minter role to Anvil account");
+    tracing::info!(%hopr_deployer_address, "granted minter role to Anvil account");
 
     // Mint 10M tokens to Anvil account 0
     instances
         .token
         .mint(
-            signer_address,
+            hopr_deployer_address,
             "10000000000000000000000000".parse()?,
             Default::default(),
             Default::default(),
@@ -126,7 +143,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?
         .watch()
         .await?;
-    tracing::info!(%signer_address, "minted tokens to Anvil account");
+    tracing::info!(%hopr_deployer_address, "minted tokens to Anvil account");
 
     // Update the stake factory to use correct addresses
     let network = instances.stake_factory.defaultHoprNetwork().call().await?;

--- a/docker/blokli-anvil-entrypoint.sh
+++ b/docker/blokli-anvil-entrypoint.sh
@@ -55,6 +55,9 @@ DEPLOYER_ARGS=()
 if [ -n "${ANVIL_DEPLOYER_PRIVATE_KEY:-}" ]; then
   DEPLOYER_ARGS+=(--private-key "${ANVIL_DEPLOYER_PRIVATE_KEY}")
 fi
+if [ -n "${ANVIL_COMMON_DEPLOYER_PRIVATE_KEY:-}" ]; then
+  DEPLOYER_ARGS+=(--common-private-key "${ANVIL_COMMON_DEPLOYER_PRIVATE_KEY}")
+fi
 
 # Deploy contracts with error handling
 if ! blokli-contract-deployer \


### PR DESCRIPTION
*Ports the change from https://github.com/hoprnet/blokli-client/pull/19*

- Enable two signers in the provider
- Update the local private key to match with the default anvil private key