### PR TITLE
feat: index and expose Curvy state

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -93,12 +93,12 @@ jobs:
           {
             "runner": "depot-ubuntu-24.04-4",
             "architecture": "x86_64-linux",
-            "build_command": "nix build -L .#docker-bloklid-anvil-x86_64-linux"
+            "build_command": "nix build -L .#docker-bloklid-anvil-curvy-x86_64-linux"
           }
         ]
       cachix_cache_name: blokli
       build_file: bloklid/Cargo.toml
-      docker_image_name: bloklid-anvil
+      docker_image_name: bloklid-anvil-curvy
       docker_image_format: skopeo
       concurrency_group_suffix: anvil
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,10 @@ target
 
 # make sure anything which is vendored is copied
 !/vendor/**/*
-vendor/.DS_Store
-vendor/cargo/.DS_Store
+
+# Local operating-system and agent metadata
+.DS_Store
+/.codex/
 
 # nix generated files
 result
@@ -45,4 +47,3 @@ local/
 /.npm/
 
 *.log
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "fixed-cache",
- "foldhash",
+ "foldhash 0.2.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
@@ -874,6 +874,7 @@ checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec 0.6.0",
  "ark-ff 0.6.0",
+ "ark-r1cs-std",
  "ark-std 0.6.0",
 ]
 
@@ -892,7 +893,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -913,7 +914,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -930,7 +931,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -950,7 +951,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -971,7 +972,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "zeroize",
@@ -989,7 +990,7 @@ dependencies = [
  "ark-std 0.6.0",
  "digest 0.10.7",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "zeroize",
 ]
@@ -1040,7 +1041,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1052,7 +1053,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1065,7 +1066,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1078,7 +1079,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1116,6 +1117,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-r1cs-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-relations",
+ "ark-std 0.6.0",
+ "educe",
+ "itertools 0.14.0",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
+dependencies = [
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash 0.1.5",
+ "indexmap 2.14.0",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ark-secp256k1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41b34e9124731f4834db5a8f92ce085a47cd6f006fdb50359ea508d6256341d"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,7 +1179,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1146,7 +1192,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1158,7 +1204,7 @@ dependencies = [
  "ark-serialize-derive 0.6.0",
  "ark-std 0.6.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
  "serde_with",
 ]
 
@@ -1300,7 +1346,7 @@ checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
 dependencies = [
  "bytes",
  "half",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
 ]
 
@@ -1818,7 +1864,7 @@ checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
 dependencies = [
  "autocfg",
  "libm",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "serde",
@@ -1940,6 +1986,7 @@ dependencies = [
  "blokli-db-migration",
  "chrono",
  "clap",
+ "curvy-bindings",
  "env_logger",
  "futures",
  "hex",
@@ -2030,6 +2077,7 @@ dependencies = [
  "blokli-db",
  "blokli-db-entity",
  "chrono",
+ "curvy-bindings",
  "futures",
  "futures-util",
  "hex-literal",
@@ -2059,6 +2107,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "blokli-chain-types",
+ "curvy-bindings",
  "env_logger",
  "futures",
  "futures-timer",
@@ -2092,6 +2141,7 @@ dependencies = [
 name = "blokli-chain-types"
 version = "0.4.0"
 dependencies = [
+ "curvy-core",
  "hex-literal",
  "hopr-bindings",
  "hopr-types",
@@ -2177,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-signal",
@@ -2191,6 +2241,7 @@ dependencies = [
  "blokli-db",
  "clap",
  "config",
+ "curvy-bindings",
  "flagset",
  "futures",
  "hopli",
@@ -2203,6 +2254,7 @@ dependencies = [
  "opentelemetry_sdk",
  "sea-orm",
  "serde",
+ "serde_json",
  "serde_with",
  "smart-default",
  "strum 0.28.0",
@@ -2868,6 +2920,43 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "curvy-bindings"
+version = "0.1.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372a02d382ff9d8ec31e1063b83e416b18fb58a1952ed858e1fc7602227f094d"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
+name = "curvy-core"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad039edd8eb265c92104aaff6758113893e198c384e0301881f127155bd9ce03"
+dependencies = [
+ "aes",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-secp256k1",
+ "ctr",
+ "getrandom 0.2.17",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "num-bigint 0.5.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3606,6 +3695,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -3944,7 +4039,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3954,7 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -5203,6 +5298,16 @@ name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -6575,7 +6680,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ blokli-db-migration = { path = "db/migration" }
 chrono = "0.4.45"
 clap = { version = "4.6.1", features = ["derive", "env", "string"] }
 config = "0.15.23"
+# Exact pins until Curvy publishes its stable crates
+curvy-bindings = { version = "=0.1.0-rc.5" }
+curvy-core = "=0.1.0-rc.3"
 dashmap = "6.2.1"
 env_logger = "0.11.10"
 flagset = "0.4.7"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -90,6 +90,7 @@ lazy_static = { workspace = true, optional = true }
 [dev-dependencies]
 base64ct            = { workspace = true, features = ["alloc"] }
 blokli-db-migration = { path = "../db/migration" }
+curvy-bindings      = { workspace = true }
 env_logger          = { workspace = true }
 hopr-types          = { workspace = true, features = ["internal"] }
 insta               = { workspace = true, features = ["redactions", "yaml"] }

--- a/api/src/curvy.rs
+++ b/api/src/curvy.rs
@@ -1,0 +1,470 @@
+use blokli_api_types::{
+    CurvyCommittedNote, CurvyCommittedNullifier, CurvyEventCursor, CurvyEventPosition, CurvyPendingNote,
+    CurvyShardRoot, CurvySyncCheckpoint, CurvySyncNote, Hex32, UInt64, UInt256,
+};
+use blokli_db_entity::{
+    curvy_committed_note::{self, Model as DbCurvyCommittedNote},
+    curvy_committed_nullifier,
+    curvy_pending_note::{self, Model as DbCurvyPendingNote},
+    curvy_shard_root,
+    curvy_sync_checkpoint::{self, Model as DbCurvySyncCheckpoint},
+};
+use hopr_bindings::exports::alloy::primitives::U256;
+use hopr_types::{
+    crypto::types::Hash,
+    primitive::{primitives::Address, traits::ToHex},
+};
+use sea_orm::{ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder};
+
+use crate::{errors, validation::validate_eth_address};
+
+type CurvyResult<T> = std::result::Result<T, blokli_api_types::QueryFailedError>;
+
+const PAGE_DEFAULT_LIMIT: u64 = 100;
+const PAGE_MAX_LIMIT: u64 = 1000;
+pub const NOTE_LOOKUP_BATCH_SIZE: usize = 900;
+
+#[derive(Clone, Copy)]
+pub struct DatabaseEventCursor {
+    pub block: i64,
+    pub transaction_index: i64,
+    pub log_index: i64,
+    pub event_item_index: i64,
+    /// Branch the cursor was issued on, when the client supplied one.
+    pub block_hash: Option<[u8; 32]>,
+}
+
+pub fn page_limit(first: Option<i32>) -> CurvyResult<u64> {
+    match first {
+        None => Ok(PAGE_DEFAULT_LIMIT),
+        Some(first) if first > 0 && u64::try_from(first).is_ok_and(|first| first <= PAGE_MAX_LIMIT) => {
+            u64::try_from(first).map_err(|error| errors::invalid_pagination(&error.to_string()))
+        }
+        Some(_) => Err(errors::invalid_pagination("first must be between 1 and 1000")),
+    }
+}
+
+pub fn from_block(from_block: Option<UInt64>) -> CurvyResult<Option<i64>> {
+    from_block
+        .map(|block| {
+            i64::try_from(block.0)
+                .map_err(|_| errors::invalid_pagination("fromBlock exceeds the supported database range"))
+        })
+        .transpose()
+}
+
+pub fn event_cursor(cursor: Option<CurvyEventCursor>) -> CurvyResult<Option<DatabaseEventCursor>> {
+    cursor
+        .map(|cursor| {
+            let convert = |value: UInt64| {
+                i64::try_from(value.0)
+                    .map_err(|_| errors::invalid_pagination("cursor exceeds the supported database range"))
+            };
+            let block_hash = cursor
+                .block_hash
+                .as_ref()
+                .map(|hash| bytes32(&hex32_bytes(hash)?, "cursor blockHash"))
+                .transpose()?;
+            Ok(DatabaseEventCursor {
+                block: convert(cursor.block)?,
+                transaction_index: convert(cursor.transaction_index)?,
+                log_index: convert(cursor.log_index)?,
+                event_item_index: convert(cursor.event_item_index)?,
+                block_hash,
+            })
+        })
+        .transpose()
+}
+
+/// Rejects a cursor whose anchoring block is no longer the one at that position.
+///
+/// `stored` is the block hash currently recorded at the cursor's exact position, or
+/// `None` when no row sits there any more. Either a mismatch or an absent row means the
+/// branch the cursor was issued on was reorganized away, so continuing with an exclusive
+/// `>` comparison would silently skip the canonical replacement at that position.
+///
+/// Cursors without an anchor are accepted unchanged.
+pub fn ensure_cursor_anchor(cursor: &DatabaseEventCursor, stored: Option<&[u8]>) -> CurvyResult<()> {
+    let Some(expected) = cursor.block_hash.as_ref() else {
+        return Ok(());
+    };
+    if stored == Some(expected.as_slice()) {
+        Ok(())
+    } else {
+        Err(errors::invalid_pagination(
+            "cursor is anchored to a block that is no longer canonical; re-read the event history from an earlier position",
+        ))
+    }
+}
+
+pub fn event_cursor_condition<C>(
+    block: C,
+    transaction_index: C,
+    log_index: C,
+    event_item_index: C,
+    cursor: DatabaseEventCursor,
+) -> Condition
+where
+    C: ColumnTrait + Copy,
+{
+    Condition::any()
+        .add(block.gt(cursor.block))
+        .add(
+            Condition::all()
+                .add(block.eq(cursor.block))
+                .add(transaction_index.gt(cursor.transaction_index)),
+        )
+        .add(
+            Condition::all()
+                .add(block.eq(cursor.block))
+                .add(transaction_index.eq(cursor.transaction_index))
+                .add(log_index.gt(cursor.log_index)),
+        )
+        .add(
+            Condition::all()
+                .add(block.eq(cursor.block))
+                .add(transaction_index.eq(cursor.transaction_index))
+                .add(log_index.eq(cursor.log_index))
+                .add(event_item_index.gt(cursor.event_item_index)),
+        )
+}
+
+pub fn dense_start(from_index: Option<UInt64>) -> CurvyResult<i64> {
+    i64::try_from(from_index.unwrap_or(UInt64(0)).0)
+        .map_err(|_| errors::invalid_pagination("fromIndex exceeds the supported database range"))
+}
+
+pub fn page_next_index(start: i64, total: i64, last: Option<i64>) -> CurvyResult<UInt64> {
+    if total < 0 {
+        return Err(errors::invalid_db_data(
+            "checkpoint count",
+            "expected a non-negative value",
+        ));
+    }
+    let next = match last {
+        Some(last) => last
+            .checked_add(1)
+            .ok_or_else(|| errors::invalid_db_data("dense index", "next index exceeds the database range"))?,
+        None => start.min(total),
+    }
+    .min(total);
+    u64::try_from(next)
+        .map(UInt64)
+        .map_err(|_| errors::invalid_db_data("dense index", "expected a non-negative value"))
+}
+
+pub fn page_total(total: i64) -> CurvyResult<UInt64> {
+    u64::try_from(total)
+        .map(UInt64)
+        .map_err(|_| errors::invalid_db_data("checkpoint count", "expected a non-negative value"))
+}
+
+pub fn validate_page_start(start: i64, total: i64) -> CurvyResult<()> {
+    if total < 0 {
+        return Err(errors::invalid_db_data(
+            "checkpoint count",
+            "expected a non-negative value",
+        ));
+    }
+    if start > total {
+        return Err(errors::invalid_pagination(
+            "fromIndex must not exceed the checkpoint total",
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_dense_page(
+    indices: impl IntoIterator<Item = i64>,
+    start: i64,
+    total: i64,
+    field: &str,
+) -> CurvyResult<()> {
+    if total < 0 {
+        return Err(errors::invalid_db_data(
+            "checkpoint count",
+            "expected a non-negative value",
+        ));
+    }
+    let mut expected = start;
+    for index in indices {
+        if index != expected {
+            return Err(errors::invalid_db_data(
+                field,
+                &format!("expected dense index {expected}, found {index}"),
+            ));
+        }
+        expected = expected
+            .checked_add(1)
+            .ok_or_else(|| errors::invalid_db_data(field, "next index exceeds the database range"))?;
+    }
+    if expected == start && start < total {
+        return Err(errors::invalid_db_data(
+            field,
+            &format!("dense index {start} is missing before checkpoint total {total}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Confirms a pinned checkpoint still exists once its page has been read.
+///
+/// Curvy rollback deletes event rows, shard roots and checkpoints at or after the first
+/// affected block in a single transaction. A checkpoint that survives that deletion is
+/// therefore older than the reorganized suffix, and every row below its counts was
+/// written before it, so nothing the page returned can have been replaced. A checkpoint
+/// that is gone pinned an orphaned branch, and its page must not be served: the dense
+/// indexes alone cannot distinguish replacement rows, because replay rebuilds them with
+/// the same values.
+///
+/// Callers must invoke this *after* reading the page, not before.
+pub async fn ensure_checkpoint_still_pinned(
+    db: &DatabaseConnection,
+    checkpoint: &DbCurvySyncCheckpoint,
+) -> CurvyResult<()> {
+    let survived = curvy_sync_checkpoint::Entity::find()
+        .filter(curvy_sync_checkpoint::Column::BlockHash.eq(checkpoint.block_hash.clone()))
+        .one(db)
+        .await
+        .map_err(|error| errors::query_failed("re-check Curvy sync checkpoint", error))?
+        .is_some();
+
+    if survived {
+        Ok(())
+    } else {
+        Err(errors::query_failed(
+            "serve checkpoint-pinned Curvy page",
+            "the pinned checkpoint was removed by a chain reorganization; re-read the checkpoint and retry",
+        ))
+    }
+}
+
+pub async fn load_checkpoint(
+    db: &DatabaseConnection,
+    block_hash: Option<&Hex32>,
+) -> CurvyResult<DbCurvySyncCheckpoint> {
+    let mut query = curvy_sync_checkpoint::Entity::find();
+    let identifier = if let Some(block_hash) = block_hash {
+        query = query.filter(curvy_sync_checkpoint::Column::BlockHash.eq(hex32_bytes(block_hash)?));
+        block_hash.0.clone()
+    } else {
+        query = query.order_by_desc(curvy_sync_checkpoint::Column::BlockNumber);
+        "latest".to_string()
+    };
+    query
+        .one(db)
+        .await
+        .map_err(|error| errors::query_failed("fetch Curvy sync checkpoint", error))?
+        .ok_or_else(|| errors::not_found("Curvy sync checkpoint", identifier))
+}
+
+pub fn pending_precedes_commit(pending: &DbCurvyPendingNote, committed: &DbCurvyCommittedNote) -> bool {
+    (
+        pending.published_block,
+        pending.published_tx_index,
+        pending.published_log_index,
+        pending.event_item_index,
+    ) <= (
+        committed.published_block,
+        committed.published_tx_index,
+        committed.published_log_index,
+        committed.event_item_index,
+    )
+}
+
+pub fn hex32_bytes(value: &Hex32) -> CurvyResult<Vec<u8>> {
+    let value = value.0.strip_prefix("0x").unwrap_or(&value.0);
+    hex::decode(value).map_err(|error| errors::validation_failed(&format!("invalid Hex32 value: {error}")))
+}
+
+pub fn hex32_array(value: &Hex32) -> CurvyResult<[u8; 32]> {
+    bytes32(&hex32_bytes(value)?, "Hex32")
+}
+
+pub fn uint256_bytes(value: &UInt256, field: &str) -> CurvyResult<[u8; 32]> {
+    value
+        .0
+        .parse::<U256>()
+        .map(|value| value.to_be_bytes())
+        .map_err(|error| errors::validation_failed(&format!("invalid {field}: {error}")))
+}
+
+pub fn require_contract(address: Address, contract: &str) -> CurvyResult<()> {
+    if address == Address::default() {
+        Err(errors::internal_error(
+            "Curvy configuration",
+            format!("{contract} address is not configured"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn address(value: &str) -> std::result::Result<Address, blokli_api_types::InvalidAddressError> {
+    validate_eth_address(value).map_err(|error| errors::invalid_address_from_message(value, error.message))?;
+    Address::from_hex(value).map_err(|error| errors::invalid_address_error(value, error))
+}
+
+pub fn bytes32(value: &[u8], field: &str) -> CurvyResult<[u8; 32]> {
+    value
+        .try_into()
+        .map_err(|_| errors::invalid_db_data(field, "expected exactly 32 bytes"))
+}
+
+fn hex32(value: &[u8], field: &str) -> CurvyResult<Hex32> {
+    Ok(Hex32(Hash::from(bytes32(value, field)?).to_hex()))
+}
+
+fn uint256(value: &[u8], field: &str) -> CurvyResult<UInt256> {
+    Ok(UInt256(U256::from_be_bytes(bytes32(value, field)?).to_string()))
+}
+
+pub fn uint256_value(value: [u8; 32]) -> UInt256 {
+    UInt256(U256::from_be_bytes(value).to_string())
+}
+
+fn uint64(value: i64, field: &str) -> CurvyResult<UInt64> {
+    u64::try_from(value)
+        .map(UInt64)
+        .map_err(|_| errors::invalid_db_data(field, "expected a non-negative 64-bit integer"))
+}
+
+fn int32(value: i64, field: &str) -> CurvyResult<i32> {
+    i32::try_from(value).map_err(|_| errors::invalid_db_data(field, "value exceeds the GraphQL Int range"))
+}
+
+fn dense_index(value: i64, field: &str) -> CurvyResult<UInt64> {
+    uint64(value, field)
+}
+
+fn position(
+    chain_tx_hash: &[u8],
+    block_hash: &[u8],
+    block: i64,
+    transaction_index: i64,
+    log_index: i64,
+    event_item_index: i64,
+) -> CurvyResult<CurvyEventPosition> {
+    Ok(CurvyEventPosition {
+        transaction_hash: hex32(chain_tx_hash, "chain_tx_hash")?,
+        block_hash: hex32(block_hash, "block_hash")?,
+        block: uint64(block, "published_block")?,
+        transaction_index: uint64(transaction_index, "published_tx_index")?,
+        log_index: uint64(log_index, "published_log_index")?,
+        event_item_index: uint64(event_item_index, "event_item_index")?,
+    })
+}
+
+pub fn pending_note(model: curvy_pending_note::Model) -> CurvyResult<CurvyPendingNote> {
+    Ok(CurvyPendingNote {
+        note_id: hex32(&model.note_id, "note_id")?,
+        ephemeral_key: vec![
+            uint256(&model.ephemeral_key_x, "ephemeral_key_x")?,
+            uint256(&model.ephemeral_key_y, "ephemeral_key_y")?,
+        ],
+        view_tag: int32(model.view_tag, "view_tag")?,
+        token_id: uint256(&model.token_id, "token_id")?,
+        amount: uint256(&model.amount, "amount")?,
+        is_plaintext: model.is_plaintext,
+        position: position(
+            &model.chain_tx_hash,
+            &model.block_hash,
+            model.published_block,
+            model.published_tx_index,
+            model.published_log_index,
+            model.event_item_index,
+        )?,
+    })
+}
+
+pub fn committed_note(model: curvy_committed_note::Model) -> CurvyResult<CurvyCommittedNote> {
+    Ok(CurvyCommittedNote {
+        batch_index: hex32(&model.batch_index, "batch_index")?,
+        note_id: hex32(&model.note_id, "note_id")?,
+        leaf_index: dense_index(model.leaf_index, "leaf_index")?,
+        position: position(
+            &model.chain_tx_hash,
+            &model.block_hash,
+            model.published_block,
+            model.published_tx_index,
+            model.published_log_index,
+            model.event_item_index,
+        )?,
+    })
+}
+
+pub fn committed_nullifier(model: curvy_committed_nullifier::Model) -> CurvyResult<CurvyCommittedNullifier> {
+    Ok(CurvyCommittedNullifier {
+        batch_index: hex32(&model.batch_index, "batch_index")?,
+        nullifier: hex32(&model.nullifier, "nullifier")?,
+        nullifier_index: dense_index(model.nullifier_index, "nullifier_index")?,
+        position: position(
+            &model.chain_tx_hash,
+            &model.block_hash,
+            model.published_block,
+            model.published_tx_index,
+            model.published_log_index,
+            model.event_item_index,
+        )?,
+    })
+}
+
+pub fn sync_checkpoint(model: curvy_sync_checkpoint::Model) -> CurvyResult<CurvySyncCheckpoint> {
+    let shard_height = uint64(model.shard_height, "shard_height")?;
+    let shard_height_bits =
+        u32::try_from(shard_height.0).map_err(|_| errors::invalid_db_data("shard_height", "value is too large"))?;
+    let shard_size = 1_u64
+        .checked_shl(shard_height_bits)
+        .ok_or_else(|| errors::invalid_db_data("shard_height", "shard size overflows UInt64"))?;
+    let aggregator_address = Address::try_from(model.aggregator_address.as_slice())
+        .map_err(|_| errors::invalid_db_data("aggregator_address", "expected exactly 20 bytes"))?;
+
+    Ok(CurvySyncCheckpoint {
+        block_number: uint64(model.block_number, "block_number")?,
+        block_hash: hex32(&model.block_hash, "block_hash")?,
+        aggregator_address: aggregator_address.to_hex(),
+        tree_version: int32(model.tree_version, "tree_version")?,
+        tree_depth: int32(model.tree_depth, "tree_depth")?,
+        shard_height: int32(model.shard_height, "shard_height")?,
+        shard_size: UInt64(shard_size),
+        note_count: uint64(model.leaf_count, "leaf_count")?,
+        nullifier_count: uint64(model.nullifier_count, "nullifier_count")?,
+        shard_count: uint64(model.shard_count, "shard_count")?,
+        notes_root: hex32(&model.root, "root")?,
+    })
+}
+
+pub fn sync_note(
+    model: curvy_committed_note::Model,
+    announcement: Option<curvy_pending_note::Model>,
+) -> CurvyResult<CurvySyncNote> {
+    Ok(CurvySyncNote {
+        leaf_index: dense_index(model.leaf_index, "leaf_index")?,
+        note_id: hex32(&model.note_id, "note_id")?,
+        batch_index: hex32(&model.batch_index, "batch_index")?,
+        announcement: announcement.map(pending_note).transpose()?,
+        commit_position: position(
+            &model.chain_tx_hash,
+            &model.block_hash,
+            model.published_block,
+            model.published_tx_index,
+            model.published_log_index,
+            model.event_item_index,
+        )?,
+    })
+}
+
+pub fn shard_root(model: curvy_shard_root::Model) -> CurvyResult<CurvyShardRoot> {
+    Ok(CurvyShardRoot {
+        shard_index: uint64(model.shard_index, "shard_index")?,
+        root: hex32(&model.root, "root")?,
+        completion_position: position(
+            &model.chain_tx_hash,
+            &model.block_hash,
+            model.completion_block,
+            model.completion_tx_index,
+            model.completion_log_index,
+            model.completion_event_item_index,
+        )?,
+    })
+}

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -112,6 +112,9 @@ pub mod codes {
     /// Request exceeds an allowed resource limit
     pub const LIMIT_EXCEEDED: &str = "LIMIT_EXCEEDED";
 
+    /// A subscription receiver fell behind its event source
+    pub const SUBSCRIPTION_LAGGED: &str = "SUBSCRIPTION_LAGGED";
+
     /// Requested schema version is not supported by this server
     pub const UNSUPPORTED_SCHEMA_VERSION: &str = "UNSUPPORTED_SCHEMA_VERSION";
 
@@ -225,6 +228,11 @@ pub mod messages {
         format!("Invalid pagination parameters: {}", reason)
     }
 
+    /// Subscription lag error message.
+    pub fn subscription_lagged(stream: &str, missed: impl std::fmt::Display) -> String {
+        format!("{stream} lagged and missed {missed} events; reconnect to resume from a persisted position")
+    }
+
     /// Resource limit exceeded message
     pub fn limit_exceeded(resource: &str, actual: impl std::fmt::Display, max: impl std::fmt::Display) -> String {
         format!(
@@ -248,11 +256,28 @@ pub mod messages {
 // GraphQL Error Builder Functions
 // ============================================================================
 
+/// Value accepted by the context-error builder.
+pub trait ContextErrorMessage {
+    fn context_error_message(self) -> String;
+}
+
+impl ContextErrorMessage for String {
+    fn context_error_message(self) -> String {
+        self
+    }
+}
+
+impl ContextErrorMessage for async_graphql::Error {
+    fn context_error_message(self) -> String {
+        self.message
+    }
+}
+
 /// Creates a QueryFailedError for context retrieval failures
-pub fn context_error(context_type: &str, error: impl std::fmt::Display) -> QueryFailedError {
+pub fn context_error(context_type: &str, error: impl ContextErrorMessage) -> QueryFailedError {
     QueryFailedError {
         code: codes::CONTEXT_ERROR.to_string(),
-        message: messages::context_error(context_type, error),
+        message: messages::context_error(context_type, error.context_error_message()),
     }
 }
 
@@ -529,4 +554,16 @@ pub fn unsupported_schema_version(version: u32) -> async_graphql::Error {
 pub fn invalid_schema_version_header() -> async_graphql::Error {
     async_graphql::Error::new("Invalid X-Blokli-Schema-Version header: expected a non-negative integer")
         .extend_with(|_, e| e.set("code", codes::INVALID_SCHEMA_VERSION_HEADER))
+}
+
+/// Adapts the shared query-error taxonomy for GraphQL surfaces that cannot return unions.
+pub fn graphql_error(error: QueryFailedError) -> async_graphql::Error {
+    let code = error.code;
+    async_graphql::Error::new(error.message).extend_with(|_, extensions| extensions.set("code", code))
+}
+
+/// Creates a top-level GraphQL error when a subscription can no longer guarantee lossless delivery.
+pub fn graphql_subscription_lagged_error(stream: &str, missed: impl std::fmt::Display) -> async_graphql::Error {
+    async_graphql::Error::new(messages::subscription_lagged(stream, missed))
+        .extend_with(|_, extensions| extensions.set("code", codes::SUBSCRIPTION_LAGGED))
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod config;
 pub mod conversions;
+mod curvy;
 pub mod errors;
 pub mod logging;
 pub mod metrics;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -104,6 +104,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             winning_probability_oracle: Address::default(),
                             node_stake_factory: Address::default(),
                             xhopr_token: Address::default(),
+                            curvy_aggregator: Address::default(),
+                            curvy_vault: Address::default(),
+                            curvy_portal_factory: Address::default(),
                         },
                         ..Default::default()
                     },

--- a/api/src/query.rs
+++ b/api/src/query.rs
@@ -5,12 +5,16 @@ use std::{collections::HashMap, sync::Arc};
 use async_graphql::{Context, ID, Object, Result, SimpleObject, Union};
 use blokli_api_types::{
     Account, AccountsList, AccountsResult, ChainInfo, ChainInfoResult, Channel, ChannelStats, ChannelStatsResult,
-    ChannelsList, ChannelsResult, ContractAddressMap, CountResult, HoprBalance, InvalidAddressError,
-    MissingFilterError, ModuleAddress, NativeBalance, QueryFailedError, RedeemedStats, RedeemedStatsFilter, Safe,
-    SafeHoprAllowance, SafeSelectorInput, SafesBalance, SafesBalanceResult, Token, TokenValueString, TransactionCount,
-    UInt64,
+    ChannelsList, ChannelsResult, ContractAddressMap, CountResult, CurvyAddress, CurvyAggregatorFees,
+    CurvyAggregatorState, CurvyBooleanValue, CurvyCommittedNotes, CurvyCommittedNullifiers, CurvyEventCursor,
+    CurvyGasFees, CurvyNoteStatus, CurvyPendingNotes, CurvyShardRootPage, CurvySyncCheckpoint, CurvySyncNotePage,
+    CurvySyncNullifierPage, CurvyVaultFees, CurvyVaultToken, CurvyVaultTokenCount, Hex32, HoprBalance,
+    InvalidAddressError, MissingFilterError, ModuleAddress, NativeBalance, QueryFailedError, RedeemedStats,
+    RedeemedStatsFilter, Safe, SafeHoprAllowance, SafeSelectorInput, SafesBalance, SafesBalanceResult, Token,
+    TokenValueString, TransactionCount, UInt64, UInt256,
 };
 use blokli_chain_api::transaction_store::TransactionStore;
+use blokli_chain_indexer::IndexerState;
 use blokli_chain_rpc::{HoprIndexerRpcOperations, HoprRpcOperations, rpc::RpcOperations};
 use blokli_chain_types::ContractAddresses;
 use blokli_db_entity::{
@@ -26,7 +30,9 @@ use blokli_db_entity::{
             fetch_safes_by_chain_key as fetch_safes_by_chain_key_db, fetch_safes_by_owner as fetch_safes_by_owner_db,
         },
     },
-    hopr_node_safe_registration,
+    curvy_committed_note, curvy_committed_nullifier,
+    curvy_pending_note::{self, Model as DbCurvyPendingNote},
+    curvy_shard_root, hopr_node_safe_registration,
     views::{account_current, channel_current},
 };
 use futures::future::try_join_all;
@@ -38,11 +44,12 @@ use hopr_types::{
         traits::{IntoEndian, ToHex},
     },
 };
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect};
 use tracing::warn;
 
 use crate::{
-    conversions::transaction_from_record, errors, mutation::TransactionResult, validation::validate_eth_address,
+    conversions::transaction_from_record, curvy, errors, mutation::TransactionResult, schema::RpcOperationsContext,
+    validation::validate_eth_address,
 };
 
 /// Result type for HOPR balance queries
@@ -98,6 +105,117 @@ pub enum SafeResult {
 #[derive(Union)]
 pub enum SafeByResult {
     Safes(SafesList),
+    InvalidAddress(InvalidAddressError),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyPendingNotesResult {
+    Notes(CurvyPendingNotes),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyCommittedNotesResult {
+    Notes(CurvyCommittedNotes),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyCommittedNullifiersResult {
+    Nullifiers(CurvyCommittedNullifiers),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvySyncCheckpointResult {
+    Checkpoint(CurvySyncCheckpoint),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvySyncNotesResult {
+    Page(CurvySyncNotePage),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvySyncNullifiersResult {
+    Page(CurvySyncNullifierPage),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyShardRootsResult {
+    Page(CurvyShardRootPage),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyAggregatorStateResult {
+    State(CurvyAggregatorState),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyNoteStatusResult {
+    Status(CurvyNoteStatus),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyValidNotesRootResult {
+    Valid(CurvyBooleanValue),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyNullifierSpentResult {
+    Spent(CurvyBooleanValue),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyVaultFeesResult {
+    Fees(CurvyVaultFees),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyAggregatorFeesResult {
+    Fees(CurvyAggregatorFees),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyVaultTokenCountResult {
+    Count(CurvyVaultTokenCount),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyVaultTokenResult {
+    Token(CurvyVaultToken),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyEntryPortalAddressResult {
+    Address(CurvyAddress),
+    InvalidAddress(InvalidAddressError),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyExitPortalAddressResult {
+    Address(CurvyAddress),
+    InvalidAddress(InvalidAddressError),
+    QueryFailed(QueryFailedError),
+}
+
+#[derive(Union)]
+pub enum CurvyPortalRegisteredResult {
+    Registered(CurvyBooleanValue),
     InvalidAddress(InvalidAddressError),
     QueryFailed(QueryFailedError),
 }
@@ -336,6 +454,767 @@ pub struct QueryRoot;
 
 #[Object]
 impl QueryRoot {
+    /// Retrieve Curvy notes emitted by `PendingNotes`, ordered by chain position.
+    #[graphql(name = "curvyPendingNotes")]
+    async fn curvy_pending_notes(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "fromBlock")] from_block: Option<UInt64>,
+        after: Option<CurvyEventCursor>,
+        first: Option<i32>,
+    ) -> CurvyPendingNotesResult {
+        let result = async {
+            let db = ctx
+                .data::<DatabaseConnection>()
+                .map_err(|error| errors::context_error("DatabaseConnection", error))?;
+            let mut query = curvy_pending_note::Entity::find();
+            if let Some(block) = curvy::from_block(from_block)? {
+                query = query.filter(curvy_pending_note::Column::PublishedBlock.gte(block));
+            }
+            if let Some(cursor) = curvy::event_cursor(after)? {
+                if cursor.block_hash.is_some() {
+                    let anchored = curvy_pending_note::Entity::find()
+                        .filter(curvy_pending_note::Column::PublishedBlock.eq(cursor.block))
+                        .filter(curvy_pending_note::Column::PublishedTxIndex.eq(cursor.transaction_index))
+                        .filter(curvy_pending_note::Column::PublishedLogIndex.eq(cursor.log_index))
+                        .filter(curvy_pending_note::Column::EventItemIndex.eq(cursor.event_item_index))
+                        .one(db)
+                        .await
+                        .map_err(|error| errors::query_failed("validate Curvy cursor anchor", error))?;
+                    curvy::ensure_cursor_anchor(&cursor, anchored.as_ref().map(|row| row.block_hash.as_slice()))?;
+                }
+                query = query.filter(curvy::event_cursor_condition(
+                    curvy_pending_note::Column::PublishedBlock,
+                    curvy_pending_note::Column::PublishedTxIndex,
+                    curvy_pending_note::Column::PublishedLogIndex,
+                    curvy_pending_note::Column::EventItemIndex,
+                    cursor,
+                ));
+            }
+            let notes = query
+                .order_by_asc(curvy_pending_note::Column::PublishedBlock)
+                .order_by_asc(curvy_pending_note::Column::PublishedTxIndex)
+                .order_by_asc(curvy_pending_note::Column::PublishedLogIndex)
+                .order_by_asc(curvy_pending_note::Column::EventItemIndex)
+                .limit(curvy::page_limit(first)?)
+                .all(db)
+                .await
+                .map_err(|error| errors::query_failed("fetch Curvy pending notes", error))?
+                .into_iter()
+                .map(curvy::pending_note)
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(CurvyPendingNotes { notes })
+        }
+        .await;
+        match result {
+            Ok(notes) => CurvyPendingNotesResult::Notes(notes),
+            Err(error) => CurvyPendingNotesResult::QueryFailed(error),
+        }
+    }
+
+    /// Retrieve Curvy notes emitted by `CommittedNotes`, ordered by chain position.
+    #[graphql(name = "curvyCommittedNotes")]
+    async fn curvy_committed_notes(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "fromBlock")] from_block: Option<UInt64>,
+        after: Option<CurvyEventCursor>,
+        first: Option<i32>,
+    ) -> CurvyCommittedNotesResult {
+        let result = async {
+            let db = ctx
+                .data::<DatabaseConnection>()
+                .map_err(|error| errors::context_error("DatabaseConnection", error))?;
+            let mut query = curvy_committed_note::Entity::find();
+            if let Some(block) = curvy::from_block(from_block)? {
+                query = query.filter(curvy_committed_note::Column::PublishedBlock.gte(block));
+            }
+            if let Some(cursor) = curvy::event_cursor(after)? {
+                if cursor.block_hash.is_some() {
+                    let anchored = curvy_committed_note::Entity::find()
+                        .filter(curvy_committed_note::Column::PublishedBlock.eq(cursor.block))
+                        .filter(curvy_committed_note::Column::PublishedTxIndex.eq(cursor.transaction_index))
+                        .filter(curvy_committed_note::Column::PublishedLogIndex.eq(cursor.log_index))
+                        .filter(curvy_committed_note::Column::EventItemIndex.eq(cursor.event_item_index))
+                        .one(db)
+                        .await
+                        .map_err(|error| errors::query_failed("validate Curvy cursor anchor", error))?;
+                    curvy::ensure_cursor_anchor(&cursor, anchored.as_ref().map(|row| row.block_hash.as_slice()))?;
+                }
+                query = query.filter(curvy::event_cursor_condition(
+                    curvy_committed_note::Column::PublishedBlock,
+                    curvy_committed_note::Column::PublishedTxIndex,
+                    curvy_committed_note::Column::PublishedLogIndex,
+                    curvy_committed_note::Column::EventItemIndex,
+                    cursor,
+                ));
+            }
+
+            let notes = query
+                .order_by_asc(curvy_committed_note::Column::PublishedBlock)
+                .order_by_asc(curvy_committed_note::Column::PublishedTxIndex)
+                .order_by_asc(curvy_committed_note::Column::PublishedLogIndex)
+                .order_by_asc(curvy_committed_note::Column::EventItemIndex)
+                .limit(curvy::page_limit(first)?)
+                .all(db)
+                .await
+                .map_err(|error| errors::query_failed("fetch Curvy committed notes", error))?
+                .into_iter()
+                .map(curvy::committed_note)
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(CurvyCommittedNotes { notes })
+        }
+        .await;
+        match result {
+            Ok(notes) => CurvyCommittedNotesResult::Notes(notes),
+            Err(error) => CurvyCommittedNotesResult::QueryFailed(error),
+        }
+    }
+
+    /// Retrieve Curvy nullifiers emitted by `CommittedNullifiers`.
+    #[graphql(name = "curvyCommittedNullifiers")]
+    async fn curvy_committed_nullifiers(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "fromBlock")] from_block: Option<UInt64>,
+        after: Option<CurvyEventCursor>,
+        first: Option<i32>,
+    ) -> CurvyCommittedNullifiersResult {
+        let result = async {
+            let db = ctx
+                .data::<DatabaseConnection>()
+                .map_err(|error| errors::context_error("DatabaseConnection", error))?;
+            let mut query = curvy_committed_nullifier::Entity::find();
+            if let Some(block) = curvy::from_block(from_block)? {
+                query = query.filter(curvy_committed_nullifier::Column::PublishedBlock.gte(block));
+            }
+            if let Some(cursor) = curvy::event_cursor(after)? {
+                if cursor.block_hash.is_some() {
+                    let anchored = curvy_committed_nullifier::Entity::find()
+                        .filter(curvy_committed_nullifier::Column::PublishedBlock.eq(cursor.block))
+                        .filter(curvy_committed_nullifier::Column::PublishedTxIndex.eq(cursor.transaction_index))
+                        .filter(curvy_committed_nullifier::Column::PublishedLogIndex.eq(cursor.log_index))
+                        .filter(curvy_committed_nullifier::Column::EventItemIndex.eq(cursor.event_item_index))
+                        .one(db)
+                        .await
+                        .map_err(|error| errors::query_failed("validate Curvy cursor anchor", error))?;
+                    curvy::ensure_cursor_anchor(&cursor, anchored.as_ref().map(|row| row.block_hash.as_slice()))?;
+                }
+                query = query.filter(curvy::event_cursor_condition(
+                    curvy_committed_nullifier::Column::PublishedBlock,
+                    curvy_committed_nullifier::Column::PublishedTxIndex,
+                    curvy_committed_nullifier::Column::PublishedLogIndex,
+                    curvy_committed_nullifier::Column::EventItemIndex,
+                    cursor,
+                ));
+            }
+            let nullifiers = query
+                .order_by_asc(curvy_committed_nullifier::Column::PublishedBlock)
+                .order_by_asc(curvy_committed_nullifier::Column::PublishedTxIndex)
+                .order_by_asc(curvy_committed_nullifier::Column::PublishedLogIndex)
+                .order_by_asc(curvy_committed_nullifier::Column::EventItemIndex)
+                .limit(curvy::page_limit(first)?)
+                .all(db)
+                .await
+                .map_err(|error| errors::query_failed("fetch Curvy committed nullifiers", error))?
+                .into_iter()
+                .map(curvy::committed_nullifier)
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(CurvyCommittedNullifiers { nullifiers })
+        }
+        .await;
+        match result {
+            Ok(nullifiers) => CurvyCommittedNullifiersResult::Nullifiers(nullifiers),
+            Err(error) => CurvyCommittedNullifiersResult::QueryFailed(error),
+        }
+    }
+
+    /// Retrieve the latest Curvy synchronization checkpoint or one pinned by block hash.
+    #[graphql(name = "curvySyncCheckpoint")]
+    async fn curvy_sync_checkpoint(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "blockHash")] block_hash: Option<Hex32>,
+    ) -> CurvySyncCheckpointResult {
+        let result = async {
+            let db = ctx
+                .data::<DatabaseConnection>()
+                .map_err(|error| errors::context_error("DatabaseConnection", error))?;
+            let indexer_state = ctx
+                .data::<IndexerState>()
+                .map_err(|error| errors::context_error("IndexerState", error))?;
+            let checkpoint_model = {
+                let _lock = indexer_state.acquire_watermark_lock().await;
+                curvy::load_checkpoint(db, block_hash.as_ref()).await?
+            };
+            curvy::sync_checkpoint(checkpoint_model)
+        }
+        .await;
+        match result {
+            Ok(checkpoint) => CurvySyncCheckpointResult::Checkpoint(checkpoint),
+            Err(error) => CurvySyncCheckpointResult::QueryFailed(error),
+        }
+    }
+
+    /// Retrieve checkpoint-pinned committed notes by dense leaf index.
+    #[graphql(name = "curvySyncNotes")]
+    async fn curvy_sync_notes(
+        &self,
+        ctx: &Context<'_>,
+        checkpoint: Hex32,
+        #[graphql(name = "fromIndex")] from_index: Option<UInt64>,
+        first: Option<i32>,
+    ) -> CurvySyncNotesResult {
+        let result = async {
+            let db = ctx
+                .data::<DatabaseConnection>()
+                .map_err(|error| errors::context_error("DatabaseConnection", error))?;
+            let indexer_state = ctx
+                .data::<IndexerState>()
+                .map_err(|error| errors::context_error("IndexerState", error))?;
+            let checkpoint_model = {
+                let _lock = indexer_state.acquire_watermark_lock().await;
+                curvy::load_checkpoint(db, Some(&checkpoint)).await?
+            };
+            let start = curvy::dense_start(from_index)?;
+            let total = checkpoint_model.leaf_count;
+            curvy::validate_page_start(start, total)?;
+            let models = curvy_committed_note::Entity::find()
+                .filter(curvy_committed_note::Column::LeafIndex.gte(start))
+                .filter(curvy_committed_note::Column::LeafIndex.lt(total))
+                .order_by_asc(curvy_committed_note::Column::LeafIndex)
+                .limit(curvy::page_limit(first)?)
+                .all(db)
+                .await
+                .map_err(|error| errors::query_failed("fetch checkpoint-pinned Curvy notes", error))?;
+            curvy::validate_dense_page(models.iter().map(|model| model.leaf_index), start, total, "leaf_index")?;
+
+            let mut note_ids = models.iter().map(|model| model.note_id.clone()).collect::<Vec<_>>();
+            note_ids.sort_unstable();
+            note_ids.dedup();
+            let mut pending_models = Vec::new();
+            for note_id_batch in note_ids.chunks(curvy::NOTE_LOOKUP_BATCH_SIZE) {
+                pending_models.extend(
+                    curvy_pending_note::Entity::find()
+                        .filter(curvy_pending_note::Column::NoteId.is_in(note_id_batch.iter().cloned()))
+                        .filter(curvy_pending_note::Column::PublishedBlock.lte(checkpoint_model.block_number))
+                        .order_by_asc(curvy_pending_note::Column::PublishedBlock)
+                        .order_by_asc(curvy_pending_note::Column::PublishedTxIndex)
+                        .order_by_asc(curvy_pending_note::Column::PublishedLogIndex)
+                        .order_by_asc(curvy_pending_note::Column::EventItemIndex)
+                        .all(db)
+                        .await
+                        .map_err(|error| errors::query_failed("fetch Curvy note announcements", error))?,
+                );
+            }
+            let mut pending_by_note = HashMap::<Vec<u8>, Vec<DbCurvyPendingNote>>::new();
+            for pending in pending_models {
+                pending_by_note
+                    .entry(pending.note_id.clone())
+                    .or_default()
+                    .push(pending);
+            }
+
+            let last_index = models.last().map(|model| model.leaf_index);
+            let notes = models
+                .into_iter()
+                .map(|model| {
+                    let announcement = pending_by_note.get(&model.note_id).and_then(|candidates| {
+                        candidates
+                            .iter()
+                            .rev()
+                            .find(|candidate| curvy::pending_precedes_commit(candidate, &model))
+                            .cloned()
+                    });
+                    curvy::sync_note(model, announcement)
+                })
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            curvy::ensure_checkpoint_still_pinned(db, &checkpoint_model).await?;
+            let checkpoint = curvy::sync_checkpoint(checkpoint_model)?;
+            Ok(CurvySyncNotePage {
+                checkpoint: checkpoint.block_hash,
+                notes,
+                next_index: curvy::page_next_index(start, total, last_index)?,
+                total: curvy::page_total(total)?,
+            })
+        }
+        .await;
+        match result {
+            Ok(page) => CurvySyncNotesResult::Page(page),
+            Err(error) => CurvySyncNotesResult::QueryFailed(error),
+        }
+    }
+
+    /// Retrieve checkpoint-pinned nullifiers by dense nullifier index.
+    #[graphql(name = "curvySyncNullifiers")]
+    async fn curvy_sync_nullifiers(
+        &self,
+        ctx: &Context<'_>,
+        checkpoint: Hex32,
+        #[graphql(name = "fromIndex")] from_index: Option<UInt64>,
+        first: Option<i32>,
+    ) -> CurvySyncNullifiersResult {
+        let result = async {
+            let db = ctx
+                .data::<DatabaseConnection>()
+                .map_err(|error| errors::context_error("DatabaseConnection", error))?;
+            let indexer_state = ctx
+                .data::<IndexerState>()
+                .map_err(|error| errors::context_error("IndexerState", error))?;
+            let checkpoint_model = {
+                let _lock = indexer_state.acquire_watermark_lock().await;
+                curvy::load_checkpoint(db, Some(&checkpoint)).await?
+            };
+            let start = curvy::dense_start(from_index)?;
+            let total = checkpoint_model.nullifier_count;
+            curvy::validate_page_start(start, total)?;
+            let models = curvy_committed_nullifier::Entity::find()
+                .filter(curvy_committed_nullifier::Column::NullifierIndex.gte(start))
+                .filter(curvy_committed_nullifier::Column::NullifierIndex.lt(total))
+                .order_by_asc(curvy_committed_nullifier::Column::NullifierIndex)
+                .limit(curvy::page_limit(first)?)
+                .all(db)
+                .await
+                .map_err(|error| errors::query_failed("fetch checkpoint-pinned Curvy nullifiers", error))?;
+            curvy::validate_dense_page(
+                models.iter().map(|model| model.nullifier_index),
+                start,
+                total,
+                "nullifier_index",
+            )?;
+            let last_index = models.last().map(|model| model.nullifier_index);
+            let nullifiers = models
+                .into_iter()
+                .map(curvy::committed_nullifier)
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            curvy::ensure_checkpoint_still_pinned(db, &checkpoint_model).await?;
+            let checkpoint = curvy::sync_checkpoint(checkpoint_model)?;
+            Ok(CurvySyncNullifierPage {
+                checkpoint: checkpoint.block_hash,
+                nullifiers,
+                next_index: curvy::page_next_index(start, total, last_index)?,
+                total: curvy::page_total(total)?,
+            })
+        }
+        .await;
+        match result {
+            Ok(page) => CurvySyncNullifiersResult::Page(page),
+            Err(error) => CurvySyncNullifiersResult::QueryFailed(error),
+        }
+    }
+
+    /// Retrieve checkpoint-pinned completed notes-tree shard roots.
+    #[graphql(name = "curvyShardRoots")]
+    async fn curvy_shard_roots(
+        &self,
+        ctx: &Context<'_>,
+        checkpoint: Hex32,
+        #[graphql(name = "fromIndex")] from_index: Option<UInt64>,
+        first: Option<i32>,
+    ) -> CurvyShardRootsResult {
+        let result = async {
+            let db = ctx
+                .data::<DatabaseConnection>()
+                .map_err(|error| errors::context_error("DatabaseConnection", error))?;
+            let indexer_state = ctx
+                .data::<IndexerState>()
+                .map_err(|error| errors::context_error("IndexerState", error))?;
+            let checkpoint_model = {
+                let _lock = indexer_state.acquire_watermark_lock().await;
+                curvy::load_checkpoint(db, Some(&checkpoint)).await?
+            };
+            let start = curvy::dense_start(from_index)?;
+            let total = checkpoint_model.shard_count;
+            curvy::validate_page_start(start, total)?;
+            let models = curvy_shard_root::Entity::find()
+                .filter(curvy_shard_root::Column::TreeVersion.eq(checkpoint_model.tree_version))
+                .filter(curvy_shard_root::Column::ShardHeight.eq(checkpoint_model.shard_height))
+                .filter(curvy_shard_root::Column::ShardIndex.gte(start))
+                .filter(curvy_shard_root::Column::ShardIndex.lt(total))
+                .order_by_asc(curvy_shard_root::Column::ShardIndex)
+                .limit(curvy::page_limit(first)?)
+                .all(db)
+                .await
+                .map_err(|error| errors::query_failed("fetch checkpoint-pinned Curvy shard roots", error))?;
+            curvy::validate_dense_page(
+                models.iter().map(|model| model.shard_index),
+                start,
+                total,
+                "shard_index",
+            )?;
+            let last_index = models.last().map(|model| model.shard_index);
+            let shard_roots = models
+                .into_iter()
+                .map(curvy::shard_root)
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            curvy::ensure_checkpoint_still_pinned(db, &checkpoint_model).await?;
+            let checkpoint = curvy::sync_checkpoint(checkpoint_model)?;
+            Ok(CurvyShardRootPage {
+                checkpoint: checkpoint.block_hash,
+                shard_roots,
+                next_index: curvy::page_next_index(start, total, last_index)?,
+                total: curvy::page_total(total)?,
+            })
+        }
+        .await;
+        match result {
+            Ok(page) => CurvyShardRootsResult::Page(page),
+            Err(error) => CurvyShardRootsResult::QueryFailed(error),
+        }
+    }
+
+    /// Read the current Curvy Aggregator root and indices directly from chain.
+    #[graphql(name = "curvyAggregatorState", complexity = 50)]
+    async fn curvy_aggregator_state(&self, ctx: &Context<'_>) -> CurvyAggregatorStateResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_aggregator, "Curvy Aggregator")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            let state = rpc
+                .0
+                .get_curvy_aggregator_state()
+                .await
+                .map_err(|error| errors::rpc_query_failed("query Curvy Aggregator state", error))?;
+            Ok(CurvyAggregatorState {
+                notes_tree_root: Hex32::from(&state.notes_tree_root),
+                notes_batch_index: curvy::uint256_value(state.notes_batch_index),
+                nullifiers_batch_index: curvy::uint256_value(state.nullifiers_batch_index),
+                note_index: curvy::uint256_value(state.note_index),
+            })
+        }
+        .await;
+        match result {
+            Ok(state) => CurvyAggregatorStateResult::State(state),
+            Err(error) => CurvyAggregatorStateResult::QueryFailed(error),
+        }
+    }
+
+    /// Read a Curvy note's raw `NoteStatus` value directly from chain.
+    #[graphql(name = "curvyNoteStatus", complexity = 50)]
+    async fn curvy_note_status(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "noteId")] note_id: Hex32,
+    ) -> CurvyNoteStatusResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_aggregator, "Curvy Aggregator")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            let status = rpc
+                .0
+                .get_curvy_note_status(curvy::hex32_array(&note_id)?)
+                .await
+                .map_err(|error| errors::rpc_query_failed("query Curvy note status", error))?;
+            Ok(CurvyNoteStatus {
+                status: i32::from(status),
+            })
+        }
+        .await;
+        match result {
+            Ok(status) => CurvyNoteStatusResult::Status(status),
+            Err(error) => CurvyNoteStatusResult::QueryFailed(error),
+        }
+    }
+
+    /// Check whether a notes root is valid in the Curvy Aggregator.
+    #[graphql(name = "curvyValidNotesRoot", complexity = 50)]
+    async fn curvy_valid_notes_root(&self, ctx: &Context<'_>, root: Hex32) -> CurvyValidNotesRootResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_aggregator, "Curvy Aggregator")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            rpc.0
+                .is_curvy_notes_root_valid(curvy::hex32_array(&root)?)
+                .await
+                .map(|value| CurvyBooleanValue { value })
+                .map_err(|error| errors::rpc_query_failed("query Curvy notes root", error))
+        }
+        .await;
+        match result {
+            Ok(value) => CurvyValidNotesRootResult::Valid(value),
+            Err(error) => CurvyValidNotesRootResult::QueryFailed(error),
+        }
+    }
+
+    /// Check whether a nullifier is already present in the Curvy Aggregator.
+    #[graphql(name = "curvyNullifierSpent", complexity = 50)]
+    async fn curvy_nullifier_spent(&self, ctx: &Context<'_>, nullifier: Hex32) -> CurvyNullifierSpentResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_aggregator, "Curvy Aggregator")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            rpc.0
+                .is_curvy_nullifier_spent(curvy::hex32_array(&nullifier)?)
+                .await
+                .map(|value| CurvyBooleanValue { value })
+                .map_err(|error| errors::rpc_query_failed("query Curvy nullifier", error))
+        }
+        .await;
+        match result {
+            Ok(value) => CurvyNullifierSpentResult::Spent(value),
+            Err(error) => CurvyNullifierSpentResult::QueryFailed(error),
+        }
+    }
+
+    /// Read the Curvy Vault deposit and withdrawal fees directly from chain.
+    #[graphql(name = "curvyVaultFees", complexity = 50)]
+    async fn curvy_vault_fees(&self, ctx: &Context<'_>) -> CurvyVaultFeesResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_vault, "Curvy Vault")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            let (deposit_fee, withdrawal_fee) = rpc
+                .0
+                .get_curvy_vault_fees()
+                .await
+                .map_err(|error| errors::rpc_query_failed("query Curvy Vault fees", error))?;
+            Ok(CurvyVaultFees {
+                deposit_fee: curvy::uint256_value(deposit_fee),
+                withdrawal_fee: curvy::uint256_value(withdrawal_fee),
+            })
+        }
+        .await;
+        match result {
+            Ok(fees) => CurvyVaultFeesResult::Fees(fees),
+            Err(error) => CurvyVaultFeesResult::QueryFailed(error),
+        }
+    }
+
+    /// Read the Curvy Aggregator fee configuration directly from chain.
+    ///
+    /// The protocol fee rate, the commitment gas-fee tree root, and the fee-note
+    /// public key are all required to build a valid aggregation proof: the circuit
+    /// constrains the fee note's owner to `feeNotePublicKey` and its amount to
+    /// `gasFee + protocolFeeQ`.
+    #[graphql(name = "curvyAggregatorFees", complexity = 50)]
+    async fn curvy_aggregator_fees(&self, ctx: &Context<'_>) -> CurvyAggregatorFeesResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_aggregator, "Curvy Aggregator")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            let fees = rpc
+                .0
+                .get_curvy_aggregator_fees()
+                .await
+                .map_err(|error| errors::rpc_query_failed("query Curvy Aggregator fees", error))?;
+            Ok(CurvyAggregatorFees {
+                protocol_fee_per_thousand: curvy::uint256_value(fees.protocol_fee_per_thousand),
+                commitment_fee_root: Hex32::from(&fees.commitment_fee_root),
+                fee_note_public_key: fees
+                    .fee_note_public_key
+                    .iter()
+                    .map(|coordinate| curvy::uint256_value(*coordinate))
+                    .collect(),
+            })
+        }
+        .await;
+        match result {
+            Ok(fees) => CurvyAggregatorFeesResult::Fees(fees),
+            Err(error) => CurvyAggregatorFeesResult::QueryFailed(error),
+        }
+    }
+
+    /// Read how many tokens are registered in the Curvy Vault, so a client can
+    /// enumerate `curvyVaultToken` over the real set instead of probing ids.
+    #[graphql(name = "curvyVaultTokenCount", complexity = 50)]
+    async fn curvy_vault_token_count(&self, ctx: &Context<'_>) -> CurvyVaultTokenCountResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_vault, "Curvy Vault")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            let count = rpc
+                .0
+                .get_curvy_vault_token_count()
+                .await
+                .map_err(|error| errors::rpc_query_failed("query Curvy Vault token count", error))?;
+            Ok(CurvyVaultTokenCount {
+                count: curvy::uint256_value(count),
+            })
+        }
+        .await;
+        match result {
+            Ok(count) => CurvyVaultTokenCountResult::Count(count),
+            Err(error) => CurvyVaultTokenCountResult::QueryFailed(error),
+        }
+    }
+
+    /// Read a Curvy Vault token address and per-token gas fees directly from chain.
+    #[graphql(name = "curvyVaultToken", complexity = 50)]
+    async fn curvy_vault_token(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "tokenId")] token_id: UInt256,
+    ) -> CurvyVaultTokenResult {
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_vault, "Curvy Vault")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            let token = rpc
+                .0
+                .get_curvy_vault_token(curvy::uint256_bytes(&token_id, "token ID")?)
+                .await
+                .map_err(|error| errors::rpc_query_failed("query Curvy Vault token", error))?
+                .ok_or_else(|| errors::not_found("Curvy Vault token", &token_id.0))?;
+            Ok(CurvyVaultToken {
+                token_address: token.token_address.to_hex(),
+                gas_fees: CurvyGasFees {
+                    token_id: curvy::uint256_value(token.gas_fees.token_id),
+                    portal_deployment: curvy::uint256_value(token.gas_fees.portal_deployment),
+                    pending_note_commitment: curvy::uint256_value(token.gas_fees.pending_note_commitment),
+                    withdrawal: curvy::uint256_value(token.gas_fees.withdrawal),
+                },
+            })
+        }
+        .await;
+        match result {
+            Ok(token) => CurvyVaultTokenResult::Token(token),
+            Err(error) => CurvyVaultTokenResult::QueryFailed(error),
+        }
+    }
+
+    /// Derive a Curvy entry portal address directly from PortalFactory.
+    #[graphql(name = "curvyEntryPortalAddress", complexity = 50)]
+    async fn curvy_entry_portal_address(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "ownerHash")] owner_hash: UInt256,
+        recovery: String,
+    ) -> CurvyEntryPortalAddressResult {
+        let recovery = match curvy::address(&recovery) {
+            Ok(address) => address,
+            Err(error) => return CurvyEntryPortalAddressResult::InvalidAddress(error),
+        };
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_portal_factory, "Curvy PortalFactory")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            rpc.0
+                .derive_curvy_entry_portal_address(curvy::uint256_bytes(&owner_hash, "owner hash")?, recovery)
+                .await
+                .map(|address| CurvyAddress {
+                    address: address.to_hex(),
+                })
+                .map_err(|error| errors::rpc_query_failed("query Curvy entry portal address", error))
+        }
+        .await;
+        match result {
+            Ok(address) => CurvyEntryPortalAddressResult::Address(address),
+            Err(error) => CurvyEntryPortalAddressResult::QueryFailed(error),
+        }
+    }
+
+    /// Derive a Curvy exit portal address directly from PortalFactory.
+    #[graphql(name = "curvyExitPortalAddress", complexity = 50)]
+    async fn curvy_exit_portal_address(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "exitAddress")] exit_address: String,
+        #[graphql(name = "exitChainId")] exit_chain_id: UInt256,
+        recovery: String,
+    ) -> CurvyExitPortalAddressResult {
+        let exit_address = match curvy::address(&exit_address) {
+            Ok(address) => address,
+            Err(error) => return CurvyExitPortalAddressResult::InvalidAddress(error),
+        };
+        let recovery = match curvy::address(&recovery) {
+            Ok(address) => address,
+            Err(error) => return CurvyExitPortalAddressResult::InvalidAddress(error),
+        };
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_portal_factory, "Curvy PortalFactory")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            rpc.0
+                .derive_curvy_exit_portal_address(
+                    exit_address,
+                    curvy::uint256_bytes(&exit_chain_id, "exit chain ID")?,
+                    recovery,
+                )
+                .await
+                .map(|address| CurvyAddress {
+                    address: address.to_hex(),
+                })
+                .map_err(|error| errors::rpc_query_failed("query Curvy exit portal address", error))
+        }
+        .await;
+        match result {
+            Ok(address) => CurvyExitPortalAddressResult::Address(address),
+            Err(error) => CurvyExitPortalAddressResult::QueryFailed(error),
+        }
+    }
+
+    /// Check whether an address is registered with Curvy PortalFactory.
+    #[graphql(name = "curvyPortalRegistered", complexity = 50)]
+    async fn curvy_portal_registered(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "portalAddress")] portal_address: String,
+    ) -> CurvyPortalRegisteredResult {
+        let portal_address = match curvy::address(&portal_address) {
+            Ok(address) => address,
+            Err(error) => return CurvyPortalRegisteredResult::InvalidAddress(error),
+        };
+        let result = async {
+            let addresses = ctx
+                .data::<ContractAddresses>()
+                .map_err(|error| errors::context_error("ContractAddresses", error))?;
+            curvy::require_contract(addresses.curvy_portal_factory, "Curvy PortalFactory")?;
+            let rpc = ctx
+                .data::<RpcOperationsContext>()
+                .map_err(|error| errors::context_error("RpcOperationsContext", error))?;
+            rpc.0
+                .is_curvy_portal_registered(portal_address)
+                .await
+                .map(|value| CurvyBooleanValue { value })
+                .map_err(|error| errors::rpc_query_failed("query Curvy portal registration", error))
+        }
+        .await;
+        match result {
+            Ok(value) => CurvyPortalRegisteredResult::Registered(value),
+            Err(error) => CurvyPortalRegisteredResult::QueryFailed(error),
+        }
+    }
+
     /// Retrieve accounts from the database with required filtering
     ///
     /// At least one filter parameter must be provided (keyid, packet_key, or chain_key).
@@ -1723,6 +2602,7 @@ mod tests {
         scale_wei_by_multiplier,
     };
     use crate::{
+        curvy::{validate_dense_page, validate_page_start},
         errors,
         schema::{ChainId, GasMultiplier, NetworkName},
     };
@@ -2187,5 +3067,18 @@ mod tests {
                 .expect_err("invalid module address length should fail")
                 .contains("Invalid module address length")
         );
+    }
+
+    #[test]
+    fn test_curvy_dense_page_validation_rejects_gaps() {
+        assert!(validate_dense_page([4, 5], 4, 10, "leaf_index").is_ok());
+        assert!(validate_dense_page([4, 6], 4, 10, "leaf_index").is_err());
+        assert!(validate_dense_page([], 4, 10, "leaf_index").is_err());
+    }
+
+    #[test]
+    fn test_curvy_page_start_cannot_exceed_checkpoint() {
+        assert!(validate_page_start(10, 10).is_ok());
+        assert!(validate_page_start(11, 10).is_err());
     }
 }

--- a/api/src/schema.rs
+++ b/api/src/schema.rs
@@ -8,7 +8,7 @@ use blokli_chain_api::{
     transaction_store::TransactionStore,
 };
 use blokli_chain_indexer::IndexerState;
-use blokli_chain_rpc::{rpc::RpcOperations, transport::HttpRequestor};
+use blokli_chain_rpc::{HoprRpcOperations, rpc::RpcOperations, transport::HttpRequestor};
 use blokli_chain_types::ContractAddresses;
 use futures::Stream;
 use sea_orm::DatabaseConnection;
@@ -34,6 +34,10 @@ pub struct ChainId(pub u64);
 /// Wrapper type for network name to avoid type confusion in context
 #[derive(Debug, Clone)]
 pub struct NetworkName(pub String);
+
+/// Type-erased read-only RPC operations used by GraphQL query resolvers.
+#[derive(Clone)]
+pub struct RpcOperationsContext(pub Arc<dyn HoprRpcOperations + Send + Sync>);
 
 /// Build the registry of all supported versioned schemas.
 ///
@@ -180,6 +184,7 @@ pub fn build_schema<R: HttpRequestor + 'static + Clone>(
     readiness_checker: ReadinessChecker,
     limits: Option<(usize, usize)>,
 ) -> Schema<QueryRoot, MutationRoot, SubscriptionRoot> {
+    let query_rpc: Arc<dyn HoprRpcOperations + Send + Sync> = rpc_operations.clone();
     let mut builder = Schema::build(QueryRoot, MutationRoot, SubscriptionRoot)
         .data(db)
         .data(ChainId(chain_id))
@@ -191,6 +196,7 @@ pub fn build_schema<R: HttpRequestor + 'static + Clone>(
         .data(indexer_state)
         .data(transaction_executor)
         .data(transaction_store)
+        .data(RpcOperationsContext(query_rpc))
         .data(rpc_operations)
         .data(readiness_checker);
 

--- a/api/src/subscription.rs
+++ b/api/src/subscription.rs
@@ -4,10 +4,11 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_broadcast::Receiver;
 use async_graphql::{Context, ID, Result, Subscription};
-use async_stream::stream;
+use async_stream::{stream, try_stream};
 use blokli_api_types::{
-    Account, Channel, ChannelUpdate, Hex32, OpenedChannelsGraphEntry, RedeemTicketDetails, Safe, TicketParameters,
-    TokenValueString, Transaction, UInt64,
+    Account, Channel, ChannelUpdate, CurvyCommittedNote, CurvyCommittedNullifier, CurvyEventPosition, CurvyPendingNote,
+    Hex32, OpenedChannelsGraphEntry, RedeemTicketDetails, Safe, TicketParameters, TokenValueString, Transaction,
+    UInt64,
 };
 use blokli_chain_api::transaction_store::{
     TransactionEvent, TransactionStatus as StoreTransactionStatus, TransactionStore,
@@ -24,10 +25,10 @@ use blokli_db_entity::{
         account_aggregation::{fetch_accounts_by_keyids, fetch_accounts_with_filters},
         safe_aggregation::{CurrentSafe, fetch_safe_by_address, fetch_safe_threshold_by_address},
     },
-    hopr_node_safe_registration,
+    curvy_committed_note, curvy_committed_nullifier, curvy_pending_note, hopr_node_safe_registration,
 };
 use chrono::Utc;
-use futures::Stream;
+use futures::{Stream, StreamExt, pin_mut};
 use hopr_bindings::exports::alloy::hex;
 use hopr_types::primitive::{
     prelude::HoprBalance as PrimitiveHoprBalance,
@@ -35,13 +36,13 @@ use hopr_types::primitive::{
     traits::{IntoEndian, ToHex},
 };
 use rand::seq::SliceRandom;
-use sea_orm::{ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder};
+use sea_orm::{ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Select};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::{
     conversions::{convert_safe_execution, convert_transaction_status},
-    errors,
+    curvy, errors,
     query::owners_for_safe,
     readiness::{ReadinessChecker, ReadinessState},
 };
@@ -398,12 +399,267 @@ fn watermark_condition(watermark: &Watermark) -> Condition {
     Condition::all().add(channel_state::Column::PublishedBlock.lte(watermark.block))
 }
 
+trait CurvyPositioned {
+    fn position(&self) -> &CurvyEventPosition;
+}
+
+impl CurvyPositioned for CurvyPendingNote {
+    fn position(&self) -> &CurvyEventPosition {
+        &self.position
+    }
+}
+
+impl CurvyPositioned for CurvyCommittedNote {
+    fn position(&self) -> &CurvyEventPosition {
+        &self.position
+    }
+}
+
+impl CurvyPositioned for CurvyCommittedNullifier {
+    fn position(&self) -> &CurvyEventPosition {
+        &self.position
+    }
+}
+
+fn curvy_history_stream<E, T, F>(
+    db: DatabaseConnection,
+    query: Select<E>,
+    operation: &'static str,
+    convert: F,
+) -> impl Stream<Item = Result<T>>
+where
+    E: EntityTrait + 'static,
+    E::Model: Send + 'static,
+    T: Send + 'static,
+    F: Fn(E::Model) -> std::result::Result<T, blokli_api_types::QueryFailedError> + Send + Sync + 'static,
+{
+    try_stream! {
+        let mut rows = query
+            .stream(&db)
+            .await
+            .map_err(|error| errors::graphql_error(errors::query_failed(operation, error)))?;
+        while let Some(row) = rows.next().await {
+            let model = row.map_err(|error| errors::graphql_error(errors::query_failed(operation, error)))?;
+            yield convert(model).map_err(errors::graphql_error)?;
+        }
+    }
+}
+
+fn curvy_event_stream<T, H, F>(
+    historical: H,
+    mut event_receiver: Receiver<IndexerEvent>,
+    mut shutdown_receiver: Receiver<()>,
+    start_block: Option<u64>,
+    select: F,
+) -> impl Stream<Item = Result<T>>
+where
+    T: CurvyPositioned + Send + 'static,
+    H: Stream<Item = Result<T>> + Send + 'static,
+    F: Fn(IndexerEvent) -> Option<T> + Send + Sync + 'static,
+{
+    try_stream! {
+        pin_mut!(historical);
+        loop {
+            let historical_event: Option<Result<T>> = tokio::select! {
+                biased;
+                shutdown_result = shutdown_receiver.recv() => {
+                    match shutdown_result {
+                        Ok(_) | Err(async_broadcast::RecvError::Closed) => return,
+                        Err(async_broadcast::RecvError::Overflowed(count)) => {
+                            Err(errors::graphql_subscription_lagged_error(
+                                "Curvy subscription shutdown signal",
+                                count,
+                            ))
+                        }
+                    }
+                }
+                historical_event = historical.next() => Ok(historical_event),
+            }?;
+            match historical_event {
+                Some(event) => yield event?,
+                None => break,
+            }
+        }
+        loop {
+            let event = tokio::select! {
+                biased;
+                shutdown_result = shutdown_receiver.recv() => {
+                    match shutdown_result {
+                        Ok(_) | Err(async_broadcast::RecvError::Closed) => return,
+                        Err(async_broadcast::RecvError::Overflowed(count)) => {
+                            Err(errors::graphql_subscription_lagged_error(
+                                "Curvy subscription shutdown signal",
+                                count,
+                            ))
+                        }
+                    }
+                }
+                event_result = event_receiver.recv() => {
+                    match event_result {
+                        Ok(event) => Ok(event),
+                        Err(async_broadcast::RecvError::Closed) => return,
+                        Err(async_broadcast::RecvError::Overflowed(count)) => {
+                            Err(errors::graphql_subscription_lagged_error(
+                                "Curvy subscription event bus",
+                                count,
+                            ))
+                        }
+                    }
+                }
+            }?;
+            if let Some(event) = select(event)
+                && start_block.is_none_or(|start_block| event.position().block.0 >= start_block)
+            {
+                yield event;
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CurvyStartBlock {
+    api: u64,
+    database: i64,
+}
+
+fn curvy_start_block(from_block: Option<UInt64>) -> Result<Option<CurvyStartBlock>> {
+    from_block
+        .map(|block| {
+            Ok(CurvyStartBlock {
+                api: block.0,
+                database: i64::try_from(block.0).map_err(|_| {
+                    errors::graphql_error(errors::invalid_pagination(
+                        "fromBlock exceeds the supported database range",
+                    ))
+                })?,
+            })
+        })
+        .transpose()
+}
+
 /// fetch_channel_update is no longer needed - events now contain complete data
 /// Root subscription type providing real-time updates via Server-Sent Events (SSE)
 pub struct SubscriptionRoot;
 
 #[Subscription]
 impl SubscriptionRoot {
+    /// Stream indexed Curvy `PendingNotes` entries with an optional historical phase.
+    #[graphql(name = "curvyPendingNote")]
+    async fn curvy_pending_note(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "fromBlock")] from_block: Option<UInt64>,
+    ) -> Result<impl Stream<Item = Result<CurvyPendingNote>>> {
+        let db = ctx.data::<DatabaseConnection>()?.clone();
+        let indexer_state = ctx.data::<IndexerState>()?.clone();
+        let (watermark, event_receiver, shutdown_receiver) =
+            capture_watermark_synchronized(&indexer_state, &db).await?;
+        let start_block = curvy_start_block(from_block)?;
+        let mut query =
+            curvy_pending_note::Entity::find().filter(curvy_pending_note::Column::PublishedBlock.lte(watermark.block));
+        if let Some(start_block) = start_block {
+            query = query.filter(curvy_pending_note::Column::PublishedBlock.gte(start_block.database));
+        }
+        let historical = curvy_history_stream(
+            db,
+            query
+                .order_by_asc(curvy_pending_note::Column::PublishedBlock)
+                .order_by_asc(curvy_pending_note::Column::PublishedTxIndex)
+                .order_by_asc(curvy_pending_note::Column::PublishedLogIndex)
+                .order_by_asc(curvy_pending_note::Column::EventItemIndex),
+            "fetch Curvy pending-note history",
+            curvy::pending_note,
+        );
+        Ok(curvy_event_stream(
+            historical,
+            event_receiver,
+            shutdown_receiver,
+            start_block.map(|start_block| start_block.api),
+            |event| match event {
+                IndexerEvent::CurvyPendingNote(event) => Some(event),
+                _ => None,
+            },
+        ))
+    }
+
+    /// Stream indexed Curvy `CommittedNotes` entries with an optional historical phase.
+    #[graphql(name = "curvyCommittedNote")]
+    async fn curvy_committed_note(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "fromBlock")] from_block: Option<UInt64>,
+    ) -> Result<impl Stream<Item = Result<CurvyCommittedNote>>> {
+        let db = ctx.data::<DatabaseConnection>()?.clone();
+        let indexer_state = ctx.data::<IndexerState>()?.clone();
+        let (watermark, event_receiver, shutdown_receiver) =
+            capture_watermark_synchronized(&indexer_state, &db).await?;
+        let start_block = curvy_start_block(from_block)?;
+        let mut query = curvy_committed_note::Entity::find()
+            .filter(curvy_committed_note::Column::PublishedBlock.lte(watermark.block));
+        if let Some(start_block) = start_block {
+            query = query.filter(curvy_committed_note::Column::PublishedBlock.gte(start_block.database));
+        }
+        let historical = curvy_history_stream(
+            db,
+            query
+                .order_by_asc(curvy_committed_note::Column::PublishedBlock)
+                .order_by_asc(curvy_committed_note::Column::PublishedTxIndex)
+                .order_by_asc(curvy_committed_note::Column::PublishedLogIndex)
+                .order_by_asc(curvy_committed_note::Column::EventItemIndex),
+            "fetch Curvy committed-note history",
+            curvy::committed_note,
+        );
+        Ok(curvy_event_stream(
+            historical,
+            event_receiver,
+            shutdown_receiver,
+            start_block.map(|start_block| start_block.api),
+            |event| match event {
+                IndexerEvent::CurvyCommittedNote(event) => Some(event),
+                _ => None,
+            },
+        ))
+    }
+
+    /// Stream indexed Curvy `CommittedNullifiers` entries with an optional historical phase.
+    #[graphql(name = "curvyCommittedNullifier")]
+    async fn curvy_committed_nullifier(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "fromBlock")] from_block: Option<UInt64>,
+    ) -> Result<impl Stream<Item = Result<CurvyCommittedNullifier>>> {
+        let db = ctx.data::<DatabaseConnection>()?.clone();
+        let indexer_state = ctx.data::<IndexerState>()?.clone();
+        let (watermark, event_receiver, shutdown_receiver) =
+            capture_watermark_synchronized(&indexer_state, &db).await?;
+        let start_block = curvy_start_block(from_block)?;
+        let mut query = curvy_committed_nullifier::Entity::find()
+            .filter(curvy_committed_nullifier::Column::PublishedBlock.lte(watermark.block));
+        if let Some(start_block) = start_block {
+            query = query.filter(curvy_committed_nullifier::Column::PublishedBlock.gte(start_block.database));
+        }
+        let historical = curvy_history_stream(
+            db,
+            query
+                .order_by_asc(curvy_committed_nullifier::Column::PublishedBlock)
+                .order_by_asc(curvy_committed_nullifier::Column::PublishedTxIndex)
+                .order_by_asc(curvy_committed_nullifier::Column::PublishedLogIndex)
+                .order_by_asc(curvy_committed_nullifier::Column::EventItemIndex),
+            "fetch Curvy committed-nullifier history",
+            curvy::committed_nullifier,
+        );
+        Ok(curvy_event_stream(
+            historical,
+            event_receiver,
+            shutdown_receiver,
+            start_block.map(|start_block| start_block.api),
+            |event| match event {
+                IndexerEvent::CurvyCommittedNullifier(event) => Some(event),
+                _ => None,
+            },
+        ))
+    }
+
     /// Subscribe to health status updates of the API
     ///
     /// Provides updates whenever the server state changes.
@@ -573,6 +829,9 @@ impl SubscriptionRoot {
                             Ok(IndexerEvent::TicketRedeemed(_)) => {
                                 // Ticket redeemed don't affect this subscription
                             }
+                            Ok(_) => {
+                                // Curvy events don't affect this subscription
+                            }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending channelUpdated subscription");
                                 return;
@@ -701,6 +960,9 @@ impl SubscriptionRoot {
                             }
                             Ok(IndexerEvent::TicketRedeemed(_)) => {
                                 // Ticket redeemed don't affect this subscription
+                            }
+                            Ok(_) => {
+                                // Curvy events don't affect this subscription
                             }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending subscription");
@@ -893,6 +1155,9 @@ impl SubscriptionRoot {
                             Ok(IndexerEvent::TicketRedeemed(_)) => {
                                 // Ticket redeemed don't affect this subscription
                             }
+                            Ok(_) => {
+                                // Curvy events don't affect this subscription
+                            }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending ticketParametersUpdated subscription");
                                 return;
@@ -1000,6 +1265,9 @@ impl SubscriptionRoot {
                             }
                             Ok(IndexerEvent::TicketRedeemed(_)) => {
                                 // Ticket redeemed don't affect this subscription
+                            }
+                            Ok(_) => {
+                                // Curvy events don't affect this subscription
                             }
                             Err(async_broadcast::RecvError::Closed) => {
                                 info!("Event bus closed, ending keyBindingFeeUpdated subscription");
@@ -1571,12 +1839,13 @@ fn matches_channel_filters(
 mod tests {
     use std::time::Duration;
 
+    use async_broadcast::broadcast;
     use async_graphql::{EmptyMutation, Object, Schema};
-    use blokli_api_types::RedemptionResult;
+    use blokli_api_types::{CurvyCommittedNote, CurvyEventPosition, Hex32, RedemptionResult, UInt64};
     use blokli_chain_indexer::state::{IndexerEvent, RedeemTicketDetailsInfo};
     use blokli_db::{BlokliDbGeneralModelOperations, db::BlokliDb};
     use blokli_db_entity::{hopr_safe_contract, hopr_safe_contract_state};
-    use futures::StreamExt;
+    use futures::{StreamExt, pin_mut, stream};
     use sea_orm::{ActiveModelTrait, Set};
 
     use super::*;
@@ -1590,6 +1859,80 @@ mod tests {
         async fn dummy(&self) -> bool {
             true
         }
+    }
+
+    fn curvy_committed_note(block: u64) -> CurvyCommittedNote {
+        CurvyCommittedNote {
+            batch_index: Hex32(format!("0x{:064x}", 1)),
+            note_id: Hex32(format!("0x{block:064x}")),
+            leaf_index: UInt64(block),
+            position: CurvyEventPosition {
+                transaction_hash: Hex32(format!("0x{:064x}", block)),
+                block_hash: Hex32(format!("0x{:064x}", block)),
+                block: UInt64(block),
+                transaction_index: UInt64(0),
+                log_index: UInt64(0),
+                event_item_index: UInt64(0),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_curvy_event_stream_reports_event_bus_lag() -> anyhow::Result<()> {
+        let (mut event_sender, event_receiver) = broadcast(1);
+        event_sender.set_overflow(true);
+        let (_shutdown_sender, shutdown_receiver) = broadcast(1);
+        event_sender
+            .try_broadcast(IndexerEvent::CurvyCommittedNote(curvy_committed_note(1)))
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        event_sender
+            .try_broadcast(IndexerEvent::CurvyCommittedNote(curvy_committed_note(2)))
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+
+        let events = curvy_event_stream(
+            stream::empty(),
+            event_receiver,
+            shutdown_receiver,
+            None,
+            |event| match event {
+                IndexerEvent::CurvyCommittedNote(event) => Some(event),
+                _ => None,
+            },
+        );
+        pin_mut!(events);
+        let error = events
+            .next()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("Curvy event stream ended without reporting lag"))?
+            .expect_err("overflow must terminate the Curvy subscription with an error");
+
+        assert!(error.message.contains("missed 1 events"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_curvy_event_stream_observes_shutdown_during_history() -> anyhow::Result<()> {
+        let (_event_sender, event_receiver) = broadcast(1);
+        let (shutdown_sender, shutdown_receiver) = broadcast(1);
+        shutdown_sender
+            .try_broadcast(())
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        let historical = stream::iter([Ok::<_, async_graphql::Error>(curvy_committed_note(1))]);
+
+        let events = curvy_event_stream(
+            historical,
+            event_receiver,
+            shutdown_receiver,
+            None,
+            |event| match event {
+                IndexerEvent::CurvyCommittedNote(event) => Some(event),
+                _ => None,
+            },
+        );
+        pin_mut!(events);
+
+        assert!(events.next().await.is_none());
+        Ok(())
     }
 
     // Helper: Create test channel in database

--- a/api/tests/curvy_event_pipeline_test.rs
+++ b/api/tests/curvy_event_pipeline_test.rs
@@ -1,0 +1,609 @@
+//! End-to-end Curvy event indexing and GraphQL subscription test.
+//!
+//! The test deploys the Curvy development contracts to Anvil and processes the
+//! events emitted during deployment plus an `autoShield` call. Events that
+//! require valid ZK proofs are encoded with the generated contract bindings so
+//! their decoder, persistence, and GraphQL paths are still covered.
+
+use std::{error::Error, future::Future, time::Duration};
+
+use async_graphql::{EmptyMutation, Schema};
+use blokli_api::{query::QueryRoot, schema::GasMultiplier, subscription::SubscriptionRoot};
+use blokli_chain_indexer::{IndexerState, handlers::ContractEventHandlers, traits::ChainLogHandler};
+use blokli_chain_rpc::{
+    Log,
+    rpc::{RpcOperations, RpcOperationsConfig},
+    transport::ReqwestClient,
+};
+use blokli_chain_types::{AlloyAddressExt, ContractAddresses};
+use blokli_db::{BlokliDbGeneralModelOperations, TargetDb, db::BlokliDb};
+use blokli_db_entity::{
+    chain_info, curvy_committed_note, curvy_committed_nullifier, curvy_pending_note, curvy_sync_checkpoint,
+};
+use curvy_bindings::{
+    config::CurvyContractInstances,
+    constants::DEV_PORTAL_DEPLOYMENT_FEE,
+    curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::{CommittedNotes, CommittedNullifiers, PendingNotes},
+    portal_factory::CurvyTypes::Note,
+};
+use futures::StreamExt;
+use hopr_bindings::exports::alloy::{
+    network::TransactionBuilder,
+    node_bindings::Anvil,
+    primitives::{B256, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::{
+        client::ClientBuilder,
+        types::{Filter, TransactionRequest},
+    },
+    signers::local::PrivateKeySigner,
+    sol_types::SolEvent,
+    transports::http::ReqwestTransport,
+};
+use hopr_types::primitive::{
+    prelude::{Address, SerializableLog},
+    traits::ToHex,
+};
+use sea_orm::{ActiveModelTrait, EntityTrait, PaginatorTrait, QueryOrder, Set};
+use serde_json::{Value, json};
+
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+
+type CurvySchema = Schema<QueryRoot, EmptyMutation, SubscriptionRoot>;
+
+fn hex32(value: U256) -> String {
+    format!("{value:#066x}")
+}
+
+fn logs_with_signature(logs: &[Log], signature: B256) -> Vec<Log> {
+    logs.iter()
+        .filter(|log| {
+            log.topics
+                .first()
+                .is_some_and(|topic| topic.as_ref() == signature.as_slice())
+        })
+        .cloned()
+        .collect()
+}
+
+fn decode_event<E: SolEvent>(log: &Log) -> anyhow::Result<E> {
+    E::decode_raw_log(
+        log.topics.iter().map(|topic| B256::from_slice(topic.as_ref())),
+        &log.data,
+    )
+    .map_err(Into::into)
+}
+
+fn event_position(log: &Log, event_item_index: usize) -> Value {
+    json!({
+        "block": log.block_number.to_string(),
+        "eventItemIndex": event_item_index.to_string(),
+        "logIndex": log.log_index.to_string(),
+        "transactionHash": log.tx_hash.to_hex(),
+        "transactionIndex": log.tx_index.to_string(),
+    })
+}
+
+fn encoded_event_log<E: SolEvent>(address: Address, event: &E, block_number: u64, tx_hash_seed: u8) -> SerializableLog {
+    let log_data = event.encode_log_data();
+    SerializableLog {
+        address,
+        topics: log_data.topics().iter().map(|topic| topic.0).collect(),
+        data: log_data.data.to_vec(),
+        tx_hash: [tx_hash_seed; 32],
+        block_hash: [tx_hash_seed.wrapping_add(1); 32],
+        block_number,
+        ..Default::default()
+    }
+}
+
+async fn assert_live_events<F, E>(
+    schema: &CurvySchema,
+    subscription: &str,
+    response_field: &str,
+    expected: &[Value],
+    process: F,
+) -> anyhow::Result<()>
+where
+    F: Future<Output = Result<(), E>>,
+    E: Error + Send + Sync + 'static,
+{
+    let mut stream = schema.execute_stream(subscription);
+    let (responses, processing_result) = tokio::time::timeout(RESPONSE_TIMEOUT, async {
+        tokio::join!(
+            async {
+                let mut responses = Vec::with_capacity(expected.len());
+                for _ in expected {
+                    let response = stream
+                        .next()
+                        .await
+                        .ok_or_else(|| anyhow::anyhow!("Curvy subscription ended before delivering all events"))?;
+                    let response = response
+                        .into_result()
+                        .map_err(|errors| anyhow::anyhow!("GraphQL subscription errors: {errors:?}"))?;
+                    responses.push(response.data.into_json()?[response_field].clone());
+                }
+                anyhow::Ok(responses)
+            },
+            async {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                process.await
+            }
+        )
+    })
+    .await?;
+    processing_result.map_err(anyhow::Error::new)?;
+    assert_eq!(responses?, expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_curvy_events_are_indexed_and_streamed() -> anyhow::Result<()> {
+    let anvil = Anvil::new().spawn();
+    let signer: PrivateKeySigner = anvil.keys()[0].clone().into();
+    let deployer_address = signer.address();
+    let provider = ProviderBuilder::new().wallet(signer).connect_http(anvil.endpoint_url());
+
+    let curvy = CurvyContractInstances::deploy_for_testing(provider.clone(), deployer_address).await?;
+    let curvy_addresses = curvy.get_contract_addresses();
+
+    let shielded_amount = U256::from(1_000_000_000_000_000_000_u64);
+    let owner_hash = U256::from(11);
+    let portal_address = curvy
+        .portal_factory
+        .getEntryPortalAddress(owner_hash, deployer_address)
+        .call()
+        .await?;
+    provider
+        .send_transaction(
+            TransactionRequest::default()
+                .with_to(portal_address)
+                .with_value(shielded_amount + DEV_PORTAL_DEPLOYMENT_FEE),
+        )
+        .await?
+        .watch()
+        .await?;
+    curvy
+        .portal_factory
+        .deployShieldPortal(
+            Note {
+                ownerHash: owner_hash,
+                token: U256::ONE,
+                amount: shielded_amount,
+                ephemeralKey: [U256::from(22), U256::from(33)],
+                viewTag: 44,
+            },
+            deployer_address,
+        )
+        .send()
+        .await?
+        .watch()
+        .await?;
+
+    let latest_block = provider.get_block_number().await?;
+    let filter = Filter::new()
+        .address(curvy_addresses.aggregator_proxy)
+        .from_block(0)
+        .to_block(latest_block);
+    let chain_logs = provider
+        .get_logs(&filter)
+        .await?
+        .into_iter()
+        .map(Log::try_from)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let contract_addresses = ContractAddresses {
+        curvy_aggregator: curvy_addresses.aggregator_proxy.to_hopr_address(),
+        curvy_vault: curvy_addresses.vault_proxy.to_hopr_address(),
+        curvy_portal_factory: curvy_addresses.portal_factory.to_hopr_address(),
+        ..Default::default()
+    };
+    let transport = ReqwestTransport::new(anvil.endpoint_url());
+    let rpc_client = ClientBuilder::default().transport(transport.clone(), transport.guess_local());
+    let rpc_operations = RpcOperations::new(
+        rpc_client,
+        ReqwestClient::new(),
+        RpcOperationsConfig {
+            chain_id: 31_337,
+            contract_addrs: contract_addresses,
+            ..Default::default()
+        },
+        None,
+    )?;
+
+    let db = BlokliDb::new_in_memory().await?;
+    chain_info::ActiveModel {
+        id: Set(1),
+        last_indexed_block: Set(0),
+        last_indexed_tx_index: Set(Some(0)),
+        last_indexed_log_index: Set(Some(0)),
+        ..Default::default()
+    }
+    .update(db.conn(TargetDb::Index))
+    .await?;
+    let indexer_state = IndexerState::new(10, 100);
+    let schema = Schema::build(QueryRoot, EmptyMutation, SubscriptionRoot)
+        .data(db.conn(TargetDb::Index).clone())
+        .data(indexer_state.clone())
+        .data(GasMultiplier(1.0))
+        .finish();
+    let handlers = ContractEventHandlers::new(
+        contract_addresses,
+        db.clone(),
+        rpc_operations,
+        indexer_state,
+        true,
+        true,
+    );
+
+    let pending_logs = logs_with_signature(&chain_logs, PendingNotes::SIGNATURE_HASH);
+    anyhow::ensure!(
+        pending_logs.len() == 1,
+        "autoShield did not emit one PendingNotes event"
+    );
+    let pending_log = &pending_logs[0];
+    let pending_event = decode_event::<PendingNotes>(pending_log)?;
+    let expected_pending_notes = pending_event
+        .noteIds
+        .iter()
+        .enumerate()
+        .map(|(index, note_id)| {
+            json!({
+                "amount": pending_event.amounts[index].to_string(),
+                "ephemeralKey": [
+                    pending_event.ephemeralKeys[0][index].to_string(),
+                    pending_event.ephemeralKeys[1][index].to_string(),
+                ],
+                "isPlaintext": pending_event.isPlaintext[index],
+                "noteId": hex32(*note_id),
+                "position": event_position(pending_log, index),
+                "tokenId": pending_event.tokens[index].to_string(),
+                "viewTag": pending_event.viewTags[index],
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_live_events(
+        &schema,
+        r#"subscription { curvyPendingNote { amount ephemeralKey isPlaintext noteId position { block eventItemIndex logIndex transactionHash transactionIndex } tokenId viewTag } }"#,
+        "curvyPendingNote",
+        &expected_pending_notes,
+        handlers.collect_log_event(SerializableLog::from(pending_log.clone()), true),
+    )
+    .await?;
+
+    let filtered_committed_notes_log = encoded_event_log(
+        contract_addresses.curvy_aggregator,
+        &CommittedNotes {
+            batchIndex: U256::from(6),
+            noteIds: vec![U256::from(100)],
+        },
+        latest_block + 1,
+        0x30,
+    );
+    let committed_notes_event = CommittedNotes {
+        batchIndex: U256::from(7),
+        noteIds: vec![U256::ZERO, U256::from(101), U256::ZERO, U256::from(102)],
+    };
+    let committed_notes_log = encoded_event_log(
+        contract_addresses.curvy_aggregator,
+        &committed_notes_event,
+        latest_block + 2,
+        0x31,
+    );
+    let expected_committed_notes = committed_notes_event
+        .noteIds
+        .iter()
+        .enumerate()
+        .filter_map(|(item_index, note_id)| {
+            (*note_id != U256::ZERO).then(|| {
+                json!({
+                    "batchIndex": hex32(committed_notes_event.batchIndex),
+                    "noteId": hex32(*note_id),
+                    "position": event_position(&Log::from(committed_notes_log.clone()), item_index),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_live_events(
+        &schema,
+        &format!(
+            "subscription {{ curvyCommittedNote(fromBlock: \"{}\") {{ batchIndex noteId position {{ block eventItemIndex logIndex transactionHash transactionIndex }} }} }}",
+            latest_block + 2
+        ),
+        "curvyCommittedNote",
+        &expected_committed_notes,
+        async {
+            handlers
+                .collect_log_event(filtered_committed_notes_log.clone(), true)
+                .await?;
+            handlers.collect_log_event(committed_notes_log.clone(), true).await
+        },
+    )
+    .await?;
+
+    let committed_nullifiers_event = CommittedNullifiers {
+        batchIndex: U256::from(8),
+        nullifiers: vec![U256::from(201), U256::ZERO, U256::from(202)],
+    };
+    let committed_nullifiers_log = encoded_event_log(
+        contract_addresses.curvy_aggregator,
+        &committed_nullifiers_event,
+        latest_block + 3,
+        0x32,
+    );
+    let expected_committed_nullifiers = committed_nullifiers_event
+        .nullifiers
+        .iter()
+        .enumerate()
+        .filter_map(|(item_index, nullifier)| {
+            (*nullifier != U256::ZERO).then(|| {
+                json!({
+                    "batchIndex": hex32(committed_nullifiers_event.batchIndex),
+                    "nullifier": hex32(*nullifier),
+                    "position": event_position(&Log::from(committed_nullifiers_log.clone()), item_index),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_live_events(
+        &schema,
+        r#"subscription { curvyCommittedNullifier { batchIndex nullifier position { block eventItemIndex logIndex transactionHash transactionIndex } } }"#,
+        "curvyCommittedNullifier",
+        &expected_committed_nullifiers,
+        handlers.collect_log_event(committed_nullifiers_log.clone(), true),
+    )
+    .await?;
+
+    let history_response = schema
+        .execute(
+            r#"
+                query {
+                    curvyCommittedNotes(first: 10) {
+                        ... on CurvyCommittedNotes { notes { batchIndex noteId position { block eventItemIndex logIndex transactionHash transactionIndex } } }
+                    }
+                    curvyCommittedNullifiers(first: 10) {
+                        ... on CurvyCommittedNullifiers { nullifiers { batchIndex nullifier position { block eventItemIndex logIndex transactionHash transactionIndex } } }
+                    }
+                    curvyPendingNotes(first: 10) {
+                        ... on CurvyPendingNotes { notes { amount ephemeralKey isPlaintext noteId position { block eventItemIndex logIndex transactionHash transactionIndex } tokenId viewTag } }
+                    }
+                }
+            "#,
+        )
+        .await
+        .into_result()
+        .map_err(|errors| anyhow::anyhow!("GraphQL query errors: {errors:?}"))?;
+    let history_data = history_response.data.into_json()?;
+    let filtered_committed_notes_event =
+        decode_event::<CommittedNotes>(&Log::from(filtered_committed_notes_log.clone()))?;
+    let expected_filtered_committed_notes = filtered_committed_notes_event
+        .noteIds
+        .iter()
+        .enumerate()
+        .filter_map(|(item_index, note_id)| {
+            (*note_id != U256::ZERO).then(|| {
+                json!({
+                    "batchIndex": hex32(filtered_committed_notes_event.batchIndex),
+                    "noteId": hex32(*note_id),
+                    "position": event_position(&Log::from(filtered_committed_notes_log.clone()), item_index),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        history_data,
+        json!({
+            "curvyCommittedNotes": {
+                "notes": expected_filtered_committed_notes
+                    .into_iter()
+                    .chain(expected_committed_notes.iter().cloned())
+                    .collect::<Vec<_>>(),
+            },
+            "curvyCommittedNullifiers": { "nullifiers": expected_committed_nullifiers },
+            "curvyPendingNotes": { "notes": expected_pending_notes },
+        })
+    );
+
+    let cursor_page_response = schema
+        .execute(format!(
+            r#"
+                query {{
+                    curvyCommittedNotes(
+                        after: {{ block: "{}", transactionIndex: "0", logIndex: "0", eventItemIndex: "0" }}
+                        first: 1
+                    ) {{
+                        ... on CurvyCommittedNotes {{
+                            notes {{
+                                batchIndex
+                                noteId
+                                position {{ block eventItemIndex logIndex transactionHash transactionIndex }}
+                            }}
+                        }}
+                    }}
+                }}
+            "#,
+            latest_block + 2
+        ))
+        .await
+        .into_result()
+        .map_err(|errors| anyhow::anyhow!("GraphQL cursor query errors: {errors:?}"))?;
+    assert_eq!(
+        cursor_page_response.data.into_json()?,
+        json!({
+            "curvyCommittedNotes": {
+                "notes": [expected_committed_notes[0].clone()],
+            }
+        })
+    );
+
+    handlers
+        .collect_log_event(SerializableLog::from(pending_log.clone()), true)
+        .await?;
+    handlers.collect_log_event(committed_notes_log.clone(), true).await?;
+    handlers
+        .collect_log_event(committed_nullifiers_log.clone(), true)
+        .await?;
+    assert_eq!(
+        curvy_pending_note::Entity::find()
+            .count(db.conn(TargetDb::Index))
+            .await?,
+        u64::try_from(expected_pending_notes.len())?
+    );
+    assert_eq!(
+        curvy_committed_note::Entity::find()
+            .count(db.conn(TargetDb::Index))
+            .await?,
+        u64::try_from(expected_committed_notes.len() + 1)?,
+        "replaying a CommittedNotes log must not duplicate its rows"
+    );
+    assert_eq!(
+        curvy_committed_nullifier::Entity::find()
+            .count(db.conn(TargetDb::Index))
+            .await?,
+        u64::try_from(expected_committed_nullifiers.len())?,
+        "replaying a CommittedNullifiers log must not duplicate its rows"
+    );
+
+    curvy_pending_note::ActiveModel {
+        note_id: Set(U256::from(101).to_be_bytes::<32>().to_vec()),
+        ephemeral_key_x: Set(U256::from(501).to_be_bytes::<32>().to_vec()),
+        ephemeral_key_y: Set(U256::from(502).to_be_bytes::<32>().to_vec()),
+        view_tag: Set(7),
+        token_id: Set(U256::ONE.to_be_bytes::<32>().to_vec()),
+        amount: Set(U256::from(503).to_be_bytes::<32>().to_vec()),
+        is_plaintext: Set(false),
+        event_item_index: Set(0),
+        chain_tx_hash: Set(vec![0x40; 32]),
+        published_block: Set(i64::try_from(latest_block + 1)?),
+        published_tx_index: Set(0),
+        published_log_index: Set(0),
+        block_hash: Set(vec![0x41; 32]),
+        ..Default::default()
+    }
+    .insert(db.conn(TargetDb::Index))
+    .await?;
+
+    let checkpoint_log = Log::from(committed_nullifiers_log.clone());
+    let checkpoint_hash = checkpoint_log.block_hash.to_hex();
+    let sync_response = schema
+        .execute(format!(
+            r#"
+                query {{
+                    curvySyncCheckpoint {{
+                        ... on CurvySyncCheckpoint {{
+                            blockNumber
+                            blockHash
+                            treeVersion
+                            treeDepth
+                            shardHeight
+                            shardSize
+                            noteCount
+                            nullifierCount
+                            shardCount
+                        }}
+                    }}
+                    curvySyncNotes(checkpoint: "{checkpoint_hash}", fromIndex: "1", first: 1) {{
+                        ... on CurvySyncNotePage {{
+                            checkpoint
+                            nextIndex
+                            total
+                            notes {{
+                                leafIndex
+                                noteId
+                                batchIndex
+                                announcement {{ noteId }}
+                                commitPosition {{ block blockHash eventItemIndex }}
+                            }}
+                        }}
+                    }}
+                    curvySyncNullifiers(checkpoint: "{checkpoint_hash}", fromIndex: "1", first: 1) {{
+                        ... on CurvySyncNullifierPage {{
+                            checkpoint
+                            nextIndex
+                            total
+                            nullifiers {{ nullifier nullifierIndex }}
+                        }}
+                    }}
+                    curvyShardRoots(checkpoint: "{checkpoint_hash}", first: 10) {{
+                        ... on CurvyShardRootPage {{
+                            checkpoint
+                            nextIndex
+                            total
+                            shardRoots {{ shardIndex root }}
+                        }}
+                    }}
+                }}
+            "#,
+        ))
+        .await
+        .into_result()
+        .map_err(|errors| anyhow::anyhow!("GraphQL Curvy sync query errors: {errors:?}"))?;
+    assert_eq!(
+        sync_response.data.into_json()?,
+        json!({
+            "curvySyncCheckpoint": {
+                "blockNumber": checkpoint_log.block_number.to_string(),
+                "blockHash": checkpoint_hash,
+                "treeVersion": 1,
+                "treeDepth": 30,
+                "shardHeight": 14,
+                "shardSize": "16384",
+                "noteCount": "3",
+                "nullifierCount": "2",
+                "shardCount": "0",
+            },
+            "curvySyncNotes": {
+                "checkpoint": checkpoint_log.block_hash.to_hex(),
+                "nextIndex": "2",
+                "total": "3",
+                "notes": [{
+                    "leafIndex": "1",
+                    "noteId": hex32(U256::from(101)),
+                    "batchIndex": hex32(U256::from(7)),
+                    "announcement": { "noteId": hex32(U256::from(101)) },
+                    "commitPosition": {
+                        "block": (latest_block + 2).to_string(),
+                        "blockHash": Log::from(committed_notes_log.clone()).block_hash.to_hex(),
+                        "eventItemIndex": "1",
+                    },
+                }],
+            },
+            "curvySyncNullifiers": {
+                "checkpoint": checkpoint_log.block_hash.to_hex(),
+                "nextIndex": "2",
+                "total": "2",
+                "nullifiers": [{
+                    "nullifier": hex32(U256::from(202)),
+                    "nullifierIndex": "1",
+                }],
+            },
+            "curvyShardRoots": {
+                "checkpoint": checkpoint_log.block_hash.to_hex(),
+                "nextIndex": "0",
+                "total": "0",
+                "shardRoots": [],
+            },
+        })
+    );
+
+    handlers.revert_block_derived_state(latest_block + 3).await?;
+    assert_eq!(
+        curvy_committed_nullifier::Entity::find()
+            .count(db.conn(TargetDb::Index))
+            .await?,
+        0,
+        "reorg rollback must remove the reverted nullifier suffix"
+    );
+    let retained_checkpoint = curvy_sync_checkpoint::Entity::find()
+        .order_by_desc(curvy_sync_checkpoint::Column::BlockNumber)
+        .one(db.conn(TargetDb::Index))
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("retained Curvy checkpoint is missing"))?;
+    assert_eq!(
+        retained_checkpoint.block_number,
+        i64::try_from(latest_block + 2)?,
+        "reorg rollback must restore the preceding atomic checkpoint"
+    );
+
+    Ok(())
+}

--- a/bloklid/Cargo.toml
+++ b/bloklid/Cargo.toml
@@ -9,6 +9,7 @@ repository  = "https://github.com/hoprnet/hoprnet"
 version     = "0.13.1"
 
 [features]
+curvy-test-deployment = ["dep:curvy-bindings"]
 default = ["runtime-tokio"]
 runtime-tokio = [
   "blokli-chain-api/runtime-tokio",
@@ -49,9 +50,11 @@ opentelemetry_sdk = { workspace = true, features = [
 ] }
 sea-orm = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_with = { workspace = true }
 smart-default = { workspace = true }
 strum = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
@@ -71,6 +74,7 @@ blokli-db            = { workspace = true }
 
 # HOPR dependencies
 config = { workspace = true }
+curvy-bindings = { workspace = true, optional = true }
 hopr-bindings = { workspace = true }
 hopr-types = { workspace = true, features = [
   "chain",

--- a/bloklid/README.md
+++ b/bloklid/README.md
@@ -47,6 +47,7 @@ For the complete OTLP setup guide, including environment overrides and endpoint 
 - `indexer`: Indexer-specific configuration
   - `start_block_number`: Block to start indexing from
   - `enable_safe_indexing`: Enable Safe contract event indexing for discovered Safes
+  - `enable_curvy_indexing`: Enable note/nullifier indexing from the configured Curvy Aggregator
   - `fast_sync`: Enable fast synchronization
   - `enable_logs_snapshot`: Enable snapshot download for faster initial sync
   - `logs_snapshot_url`: URL of a tar.xz archive containing `hopr_logs.sql`

--- a/bloklid/example-config.toml
+++ b/bloklid/example-config.toml
@@ -38,6 +38,12 @@ max_block_range = 10000
 # winning_probability_oracle = "0x0000000000000000000000000000000000000000"
 # node_stake_factory = "0x0000000000000000000000000000000000000000"
 # xhopr_token = "0x0000000000000000000000000000000000000000"
+# Curvy addresses are not supplied by the HOPR network registry. A non-zero Aggregator
+# address is required when indexer.enable_curvy_indexing is true; Vault and PortalFactory
+# addresses enable the corresponding typed GraphQL contract reads.
+# curvy_aggregator = "0x0000000000000000000000000000000000000000"
+# curvy_vault = "0x0000000000000000000000000000000000000000"
+# curvy_portal_factory = "0x0000000000000000000000000000000000000000"
 
 # Database configuration - supports PostgreSQL or SQLite
 # IMPORTANT: This section is OPTIONAL if using environment variables.
@@ -112,6 +118,10 @@ logs_snapshot_url = "https://example.com/logs-snapshot.tar.xz"
 # Enable indexing of Safe contract events after a Safe has been discovered
 # Safe discovery via registry/stake-factory events remains enabled regardless
 enable_safe_indexing = false
+
+# Enable note/nullifier indexing from the configured Curvy Aggregator
+# Requires contracts.curvy_aggregator to be set to a non-zero address
+enable_curvy_indexing = false
 
 # GraphQL subscription behavior configuration
 [indexer.subscription]

--- a/bloklid/src/args.rs
+++ b/bloklid/src/args.rs
@@ -115,6 +115,7 @@ impl Args {
             ("BLOKLI_INDEXER_FAST_SYNC", "indexer.fast_sync"),
             ("BLOKLI_INDEXER_ENABLE_LOGS_SNAPSHOT", "indexer.enable_logs_snapshot"),
             ("BLOKLI_INDEXER_ENABLE_SAFE_INDEXING", "indexer.enable_safe_indexing"),
+            ("BLOKLI_INDEXER_ENABLE_CURVY_INDEXING", "indexer.enable_curvy_indexing"),
             ("BLOKLI_INDEXER_LOGS_SNAPSHOT_URL", "indexer.logs_snapshot_url"),
             (
                 "BLOKLI_INDEXER_SUBSCRIPTION_EVENT_BUS_CAPACITY",
@@ -186,6 +187,7 @@ impl Args {
             "indexer.fast_sync",
             "indexer.enable_logs_snapshot",
             "indexer.enable_safe_indexing",
+            "indexer.enable_curvy_indexing",
             "api.enabled",
             "api.playground_enabled",
             "api.sse_keepalive.enabled",
@@ -278,6 +280,9 @@ impl Args {
             winning_probability_oracle: network_config.addresses.winning_probability_oracle.to_hopr_address(),
             node_stake_factory: network_config.addresses.node_stake_factory.to_hopr_address(),
             xhopr_token: network_config.addresses.xhopr_token.to_hopr_address(),
+            curvy_aggregator: Default::default(),
+            curvy_vault: Default::default(),
+            curvy_portal_factory: Default::default(),
         };
 
         if let Some(override_contracts) = config.contracts_override {

--- a/bloklid/src/bin/blokli-contract-deployer.rs
+++ b/bloklid/src/bin/blokli-contract-deployer.rs
@@ -1,16 +1,25 @@
 use std::{
-    any::Any, backtrace::Backtrace, borrow::Cow, error::Error, fs, io::stdout, panic, path::PathBuf, str::FromStr,
+    any::Any,
+    backtrace::Backtrace,
+    borrow::Cow,
+    error::Error,
+    io::{self, Write, stdout},
+    panic,
+    path::{Component, Path, PathBuf},
+    str::FromStr,
     sync::Once,
 };
 
 use blokli_chain_types::ContractAddresses as BlokliContractAddresses;
 use clap::Parser;
+#[cfg(feature = "curvy-test-deployment")]
+use curvy_bindings::{CurvyContractAddresses, config::CurvyContractInstances};
 use hopli_lib::utils::{a2h, h2a};
 use hopr_bindings::{
     config::ContractInstances,
     exports::alloy::{
         primitives::{U256, aliases::U56},
-        providers::ProviderBuilder,
+        providers::{Provider, ProviderBuilder},
         rpc::client::ClientBuilder,
         signers::local::PrivateKeySigner,
     },
@@ -20,13 +29,15 @@ use hopr_types::{
     chain::ContractAddresses,
     crypto::keypairs::{ChainKeypair, Keypair},
     internal::prelude::WinningProbability,
-    primitive::{prelude::HoprBalance, traits::IntoEndian},
+    primitive::{prelude::HoprBalance, primitives::Address, traits::IntoEndian},
 };
 use serde::Serialize;
+use tempfile::NamedTempFile;
 use tracing_subscriber::{Layer as _, prelude::*};
 use url::Url;
 
 const DEFAULT_ANVIL_PRIVATE_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const ANVIL_CHAIN_ID: u64 = 31_337;
 static PANIC_HOOK_INSTALLED: Once = Once::new();
 
 #[derive(Debug, Parser)]
@@ -61,6 +72,18 @@ struct Args {
     /// Optional output path for TOML configuration
     #[arg(long)]
     output: Option<PathBuf>,
+
+    /// Also deploy the Curvy v2 local-development contract suite
+    #[arg(long, default_value_t = false)]
+    with_curvy: bool,
+
+    /// Curvy Ignition-compatible address JSON output path
+    #[arg(long)]
+    curvy_json_out: Option<PathBuf>,
+
+    /// Allow Curvy deployment outside Anvil's default chain ID
+    #[arg(long, env = "BLOKLI_DEPLOYER_ALLOW_UNSAFE_CHAIN", default_value_t = false)]
+    allow_unsafe_chain: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -73,6 +96,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     install_tracing()?;
 
     let args = Args::parse();
+    validate_args(&args)?;
 
     let signer = PrivateKeySigner::from_str(&args.private_key)?;
     let signer_chain_key = ChainKeypair::from_secret(signer.to_bytes().as_ref())?;
@@ -81,12 +105,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let rpc_url = Url::parse(&args.rpc_url)?;
     let rpc_client = ClientBuilder::default().http(rpc_url);
     let provider = ProviderBuilder::new().wallet(signer).connect_client(rpc_client);
+    let chain_id = provider.get_chain_id().await?;
+    if args.with_curvy && chain_id != ANVIL_CHAIN_ID && !args.allow_unsafe_chain {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "refusing local-development deployment on chain {chain_id}; expected {ANVIL_CHAIN_ID} (use --allow-unsafe-chain to override)"
+            ),
+        )
+        .into());
+    }
 
     // The local deployment uses a single signer for both the HOPR and common contract deployers.
     let deployer_address = a2h(signer_chain_key.public().to_address());
-    let instances = ContractInstances::deploy_for_testing(provider, deployer_address, deployer_address).await?;
+    let instances = ContractInstances::deploy_for_testing(provider.clone(), deployer_address, deployer_address).await?;
     let contracts = ContractAddresses::from(&instances);
-    let output = ContractsOutput {
+    #[cfg_attr(not(feature = "curvy-test-deployment"), allow(unused_mut))]
+    let mut output = ContractsOutput {
         contracts: BlokliContractAddresses {
             token: h2a(contracts.token),
             channels: h2a(contracts.channels),
@@ -98,9 +133,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             winning_probability_oracle: h2a(contracts.winning_probability_oracle),
             node_stake_factory: h2a(contracts.node_stake_factory),
             xhopr_token: h2a(contracts.xhopr_token),
+            curvy_aggregator: Address::default(),
+            curvy_vault: Address::default(),
+            curvy_portal_factory: Address::default(),
         },
     };
-    let toml_output = toml::to_string(&output)?;
 
     // Assign minter role to Anvil account 0
     let minter_role = instances.token.MINTER_ROLE().call().await?;
@@ -165,12 +202,117 @@ async fn main() -> Result<(), Box<dyn Error>> {
         args.winning_probability.as_f64()
     );
 
-    if let Some(path) = args.output {
-        fs::write(path, toml_output)?;
+    let curvy_json: Option<String> = if args.with_curvy {
+        #[cfg(feature = "curvy-test-deployment")]
+        {
+            tracing::info!("deploying Curvy v2 local-development contracts");
+            let curvy_instances = CurvyContractInstances::deploy_for_testing(provider, signer_address).await?;
+            let hopr_token_id = curvy_instances.vault.getNumberOfTokens().call().await? + U256::ONE;
+            curvy_instances
+                .vault
+                .registerToken(*instances.token.address())
+                .send()
+                .await?
+                .watch()
+                .await?;
+            tracing::info!(
+                token = %instances.token.address(),
+                token_id = %hopr_token_id,
+                "registered the HOPR token in the Curvy vault"
+            );
+            let curvy_contracts = CurvyContractAddresses::from(&curvy_instances);
+            tracing::info!(
+                aggregator = %curvy_contracts.aggregator_proxy,
+                vault = %curvy_contracts.vault_proxy,
+                portal_factory = %curvy_contracts.portal_factory,
+                "Curvy contracts ready"
+            );
+            output.contracts.curvy_aggregator = h2a(curvy_contracts.aggregator_proxy);
+            output.contracts.curvy_vault = h2a(curvy_contracts.vault_proxy);
+            output.contracts.curvy_portal_factory = h2a(curvy_contracts.portal_factory);
+            Some(format!(
+                "{}\n",
+                serde_json::to_string_pretty(&curvy_contracts.to_ignition_json())?
+            ))
+        }
+        #[cfg(not(feature = "curvy-test-deployment"))]
+        unreachable!("validate_args rejects Curvy without compiled support")
+    } else {
+        None
+    };
+    let toml_output = toml::to_string(&output)?;
+
+    // Publish outputs only after every requested deployment and serialization succeeds.
+    if let Some(path) = args.output.as_deref() {
+        atomic_write(path, toml_output.as_bytes())?;
+        tracing::info!(path = %path.display(), "wrote HOPR contract configuration");
     } else {
         print!("{toml_output}");
     }
+    if let (Some(path), Some(json)) = (args.curvy_json_out.as_deref(), curvy_json.as_deref()) {
+        atomic_write(path, json.as_bytes())?;
+        tracing::info!(path = %path.display(), "wrote Curvy contract addresses");
+    }
 
+    Ok(())
+}
+
+fn validate_args(args: &Args) -> io::Result<()> {
+    if args.curvy_json_out.is_some() && !args.with_curvy {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--curvy-json-out requires --with-curvy",
+        ));
+    }
+    if let (Some(hopr), Some(curvy)) = (args.output.as_deref(), args.curvy_json_out.as_deref())
+        && normalize_path(hopr)? == normalize_path(curvy)?
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "HOPR and Curvy output paths must be different",
+        ));
+    }
+    if args.with_curvy && !cfg!(feature = "curvy-test-deployment") {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Curvy deployment requires a binary built with the curvy-test-deployment feature",
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_path(path: &Path) -> io::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    Ok(normalized)
+}
+
+fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let mut temporary = NamedTempFile::new_in(parent)?;
+    temporary.write_all(contents)?;
+    #[cfg(unix)]
+    temporary
+        .as_file()
+        .set_permissions(std::os::unix::fs::PermissionsExt::from_mode(0o644))?;
+    temporary.as_file().sync_all()?;
+    temporary.persist(path).map_err(|error| error.error)?;
     Ok(())
 }
 
@@ -238,13 +380,17 @@ fn panic_payload_to_str(payload: &(dyn Any + Send)) -> Cow<'static, str> {
 
 #[cfg(test)]
 mod tests {
-    use std::any::Any;
+    use std::{any::Any, fs};
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
 
     use anyhow::Result;
     use clap::Parser;
     use hopr_types::{internal::prelude::WinningProbability, primitive::traits::IntoEndian};
+    use tempfile::tempdir;
 
-    use super::{Args, panic_payload_to_str};
+    use super::{Args, atomic_write, panic_payload_to_str, validate_args};
 
     #[test]
     fn test_panic_payload_to_str_from_str() {
@@ -275,6 +421,68 @@ mod tests {
         let args = Args::try_parse_from(["blokli-contract-deployer"])?;
         let roundtrip = args.winning_probability.as_f64();
         assert!((roundtrip - 0.000125_f64).abs() < WinningProbability::EPSILON);
+        Ok(())
+    }
+
+    #[test]
+    fn curvy_defaults_off() -> Result<()> {
+        let args = Args::try_parse_from(["blokli-contract-deployer"])?;
+        assert!(!args.with_curvy);
+        assert!(args.curvy_json_out.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn curvy_output_requires_explicit_activation() -> Result<()> {
+        let args = Args::try_parse_from(["blokli-contract-deployer", "--curvy-json-out", "curvy.json"])?;
+        let error = validate_args(&args).expect_err("output alone must not enable Curvy deployment");
+        assert_eq!(error.to_string(), "--curvy-json-out requires --with-curvy");
+        Ok(())
+    }
+
+    #[test]
+    fn output_paths_must_not_collide() -> Result<()> {
+        let args = Args::try_parse_from([
+            "blokli-contract-deployer",
+            "--with-curvy",
+            "--output",
+            "deployments.toml",
+            "--curvy-json-out",
+            "./deployments.toml",
+        ])?;
+        let error = validate_args(&args).expect_err("colliding paths must fail before deployment");
+        assert_eq!(error.to_string(), "HOPR and Curvy output paths must be different");
+        Ok(())
+    }
+
+    #[cfg(not(feature = "curvy-test-deployment"))]
+    #[test]
+    fn feature_off_binary_rejects_curvy() -> Result<()> {
+        let args = Args::try_parse_from(["blokli-contract-deployer", "--with-curvy"])?;
+        let error = validate_args(&args).expect_err("feature-off binary must reject Curvy deployment");
+        assert!(error.to_string().contains("curvy-test-deployment"));
+        Ok(())
+    }
+
+    #[cfg(feature = "curvy-test-deployment")]
+    #[test]
+    fn feature_on_binary_accepts_curvy() -> Result<()> {
+        let args = Args::try_parse_from(["blokli-contract-deployer", "--with-curvy"])?;
+        validate_args(&args)?;
+        Ok(())
+    }
+
+    #[test]
+    fn atomic_write_replaces_complete_file() -> Result<()> {
+        let directory = tempdir()?;
+        let path = directory.path().join("contracts.toml");
+        fs::write(&path, "old")?;
+
+        atomic_write(&path, b"new\n")?;
+
+        assert_eq!(fs::read_to_string(&path)?, "new\n");
+        #[cfg(unix)]
+        assert_eq!(fs::metadata(path)?.permissions().mode() & 0o777, 0o644);
         Ok(())
     }
 }

--- a/bloklid/src/config.rs
+++ b/bloklid/src/config.rs
@@ -315,6 +315,10 @@ impl Config {
             "  indexer.enable_safe_indexing: {}\n",
             self.indexer.enable_safe_indexing
         ));
+        output.push_str(&format!(
+            "  indexer.enable_curvy_indexing: {}\n",
+            self.indexer.enable_curvy_indexing
+        ));
 
         if let Some(snapshot_url) = &self.indexer.logs_snapshot_url {
             output.push_str(&format!("  indexer.logs_snapshot_url: {}\n", redact_url(snapshot_url)));
@@ -389,6 +393,10 @@ pub struct IndexerConfig {
     #[default(false)]
     #[serde(default = "default_false")]
     pub enable_safe_indexing: bool,
+
+    #[default(false)]
+    #[serde(default = "default_false")]
+    pub enable_curvy_indexing: bool,
 
     #[serde(default)]
     pub logs_snapshot_url: Option<String>,
@@ -808,6 +816,7 @@ mod tests {
         // Check indexer config
         assert!(config.indexer.fast_sync);
         assert!(!config.indexer.enable_safe_indexing);
+        assert!(!config.indexer.enable_curvy_indexing);
         assert_eq!(config.indexer.subscription.event_bus_capacity, 1000);
 
         // Check API config
@@ -840,6 +849,7 @@ mod tests {
         assert!(!cfg.indexer.fast_sync);
         assert!(!cfg.indexer.enable_logs_snapshot); // Default
         assert!(!cfg.indexer.enable_safe_indexing); // Default
+        assert!(!cfg.indexer.enable_curvy_indexing); // Default
         assert_eq!(cfg.indexer.subscription.event_bus_capacity, 1000); // Default
         assert_eq!(cfg.indexer.subscription.batch_size, 100); // Default
     }

--- a/bloklid/src/main.rs
+++ b/bloklid/src/main.rs
@@ -191,6 +191,7 @@ async fn run(args: Args, initial_config: Option<Config>) -> errors::Result<()> {
                 fast_sync: cfg.indexer.fast_sync,
                 enable_logs_snapshot: cfg.indexer.enable_logs_snapshot,
                 enable_safe_indexing: cfg.indexer.enable_safe_indexing,
+                enable_curvy_indexing: cfg.indexer.enable_curvy_indexing,
                 logs_snapshot_url: cfg.indexer.logs_snapshot_url.clone(),
                 data_directory: cfg.data_directory.clone(),
                 event_bus_capacity: cfg.indexer.subscription.event_bus_capacity,

--- a/bloklid/tests/indexer_startup_test.rs
+++ b/bloklid/tests/indexer_startup_test.rs
@@ -150,6 +150,9 @@ async fn test_indexer_startup() -> anyhow::Result<()> {
         winning_probability_oracle: Address::from([6; 20]),
         node_stake_factory: Address::from([7; 20]),
         xhopr_token: Address::from([10; 20]),
+        curvy_aggregator: Address::default(),
+        curvy_vault: Address::default(),
+        curvy_portal_factory: Address::default(),
     };
 
     // Create indexer state for subscriptions (must be created before handlers)
@@ -161,6 +164,7 @@ async fn test_indexer_startup() -> anyhow::Result<()> {
         db.clone(),
         mock_rpc.clone(),
         indexer_state.clone(),
+        false,
         false,
     );
 
@@ -182,6 +186,7 @@ async fn test_indexer_startup() -> anyhow::Result<()> {
         fast_sync: false, // Disable fast sync for testing
         enable_logs_snapshot: false,
         enable_safe_indexing: false,
+        enable_curvy_indexing: false,
         logs_snapshot_url: None,
         data_directory: db_path.to_string_lossy().to_string(),
         event_bus_capacity: 1000,
@@ -233,6 +238,9 @@ async fn test_indexer_with_fast_sync() -> anyhow::Result<()> {
         winning_probability_oracle: Address::from([6; 20]),
         node_stake_factory: Address::from([7; 20]),
         xhopr_token: Address::from([10; 20]),
+        curvy_aggregator: Address::default(),
+        curvy_vault: Address::default(),
+        curvy_portal_factory: Address::default(),
     };
 
     // Create indexer state for subscriptions (must be created before handlers)
@@ -244,6 +252,7 @@ async fn test_indexer_with_fast_sync() -> anyhow::Result<()> {
         db.clone(),
         mock_rpc.clone(),
         indexer_state.clone(),
+        false,
         false,
     );
 
@@ -265,6 +274,7 @@ async fn test_indexer_with_fast_sync() -> anyhow::Result<()> {
         fast_sync: true,
         enable_logs_snapshot: false, // Don't try to download snapshots
         enable_safe_indexing: false,
+        enable_curvy_indexing: false,
         logs_snapshot_url: None,
         data_directory: db_path.to_string_lossy().to_string(),
         event_bus_capacity: 1000,
@@ -420,6 +430,9 @@ async fn test_indexer_handles_start_block_configuration() -> anyhow::Result<()> 
         winning_probability_oracle: Address::from([6; 20]),
         node_stake_factory: Address::from([7; 20]),
         xhopr_token: Address::from([10; 20]),
+        curvy_aggregator: Address::default(),
+        curvy_vault: Address::default(),
+        curvy_portal_factory: Address::default(),
     };
 
     // Create indexer state for subscriptions (must be created before handlers)
@@ -431,6 +444,7 @@ async fn test_indexer_handles_start_block_configuration() -> anyhow::Result<()> 
         db.clone(),
         tracking_rpc.clone(),
         indexer_state.clone(),
+        false,
         false,
     );
 
@@ -453,6 +467,7 @@ async fn test_indexer_handles_start_block_configuration() -> anyhow::Result<()> 
         fast_sync: false,
         enable_logs_snapshot: false,
         enable_safe_indexing: false,
+        enable_curvy_indexing: false,
         logs_snapshot_url: None,
         data_directory: db_path.to_string_lossy().to_string(),
         event_bus_capacity: 1000,
@@ -526,6 +541,9 @@ async fn test_channel_closure_grace_period_initialized_on_startup() -> anyhow::R
         winning_probability_oracle: Address::from([6; 20]),
         node_stake_factory: Address::from([7; 20]),
         xhopr_token: Address::from([10; 20]),
+        curvy_aggregator: Address::default(),
+        curvy_vault: Address::default(),
+        curvy_portal_factory: Address::default(),
     };
 
     // Create indexer state for subscriptions
@@ -537,6 +555,7 @@ async fn test_channel_closure_grace_period_initialized_on_startup() -> anyhow::R
         db.clone(),
         mock_rpc.clone(),
         indexer_state.clone(),
+        false,
         false,
     );
 
@@ -558,6 +577,7 @@ async fn test_channel_closure_grace_period_initialized_on_startup() -> anyhow::R
         fast_sync: false,
         enable_logs_snapshot: false,
         enable_safe_indexing: false,
+        enable_curvy_indexing: false,
         logs_snapshot_url: None,
         data_directory: db_path.to_string_lossy().to_string(),
         event_bus_capacity: 1000,

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -94,6 +94,12 @@ impl<T: BlokliDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static>
         indexer_cfg: IndexerConfig,
         rpc_url: String,
     ) -> Result<Self> {
+        if indexer_cfg.enable_curvy_indexing && contract_addresses.curvy_aggregator == Address::default() {
+            return Err(BlokliChainError::Configuration(
+                "Curvy indexing is enabled but the Curvy Aggregator address is not configured".to_string(),
+            ));
+        }
+
         // TODO(#7140): replace this DefaultRetryPolicy with a custom one that computes backoff with the number of
         // retries
         let rpc_http_retry_policy = DefaultRetryPolicy::default();
@@ -257,6 +263,7 @@ impl<T: BlokliDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static>
                     self.rpc_operations.clone(),
                     self.indexer_state.clone(),
                     self.indexer_cfg.enable_safe_indexing,
+                    self.indexer_cfg.enable_curvy_indexing,
                 ),
                 self.db.clone(),
                 self.indexer_cfg.clone(),

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -47,6 +47,7 @@ blokli-chain-rpc = { workspace = true }
 blokli-chain-types = { workspace = true }
 blokli-db = { workspace = true }
 blokli-db-entity = { workspace = true }
+curvy-bindings = { workspace = true }
 hopr-bindings = { workspace = true }
 hopr-types = { workspace = true, features = [
   "chain",

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -198,7 +198,7 @@ where
 
         // Check that the contract addresses and topics are consistent with what is in the logs DB,
         // or if the DB is empty, prime it with the given addresses and topics.
-        db.ensure_logs_origin(address_topics).await?;
+        db.ensure_logs_origin(address_topics.clone()).await?;
 
         let is_synced = Arc::new(AtomicBool::new(false));
         let chain_head = Arc::new(AtomicU64::new(0));
@@ -220,6 +220,17 @@ where
 
         // Pre-start operations to ensure the indexer is ready, including snapshot fetching
         self.pre_start().await?;
+
+        // Re-check the origin after pre-start. Importing a logs snapshot replaces the log and
+        // topic tables wholesale, discarding whatever was primed above, and indexing then resumes
+        // from the snapshot's watermark. A snapshot that does not cover every configured contract
+        // would therefore skip that contract's entire pre-watermark history with no other symptom.
+        // For Curvy that is unrecoverable rather than merely incomplete: dense leaf indices are a
+        // function of every preceding note, so missing history yields a tree whose roots disagree
+        // with the aggregator's, surfacing only when a wallet's witness fails to verify. The
+        // address/topic set is derived from the enabled contracts, so this is inert unless a
+        // configured contract is genuinely absent from the snapshot.
+        db.ensure_logs_origin(address_topics).await?;
 
         #[derive(PartialEq, Eq)]
         enum FastSyncMode {
@@ -847,7 +858,7 @@ where
 
             // Handle the reorg by inserting corrective channel states
             // Use the current block as the canonical block for corrective states
-            match Self::handle_reorg(db, &reorg_info, block_id, indexer_state).await {
+            match Self::handle_reorg(logs_handler, db, &reorg_info, block_id, indexer_state).await {
                 Ok(corrected_count) => {
                     info!(
                         block_id,
@@ -870,6 +881,19 @@ where
         // transaction. This is difficult since currently this would be across databases.
         // Process all logs - events are published internally via IndexerState
         for log in block.logs.clone() {
+            if !logs_handler.should_process_log(&log) {
+                debug!(
+                    block_id = log.block_number,
+                    tx_index = log.tx_index,
+                    log_index = %log.log_index,
+                    "skipping log excluded by its contract handler"
+                );
+                if let Err(error) = db.set_log_processed(log).await {
+                    error!(block_id, %error, "failed to mark skipped log as processed");
+                    panic!("failed to mark skipped log as processed")
+                }
+                continue;
+            }
             match logs_handler.collect_log_event(log.clone(), is_synced).await {
                 Ok(()) => match db.set_log_processed(log).await {
                     Ok(_) => {}
@@ -1007,7 +1031,7 @@ where
     ///
     /// # Audit Trail Preservation
     ///
-    /// This function follows the **never-delete principle**:
+    /// Channel history follows the **never-delete principle**:
     /// - Invalidated states from reorganized blocks remain in the database
     /// - Temporal queries automatically use corrective states to reflect canonical chain state
     /// - Complete history is preserved for auditing and forensic analysis
@@ -1078,6 +1102,7 @@ where
     ///   corrective states
     /// - Design document section 6.5 - Detailed reorg handling specification
     async fn handle_reorg(
+        logs_handler: &U,
         db: &Db,
         reorg_info: &ReorgInfo,
         canonical_block: u64,
@@ -1099,6 +1124,15 @@ where
             min_block,
             max_block, canonical_block, "Processing reorg: identifying affected channels"
         );
+
+        // Stop active subscriptions before canonical event history is changed.
+        if !indexer_state.signal_shutdown() {
+            error!("Failed to signal shutdown to subscriptions after reorg - channel may be closed");
+        } else {
+            info!("Signaled shutdown to active subscriptions after reorg");
+        }
+
+        logs_handler.revert_block_derived_state(min_block).await?;
 
         // Step 1: Query channel_state table for all states in the affected block range
         // This tells us which channels were affected by the reorg
@@ -1174,15 +1208,6 @@ where
             corrected_count += 1;
 
             debug!(channel_id, canonical_block, "Inserted corrective state");
-        }
-
-        // Signal shutdown to active subscriptions
-        // Subscriptions will detect shutdown signal and close client connections,
-        // forcing clients to reconnect and get fresh watermarks
-        if !indexer_state.signal_shutdown() {
-            error!("Failed to signal shutdown to subscriptions after reorg - channel may be closed");
-        } else {
-            info!("Signaled shutdown to active subscriptions after reorg");
         }
 
         info!(corrected_count, "Reorg handling complete");
@@ -1284,6 +1309,8 @@ mod tests {
         time::Duration,
     };
 
+    use super::*;
+    use crate::traits::{ChainLogHandler, MockChainLogHandler};
     use async_trait::async_trait;
     use blokli_chain_rpc::BlockWithLogs;
     use blokli_chain_types::{ContractAddresses, chain_events::ChainEventType};
@@ -1311,9 +1338,6 @@ mod tests {
     };
     use mockall::mock;
     use multiaddr::Multiaddr;
-
-    use super::*;
-    use crate::traits::{ChainLogHandler, MockChainLogHandler};
 
     lazy_static::lazy_static! {
         static ref ALICE_OKP: OffchainKeypair = OffchainKeypair::random();
@@ -1793,7 +1817,17 @@ mod tests {
                 .expect_contract_addresses_map()
                 .return_const(ContractAddresses::default());
 
-            let indexer_cfg = IndexerConfig::new(0, true, false, false, None, "/tmp/test_data".to_string(), 1000, 10);
+            let indexer_cfg = IndexerConfig::new(
+                0,
+                true,
+                false,
+                false,
+                false,
+                None,
+                "/tmp/test_data".to_string(),
+                1000,
+                10,
+            );
             let indexer = Indexer::new(rpc, handlers, db.clone(), indexer_cfg, IndexerState::default())
                 .without_panic_on_completion();
             let (indexing, _) = join!(indexer.start(), async move {
@@ -1884,7 +1918,17 @@ mod tests {
                 .expect_contract_addresses_map()
                 .return_const(ContractAddresses::default());
 
-            let indexer_cfg = IndexerConfig::new(0, true, false, false, None, "/tmp/test_data".to_string(), 1000, 10);
+            let indexer_cfg = IndexerConfig::new(
+                0,
+                true,
+                false,
+                false,
+                false,
+                None,
+                "/tmp/test_data".to_string(),
+                1000,
+                10,
+            );
             let indexer = Indexer::new(rpc, handlers, db.clone(), indexer_cfg, IndexerState::default())
                 .without_panic_on_completion();
             let (indexing, _) = join!(indexer.start(), async move {
@@ -1915,6 +1959,7 @@ mod tests {
                 0,
                 true,
                 true,
+                false,
                 false,
                 Some("file:///definitely/missing/snapshot.tar.xz".to_string()),
                 temp_dir.path().display().to_string(),
@@ -2100,7 +2145,17 @@ mod tests {
             .withf(move |l, _| l.block_number == last_processed_block + 1)
             .returning(|_, _| Ok(()));
 
-        let indexer_cfg = IndexerConfig::new(0, false, false, false, None, "/tmp/test_data".to_string(), 1000, 10);
+        let indexer_cfg = IndexerConfig::new(
+            0,
+            false,
+            false,
+            false,
+            false,
+            None,
+            "/tmp/test_data".to_string(),
+            1000,
+            10,
+        );
 
         let indexer =
             Indexer::new(rpc, handlers, db.clone(), indexer_cfg, IndexerState::default()).without_panic_on_completion();
@@ -2504,7 +2559,6 @@ mod tests {
         create_channel_state(&db, 1, 10, 0, 0, [1u8; 12], 1, false).await?;
         create_channel_state(&db, 1, 50, 0, 0, [2u8; 12], 1, false).await?;
         create_channel_state(&db, 1, 100, 0, 0, [3u8; 12], 2, false).await?;
-
         // Simulate reorg affecting blocks 100-100
         let reorg_info = ReorgInfo {
             detected_at_block: 200,
@@ -2514,6 +2568,7 @@ mod tests {
 
         // Handle the reorg
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,
@@ -2523,7 +2578,6 @@ mod tests {
 
         // Verify correction was made
         assert_eq!(corrected_count, 1, "Expected 1 channel to be corrected");
-
         // Verify corrective state was inserted
         let states = get_channel_states(&db, 1).await?;
         assert_eq!(states.len(), 4, "Expected 4 states (3 original + 1 corrective)");
@@ -2591,6 +2645,7 @@ mod tests {
 
         // Handle the reorg
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             150,
@@ -2664,6 +2719,7 @@ mod tests {
 
         // Handle the reorg
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             150,
@@ -2709,6 +2765,7 @@ mod tests {
 
         // Handle the reorg
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             150,
@@ -2746,6 +2803,7 @@ mod tests {
         };
 
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,
@@ -2802,6 +2860,7 @@ mod tests {
         };
 
         Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,
@@ -2867,6 +2926,7 @@ mod tests {
         };
 
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             250,
@@ -2909,6 +2969,7 @@ mod tests {
         };
 
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             150,
@@ -2952,6 +3013,7 @@ mod tests {
         };
 
         Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,
@@ -3001,6 +3063,7 @@ mod tests {
         };
 
         Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,
@@ -3039,6 +3102,7 @@ mod tests {
 
         // First correction
         let count1 = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,
@@ -3052,6 +3116,7 @@ mod tests {
 
         // Second correction attempt at different canonical block
         let count2 = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             201,
@@ -3093,6 +3158,7 @@ mod tests {
         };
 
         let corrected_count = Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,
@@ -3140,6 +3206,7 @@ mod tests {
         };
 
         Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             250,
@@ -3186,6 +3253,7 @@ mod tests {
         };
 
         Indexer::<MockHoprIndexerOps, MockChainLogHandler, BlokliDb>::handle_reorg(
+            &MockChainLogHandler::new(),
             &db,
             &reorg_info,
             200,

--- a/chain/indexer/src/config.rs
+++ b/chain/indexer/src/config.rs
@@ -32,6 +32,12 @@ pub struct IndexerConfig {
     #[default(false)]
     pub enable_safe_indexing: bool,
 
+    /// Whether to index note and nullifier events from the configured Curvy Aggregator.
+    ///
+    /// Default is `false`.
+    #[default(false)]
+    pub enable_curvy_indexing: bool,
+
     /// URL to download logs snapshot from.
     /// This should point to a publicly accessible tar.xz file containing
     /// the SQLite logs database files.
@@ -70,6 +76,7 @@ impl IndexerConfig {
     /// * `fast_sync` - Whether to enable fast synchronization during startup
     /// * `enable_logs_snapshot` - Whether to enable logs snapshot download
     /// * `enable_safe_indexing` - Whether to index Safe contract events for discovered Safes
+    /// * `enable_curvy_indexing` - Whether to index Curvy Aggregator note and nullifier events
     /// * `logs_snapshot_url` - URL to download logs snapshot from
     /// * `data_directory` - Path to the data directory where databases are stored
     /// * `event_bus_capacity` - Capacity of the event bus buffer
@@ -84,6 +91,7 @@ impl IndexerConfig {
         fast_sync: bool,
         enable_logs_snapshot: bool,
         enable_safe_indexing: bool,
+        enable_curvy_indexing: bool,
         logs_snapshot_url: Option<String>,
         data_directory: String,
         event_bus_capacity: usize,
@@ -94,6 +102,7 @@ impl IndexerConfig {
             fast_sync,
             enable_logs_snapshot,
             enable_safe_indexing,
+            enable_curvy_indexing,
             logs_snapshot_url,
             data_directory,
             event_bus_capacity,
@@ -123,6 +132,7 @@ impl IndexerConfig {
     ///     100,
     ///     true,
     ///     true,
+    ///     false,
     ///     false,
     ///     Some("https://example.com/snapshot.tar.xz".to_string()),
     ///     "/tmp/hopr_data".to_string(),
@@ -179,6 +189,7 @@ mod tests {
             true,
             true,
             false,
+            false,
             Some(logs_snapshot_url),
             data_directory.into(),
             1000,
@@ -191,7 +202,17 @@ mod tests {
 
     #[test]
     fn test_disabled_snapshot_config() {
-        let cfg = IndexerConfig::new(0, true, false, false, Some("".to_string()), "".to_string(), 1000, 10);
+        let cfg = IndexerConfig::new(
+            0,
+            true,
+            false,
+            false,
+            false,
+            Some("".to_string()),
+            "".to_string(),
+            1000,
+            10,
+        );
 
         assert!(
             cfg.validate().is_ok(),
@@ -201,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_missing_snapshot_url() {
-        let cfg = IndexerConfig::new(0, true, true, false, None, "".to_string(), 1000, 10);
+        let cfg = IndexerConfig::new(0, true, true, false, false, None, "".to_string(), 1000, 10);
 
         assert!(
             cfg.validate().is_err(),

--- a/chain/indexer/src/constants.rs
+++ b/chain/indexer/src/constants.rs
@@ -5,6 +5,9 @@ pub const LOGS_SNAPSHOT_DOWNLOADER_TIMEOUT: Duration = Duration::from_secs(1800)
 pub const LOGS_SNAPSHOT_DOWNLOADER_MAX_RETRIES: u32 = 3;
 
 pub mod topics {
+    use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::{
+        CommittedNotes, CommittedNullifiers, PendingNotes,
+    };
     use hopr_bindings::{
         exports::alloy::{primitives::B256, sol_types::SolEvent},
         hopr_announcements_events::HoprAnnouncementsEvents::{
@@ -122,6 +125,14 @@ pub mod topics {
             ExecutionSuccess::SIGNATURE_HASH,
             ExecutionFailure::SIGNATURE_HASH,
             ExecutionFromModuleFailure::SIGNATURE_HASH,
+        ]
+    }
+
+    pub fn curvy_aggregator() -> Vec<B256> {
+        vec![
+            PendingNotes::SIGNATURE_HASH,
+            CommittedNotes::SIGNATURE_HASH,
+            CommittedNullifiers::SIGNATURE_HASH,
         ]
     }
 

--- a/chain/indexer/src/errors.rs
+++ b/chain/indexer/src/errors.rs
@@ -1,6 +1,10 @@
+use std::num::TryFromIntError;
+
 use hopr_bindings::exports::alloy::{dyn_abi::Error as AbiError, sol_types::Error as SolTypeError};
 use hopr_types::primitive::{errors::GeneralError, primitives::Address};
 use thiserror::Error;
+
+use blokli_chain_types::curvy_tree::TreeError;
 
 #[derive(Error, Debug)]
 pub enum CoreEthereumIndexerError {
@@ -27,6 +31,15 @@ pub enum CoreEthereumIndexerError {
 
     #[error("{0}")]
     ValidationError(String),
+
+    #[error(transparent)]
+    CurvyTreeError(#[from] TreeError),
+
+    #[error("Curvy derived-state invariant failed: {0}")]
+    CurvyStateInvariant(String),
+
+    #[error("Curvy index conversion failed: {0}")]
+    CurvyIndexConversion(#[from] TryFromIntError),
 
     #[error("Address announcement without a preceding key binding.")]
     AnnounceBeforeKeyBinding,

--- a/chain/indexer/src/handlers/curvy.rs
+++ b/chain/indexer/src/handlers/curvy.rs
@@ -1,0 +1,684 @@
+use blokli_api_types::{
+    CurvyCommittedNote, CurvyCommittedNullifier, CurvyEventPosition, CurvyPendingNote, Hex32, UInt64, UInt256,
+};
+use blokli_chain_rpc::Log;
+use blokli_chain_types::curvy_tree::{
+    NOTES_SHARD_HEIGHT, NOTES_TREE_DEPTH, NOTES_TREE_VERSION, NotesFrontier, fr_to_be_32,
+};
+use blokli_db::{BlokliDbAllOperations, OpenTransaction, errors::DbSqlError};
+use blokli_db_entity::{
+    curvy_committed_note, curvy_committed_nullifier, curvy_pending_note, curvy_shard_root, curvy_sync_checkpoint,
+};
+use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::{
+    CommittedNotes, CommittedNullifiers, CurvyAggregatorAlphaV2Events, PendingNotes,
+};
+use hopr_bindings::exports::alloy::primitives::U256;
+use hopr_types::primitive::traits::ToHex;
+use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, sea_query::OnConflict};
+use tracing::info;
+
+use super::ContractEventHandlers;
+#[cfg(all(feature = "telemetry", not(test)))]
+use super::increment_indexer_contract_log_count;
+use crate::{
+    errors::{CoreEthereumIndexerError, Result},
+    state::IndexerEvent,
+};
+
+#[derive(Clone, Copy)]
+enum CurvyEventKind {
+    PendingNote,
+    CommittedNote,
+    CommittedNullifier,
+}
+
+fn invalid_state(message: impl Into<String>) -> CoreEthereumIndexerError {
+    CoreEthereumIndexerError::CurvyStateInvariant(message.into())
+}
+
+fn u256_bytes(value: U256) -> Vec<u8> {
+    value.to_be_bytes::<32>().to_vec()
+}
+
+fn u256_scalar(value: U256) -> UInt256 {
+    UInt256(value.to_string())
+}
+
+fn u256_hex(value: U256) -> Hex32 {
+    Hex32(format!("{value:#066x}"))
+}
+
+fn position(log: &Log, event_item_index: i64) -> Result<CurvyEventPosition> {
+    Ok(CurvyEventPosition {
+        transaction_hash: Hex32(log.tx_hash.to_hex()),
+        block_hash: Hex32(log.block_hash.to_hex()),
+        block: UInt64(log.block_number),
+        transaction_index: UInt64(log.tx_index),
+        log_index: UInt64(log.log_index.as_u64()),
+        event_item_index: UInt64(u64::try_from(event_item_index)?),
+    })
+}
+
+fn coordinates(log: &Log) -> Result<(i64, i64, i64)> {
+    Ok((
+        i64::try_from(log.block_number)?,
+        i64::try_from(log.tx_index)?,
+        i64::try_from(log.log_index.as_u64())?,
+    ))
+}
+
+fn validate_pending_notes(event: &PendingNotes) -> Result<usize> {
+    let len = event.noteIds.len();
+    if event.ephemeralKeys[0].len() != len
+        || event.ephemeralKeys[1].len() != len
+        || event.viewTags.len() != len
+        || event.tokens.len() != len
+        || event.amounts.len() != len
+        || event.isPlaintext.len() != len
+    {
+        return Err(invalid_state("PendingNotes contains arrays with different lengths"));
+    }
+    Ok(len)
+}
+
+async fn log_already_indexed(
+    tx: &OpenTransaction,
+    kind: CurvyEventKind,
+    block: i64,
+    tx_index: i64,
+    log_index: i64,
+) -> Result<bool> {
+    let exists = match kind {
+        CurvyEventKind::PendingNote => curvy_pending_note::Entity::find()
+            .filter(curvy_pending_note::Column::PublishedBlock.eq(block))
+            .filter(curvy_pending_note::Column::PublishedTxIndex.eq(tx_index))
+            .filter(curvy_pending_note::Column::PublishedLogIndex.eq(log_index))
+            .one(tx.as_ref())
+            .await
+            .map_err(DbSqlError::from)?
+            .is_some(),
+        CurvyEventKind::CommittedNote => curvy_committed_note::Entity::find()
+            .filter(curvy_committed_note::Column::PublishedBlock.eq(block))
+            .filter(curvy_committed_note::Column::PublishedTxIndex.eq(tx_index))
+            .filter(curvy_committed_note::Column::PublishedLogIndex.eq(log_index))
+            .one(tx.as_ref())
+            .await
+            .map_err(DbSqlError::from)?
+            .is_some(),
+        CurvyEventKind::CommittedNullifier => curvy_committed_nullifier::Entity::find()
+            .filter(curvy_committed_nullifier::Column::PublishedBlock.eq(block))
+            .filter(curvy_committed_nullifier::Column::PublishedTxIndex.eq(tx_index))
+            .filter(curvy_committed_nullifier::Column::PublishedLogIndex.eq(log_index))
+            .one(tx.as_ref())
+            .await
+            .map_err(DbSqlError::from)?
+            .is_some(),
+    };
+    Ok(exists)
+}
+
+async fn retained_dense_counts(tx: &OpenTransaction) -> Result<(usize, usize)> {
+    let leaf_count = curvy_committed_note::Entity::find()
+        .order_by_desc(curvy_committed_note::Column::LeafIndex)
+        .one(tx.as_ref())
+        .await
+        .map_err(DbSqlError::from)?
+        .map(|model| usize::try_from(model.leaf_index))
+        .transpose()?
+        .map(|index| index + 1)
+        .unwrap_or_default();
+    let nullifier_count = curvy_committed_nullifier::Entity::find()
+        .order_by_desc(curvy_committed_nullifier::Column::NullifierIndex)
+        .one(tx.as_ref())
+        .await
+        .map_err(DbSqlError::from)?
+        .map(|model| usize::try_from(model.nullifier_index))
+        .transpose()?
+        .map(|index| index + 1)
+        .unwrap_or_default();
+    Ok((leaf_count, nullifier_count))
+}
+
+fn restore_checkpoint(
+    checkpoint: &curvy_sync_checkpoint::Model,
+    retained_leaf_count: usize,
+    retained_nullifier_count: usize,
+) -> Result<(NotesFrontier, usize)> {
+    if checkpoint.tree_version != NOTES_TREE_VERSION
+        || checkpoint.tree_depth != i64::try_from(NOTES_TREE_DEPTH)?
+        || checkpoint.shard_height != i64::try_from(NOTES_SHARD_HEIGHT)?
+    {
+        return Err(invalid_state("stored Curvy checkpoint uses unsupported tree geometry"));
+    }
+
+    let checkpoint_leaf_count = usize::try_from(checkpoint.leaf_count)?;
+    let checkpoint_nullifier_count = usize::try_from(checkpoint.nullifier_count)?;
+    if checkpoint_leaf_count != retained_leaf_count || checkpoint_nullifier_count != retained_nullifier_count {
+        return Err(invalid_state(
+            "stored Curvy checkpoint counts do not match retained dense event indexes",
+        ));
+    }
+
+    let frontier = NotesFrontier::from_snapshot_bytes(&checkpoint.frontier_snapshot)?;
+    if frontier.leaf_count() != checkpoint_leaf_count
+        || frontier.shard_count() != usize::try_from(checkpoint.shard_count)?
+        || frontier.root_be_32().as_slice() != checkpoint.root.as_slice()
+    {
+        return Err(invalid_state(
+            "stored Curvy checkpoint is inconsistent with its frontier snapshot",
+        ));
+    }
+    Ok((frontier, checkpoint_nullifier_count))
+}
+
+async fn load_frontier(tx: &OpenTransaction) -> Result<(NotesFrontier, usize)> {
+    let retained_counts = retained_dense_counts(tx).await?;
+    let checkpoint = curvy_sync_checkpoint::Entity::find()
+        .order_by_desc(curvy_sync_checkpoint::Column::BlockNumber)
+        .one(tx.as_ref())
+        .await
+        .map_err(DbSqlError::from)?;
+
+    match checkpoint {
+        Some(checkpoint) => restore_checkpoint(&checkpoint, retained_counts.0, retained_counts.1),
+        None if retained_counts == (0, 0) => Ok((NotesFrontier::production(), 0)),
+        None => Err(invalid_state(
+            "stored Curvy event history exists but its checkpoint is missing",
+        )),
+    }
+}
+
+async fn persist_checkpoint(
+    tx: &OpenTransaction,
+    log: &Log,
+    aggregator_address: Vec<u8>,
+    frontier: &NotesFrontier,
+    nullifier_count: usize,
+) -> Result<()> {
+    let checkpoint = curvy_sync_checkpoint::ActiveModel {
+        block_number: Set(i64::try_from(log.block_number)?),
+        block_hash: Set(log.block_hash.as_ref().to_vec()),
+        aggregator_address: Set(aggregator_address),
+        tree_version: Set(NOTES_TREE_VERSION),
+        tree_depth: Set(i64::try_from(NOTES_TREE_DEPTH)?),
+        shard_height: Set(i64::try_from(NOTES_SHARD_HEIGHT)?),
+        leaf_count: Set(i64::try_from(frontier.leaf_count())?),
+        nullifier_count: Set(i64::try_from(nullifier_count)?),
+        shard_count: Set(i64::try_from(frontier.shard_count())?),
+        root: Set(frontier.root_be_32().to_vec()),
+        frontier_snapshot: Set(frontier.encode_snapshot()),
+        ..Default::default()
+    };
+    curvy_sync_checkpoint::Entity::insert(checkpoint)
+        .on_conflict(
+            OnConflict::column(curvy_sync_checkpoint::Column::BlockNumber)
+                .update_columns([
+                    curvy_sync_checkpoint::Column::BlockHash,
+                    curvy_sync_checkpoint::Column::AggregatorAddress,
+                    curvy_sync_checkpoint::Column::TreeVersion,
+                    curvy_sync_checkpoint::Column::TreeDepth,
+                    curvy_sync_checkpoint::Column::ShardHeight,
+                    curvy_sync_checkpoint::Column::LeafCount,
+                    curvy_sync_checkpoint::Column::NullifierCount,
+                    curvy_sync_checkpoint::Column::ShardCount,
+                    curvy_sync_checkpoint::Column::Root,
+                    curvy_sync_checkpoint::Column::FrontierSnapshot,
+                ])
+                .to_owned(),
+        )
+        .exec_without_returning(tx.as_ref())
+        .await
+        .map_err(DbSqlError::from)?;
+    Ok(())
+}
+
+impl<T, Db> ContractEventHandlers<T, Db>
+where
+    Db: BlokliDbAllOperations + Clone,
+{
+    pub(super) async fn on_curvy_aggregator_event(
+        &self,
+        tx: &OpenTransaction,
+        log: &Log,
+        event: CurvyAggregatorAlphaV2Events,
+    ) -> Result<Vec<IndexerEvent>> {
+        #[cfg(all(feature = "telemetry", not(test)))]
+        increment_indexer_contract_log_count("curvy_aggregator");
+        match event {
+            CurvyAggregatorAlphaV2Events::PendingNotes(event) => self.on_curvy_pending_notes(tx, log, event).await,
+            CurvyAggregatorAlphaV2Events::CommittedNotes(event) => self.on_curvy_committed_notes(tx, log, event).await,
+            CurvyAggregatorAlphaV2Events::CommittedNullifiers(event) => {
+                self.on_curvy_committed_nullifiers(tx, log, event).await
+            }
+            CurvyAggregatorAlphaV2Events::CommitmentGasFeeRootUpdated(_)
+            | CurvyAggregatorAlphaV2Events::DirectShieldEnabledUpdated(_)
+            | CurvyAggregatorAlphaV2Events::Initialized(_)
+            | CurvyAggregatorAlphaV2Events::OwnershipTransferred(_)
+            | CurvyAggregatorAlphaV2Events::RoleAdminChanged(_)
+            | CurvyAggregatorAlphaV2Events::RoleGranted(_)
+            | CurvyAggregatorAlphaV2Events::RoleRevoked(_)
+            | CurvyAggregatorAlphaV2Events::Upgraded(_) => Ok(Vec::new()),
+        }
+    }
+
+    async fn on_curvy_pending_notes(
+        &self,
+        tx: &OpenTransaction,
+        log: &Log,
+        event: PendingNotes,
+    ) -> Result<Vec<IndexerEvent>> {
+        let len = validate_pending_notes(&event)?;
+        if len == 0 {
+            return Ok(Vec::new());
+        }
+        let (block, tx_index, log_index) = coordinates(log)?;
+        if log_already_indexed(tx, CurvyEventKind::PendingNote, block, tx_index, log_index).await? {
+            return Ok(Vec::new());
+        }
+
+        let chain_tx_hash = log.tx_hash.as_ref().to_vec();
+        let block_hash = log.block_hash.as_ref().to_vec();
+        let mut models = Vec::with_capacity(len);
+        let mut events = Vec::with_capacity(len);
+        for item_index in 0..len {
+            if event.noteIds[item_index] == U256::ZERO {
+                continue;
+            }
+            let event_item_index = i64::try_from(item_index)?;
+            models.push(curvy_pending_note::ActiveModel {
+                note_id: Set(u256_bytes(event.noteIds[item_index])),
+                ephemeral_key_x: Set(u256_bytes(event.ephemeralKeys[0][item_index])),
+                ephemeral_key_y: Set(u256_bytes(event.ephemeralKeys[1][item_index])),
+                view_tag: Set(i64::from(event.viewTags[item_index])),
+                token_id: Set(u256_bytes(event.tokens[item_index])),
+                amount: Set(u256_bytes(event.amounts[item_index])),
+                is_plaintext: Set(event.isPlaintext[item_index]),
+                event_item_index: Set(event_item_index),
+                chain_tx_hash: Set(chain_tx_hash.clone()),
+                block_hash: Set(block_hash.clone()),
+                published_block: Set(block),
+                published_tx_index: Set(tx_index),
+                published_log_index: Set(log_index),
+                ..Default::default()
+            });
+            events.push(IndexerEvent::CurvyPendingNote(CurvyPendingNote {
+                note_id: u256_hex(event.noteIds[item_index]),
+                ephemeral_key: vec![
+                    u256_scalar(event.ephemeralKeys[0][item_index]),
+                    u256_scalar(event.ephemeralKeys[1][item_index]),
+                ],
+                view_tag: i32::from(event.viewTags[item_index]),
+                token_id: u256_scalar(event.tokens[item_index]),
+                amount: u256_scalar(event.amounts[item_index]),
+                is_plaintext: event.isPlaintext[item_index],
+                position: position(log, event_item_index)?,
+            }));
+        }
+        if !models.is_empty() {
+            curvy_pending_note::Entity::insert_many(models)
+                .exec_without_returning(tx.as_ref())
+                .await
+                .map_err(DbSqlError::from)?;
+        }
+        Ok(events)
+    }
+
+    async fn on_curvy_committed_notes(
+        &self,
+        tx: &OpenTransaction,
+        log: &Log,
+        event: CommittedNotes,
+    ) -> Result<Vec<IndexerEvent>> {
+        let (block, tx_index, log_index) = coordinates(log)?;
+        if log_already_indexed(tx, CurvyEventKind::CommittedNote, block, tx_index, log_index).await? {
+            return Ok(Vec::new());
+        }
+
+        let chain_tx_hash = log.tx_hash.as_ref().to_vec();
+        let block_hash = log.block_hash.as_ref().to_vec();
+        let (mut frontier, nullifier_count) = load_frontier(tx).await?;
+        let mut models = Vec::with_capacity(event.noteIds.len());
+        let mut shard_roots = Vec::new();
+        let mut events = Vec::with_capacity(event.noteIds.len());
+        for (item_index, note_id) in event.noteIds.into_iter().enumerate() {
+            if note_id == U256::ZERO {
+                continue;
+            }
+            let event_item_index = i64::try_from(item_index)?;
+            let note_id_bytes = note_id.to_be_bytes::<32>();
+            let appended = frontier.append_be_32(&note_id_bytes)?;
+            let leaf_index = i64::try_from(appended.leaf_index)?;
+            models.push(curvy_committed_note::ActiveModel {
+                batch_index: Set(u256_bytes(event.batchIndex)),
+                note_id: Set(note_id_bytes.to_vec()),
+                event_item_index: Set(event_item_index),
+                chain_tx_hash: Set(chain_tx_hash.clone()),
+                block_hash: Set(block_hash.clone()),
+                published_block: Set(block),
+                published_tx_index: Set(tx_index),
+                published_log_index: Set(log_index),
+                leaf_index: Set(leaf_index),
+                ..Default::default()
+            });
+            if let Some(shard) = appended.completed_shard {
+                shard_roots.push(curvy_shard_root::ActiveModel {
+                    tree_version: Set(NOTES_TREE_VERSION),
+                    shard_height: Set(i64::try_from(NOTES_SHARD_HEIGHT)?),
+                    shard_index: Set(i64::try_from(shard.shard_index)?),
+                    root: Set(fr_to_be_32(&shard.root).to_vec()),
+                    block_hash: Set(block_hash.clone()),
+                    chain_tx_hash: Set(chain_tx_hash.clone()),
+                    completion_block: Set(block),
+                    completion_tx_index: Set(tx_index),
+                    completion_log_index: Set(log_index),
+                    completion_event_item_index: Set(event_item_index),
+                    ..Default::default()
+                });
+            }
+            events.push(IndexerEvent::CurvyCommittedNote(CurvyCommittedNote {
+                batch_index: u256_hex(event.batchIndex),
+                note_id: u256_hex(note_id),
+                leaf_index: UInt64(u64::try_from(leaf_index)?),
+                position: position(log, event_item_index)?,
+            }));
+        }
+        if !models.is_empty() {
+            curvy_committed_note::Entity::insert_many(models)
+                .exec_without_returning(tx.as_ref())
+                .await
+                .map_err(DbSqlError::from)?;
+        }
+        if !shard_roots.is_empty() {
+            curvy_shard_root::Entity::insert_many(shard_roots)
+                .exec_without_returning(tx.as_ref())
+                .await
+                .map_err(DbSqlError::from)?;
+        }
+        persist_checkpoint(
+            tx,
+            log,
+            self.addresses.curvy_aggregator.as_ref().to_vec(),
+            &frontier,
+            nullifier_count,
+        )
+        .await?;
+        Ok(events)
+    }
+
+    async fn on_curvy_committed_nullifiers(
+        &self,
+        tx: &OpenTransaction,
+        log: &Log,
+        event: CommittedNullifiers,
+    ) -> Result<Vec<IndexerEvent>> {
+        let (block, tx_index, log_index) = coordinates(log)?;
+        if log_already_indexed(tx, CurvyEventKind::CommittedNullifier, block, tx_index, log_index).await? {
+            return Ok(Vec::new());
+        }
+
+        let chain_tx_hash = log.tx_hash.as_ref().to_vec();
+        let block_hash = log.block_hash.as_ref().to_vec();
+        let (frontier, nullifier_count) = load_frontier(tx).await?;
+        let mut models = Vec::with_capacity(event.nullifiers.len());
+        let mut events = Vec::with_capacity(event.nullifiers.len());
+        for (item_index, nullifier) in event.nullifiers.into_iter().enumerate() {
+            if nullifier == U256::ZERO {
+                continue;
+            }
+            let event_item_index = i64::try_from(item_index)?;
+            let nullifier_index = nullifier_count
+                .checked_add(models.len())
+                .ok_or_else(|| invalid_state("Curvy nullifier index overflow"))?;
+            models.push(curvy_committed_nullifier::ActiveModel {
+                batch_index: Set(u256_bytes(event.batchIndex)),
+                nullifier: Set(u256_bytes(nullifier)),
+                event_item_index: Set(event_item_index),
+                chain_tx_hash: Set(chain_tx_hash.clone()),
+                block_hash: Set(block_hash.clone()),
+                published_block: Set(block),
+                published_tx_index: Set(tx_index),
+                published_log_index: Set(log_index),
+                nullifier_index: Set(i64::try_from(nullifier_index)?),
+                ..Default::default()
+            });
+            events.push(IndexerEvent::CurvyCommittedNullifier(CurvyCommittedNullifier {
+                batch_index: u256_hex(event.batchIndex),
+                nullifier: u256_hex(nullifier),
+                nullifier_index: UInt64(u64::try_from(nullifier_index)?),
+                position: position(log, event_item_index)?,
+            }));
+        }
+        let new_nullifier_count = nullifier_count
+            .checked_add(models.len())
+            .ok_or_else(|| invalid_state("Curvy nullifier count overflow"))?;
+        if !models.is_empty() {
+            curvy_committed_nullifier::Entity::insert_many(models)
+                .exec_without_returning(tx.as_ref())
+                .await
+                .map_err(DbSqlError::from)?;
+        }
+        persist_checkpoint(
+            tx,
+            log,
+            self.addresses.curvy_aggregator.as_ref().to_vec(),
+            &frontier,
+            new_nullifier_count,
+        )
+        .await?;
+        Ok(events)
+    }
+}
+
+impl<T, Db> ContractEventHandlers<T, Db>
+where
+    Db: BlokliDbAllOperations + Clone + Send + Sync,
+{
+    pub(super) async fn revert_curvy_state(&self, from_block: u64) -> Result<()> {
+        let from_block = i64::try_from(from_block)?;
+        self.db
+            .begin_transaction()
+            .await?
+            .perform(|tx| {
+                Box::pin(async move {
+                    let pending_notes = curvy_pending_note::Entity::delete_many()
+                        .filter(curvy_pending_note::Column::PublishedBlock.gte(from_block))
+                        .exec(tx.as_ref())
+                        .await
+                        .map_err(DbSqlError::from)?
+                        .rows_affected;
+                    let committed_notes = curvy_committed_note::Entity::delete_many()
+                        .filter(curvy_committed_note::Column::PublishedBlock.gte(from_block))
+                        .exec(tx.as_ref())
+                        .await
+                        .map_err(DbSqlError::from)?
+                        .rows_affected;
+                    let committed_nullifiers = curvy_committed_nullifier::Entity::delete_many()
+                        .filter(curvy_committed_nullifier::Column::PublishedBlock.gte(from_block))
+                        .exec(tx.as_ref())
+                        .await
+                        .map_err(DbSqlError::from)?
+                        .rows_affected;
+                    curvy_shard_root::Entity::delete_many()
+                        .filter(curvy_shard_root::Column::CompletionBlock.gte(from_block))
+                        .exec(tx.as_ref())
+                        .await
+                        .map_err(DbSqlError::from)?;
+                    curvy_sync_checkpoint::Entity::delete_many()
+                        .filter(curvy_sync_checkpoint::Column::BlockNumber.gte(from_block))
+                        .exec(tx.as_ref())
+                        .await
+                        .map_err(DbSqlError::from)?;
+
+                    let retained_counts = retained_dense_counts(tx).await?;
+                    let checkpoint = curvy_sync_checkpoint::Entity::find()
+                        .order_by_desc(curvy_sync_checkpoint::Column::BlockNumber)
+                        .one(tx.as_ref())
+                        .await
+                        .map_err(DbSqlError::from)?;
+                    match checkpoint {
+                        Some(checkpoint) => {
+                            restore_checkpoint(&checkpoint, retained_counts.0, retained_counts.1)?;
+                        }
+                        None if retained_counts == (0, 0) => {}
+                        None => {
+                            return Err(invalid_state(
+                                "cannot restore retained Curvy history because its checkpoint is missing",
+                            ));
+                        }
+                    }
+
+                    info!(
+                        deleted_events = pending_notes + committed_notes + committed_nullifiers,
+                        "removed orphaned Curvy event history"
+                    );
+                    Ok(())
+                })
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use blokli_chain_types::curvy_tree::{NOTES_SHARD_HEIGHT, NOTES_TREE_DEPTH, NOTES_TREE_VERSION, NotesFrontier};
+    use blokli_db::{BlokliDbGeneralModelOperations, db::BlokliDb};
+    use blokli_db_entity::{curvy_committed_note, curvy_sync_checkpoint};
+    use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::PendingNotes;
+    use hopr_bindings::exports::alloy::primitives::U256;
+    use sea_orm::{ActiveValue::Set, EntityTrait};
+
+    use super::{load_frontier, restore_checkpoint, validate_pending_notes};
+    use crate::{
+        errors::CoreEthereumIndexerError,
+        handlers::test_utils::test_helpers::{ClonableMockOperations, MockIndexerRpcOperations, init_handlers},
+    };
+
+    fn empty_checkpoint() -> anyhow::Result<curvy_sync_checkpoint::Model> {
+        let frontier = NotesFrontier::production();
+        Ok(curvy_sync_checkpoint::Model {
+            id: 1,
+            block_number: 1,
+            block_hash: vec![1; 32],
+            aggregator_address: vec![2; 20],
+            tree_version: NOTES_TREE_VERSION,
+            tree_depth: i64::try_from(NOTES_TREE_DEPTH)?,
+            shard_height: i64::try_from(NOTES_SHARD_HEIGHT)?,
+            leaf_count: 0,
+            nullifier_count: 0,
+            shard_count: 0,
+            root: frontier.root_be_32().to_vec(),
+            frontier_snapshot: frontier.encode_snapshot(),
+        })
+    }
+
+    async fn insert_committed_note(db: &BlokliDb, published_block: i64) -> anyhow::Result<()> {
+        curvy_committed_note::Entity::insert(curvy_committed_note::ActiveModel {
+            batch_index: Set(vec![0; 32]),
+            note_id: Set(vec![1; 32]),
+            event_item_index: Set(0),
+            chain_tx_hash: Set(vec![2; 32]),
+            block_hash: Set(vec![3; 32]),
+            published_block: Set(published_block),
+            published_tx_index: Set(0),
+            published_log_index: Set(0),
+            leaf_index: Set(0),
+            ..Default::default()
+        })
+        .exec_without_returning(db.conn(Default::default()))
+        .await?;
+        Ok(())
+    }
+
+    fn pending_notes() -> PendingNotes {
+        PendingNotes {
+            noteIds: vec![U256::from(1)],
+            ephemeralKeys: [vec![U256::from(2)], vec![U256::from(3)]],
+            viewTags: vec![4],
+            tokens: vec![U256::from(5)],
+            amounts: vec![U256::from(6)],
+            isPlaintext: vec![true],
+        }
+    }
+
+    #[test]
+    fn test_pending_notes_accepts_aligned_arrays() {
+        assert_eq!(validate_pending_notes(&pending_notes()).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_pending_notes_rejects_misaligned_arrays() {
+        let mut event = pending_notes();
+        event.amounts.clear();
+
+        assert!(validate_pending_notes(&event).is_err());
+    }
+
+    #[test]
+    fn test_restore_checkpoint_rejects_unsupported_tree_geometry() -> anyhow::Result<()> {
+        let mut checkpoint = empty_checkpoint()?;
+        checkpoint.tree_depth -= 1;
+
+        assert!(matches!(
+            restore_checkpoint(&checkpoint, 0, 0),
+            Err(CoreEthereumIndexerError::CurvyStateInvariant(message))
+                if message == "stored Curvy checkpoint uses unsupported tree geometry"
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_restore_checkpoint_rejects_counts_mismatching_dense_indexes() -> anyhow::Result<()> {
+        let checkpoint = empty_checkpoint()?;
+
+        for retained_counts in [(1, 0), (0, 1)] {
+            assert!(matches!(
+                restore_checkpoint(&checkpoint, retained_counts.0, retained_counts.1),
+                Err(CoreEthereumIndexerError::CurvyStateInvariant(message))
+                    if message == "stored Curvy checkpoint counts do not match retained dense event indexes"
+            ));
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_load_frontier_rejects_history_without_checkpoint() -> anyhow::Result<()> {
+        let db = BlokliDb::new_in_memory().await?;
+        insert_committed_note(&db, 1).await?;
+
+        let result = db
+            .begin_transaction()
+            .await?
+            .perform(|tx| Box::pin(async move { load_frontier(tx).await }))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(CoreEthereumIndexerError::CurvyStateInvariant(message))
+                if message == "stored Curvy event history exists but its checkpoint is missing"
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_revert_curvy_state_rejects_retained_history_without_checkpoint() -> anyhow::Result<()> {
+        let db = BlokliDb::new_in_memory().await?;
+        insert_committed_note(&db, 1).await?;
+        let handlers = init_handlers(
+            ClonableMockOperations {
+                inner: Arc::new(MockIndexerRpcOperations::new()),
+            },
+            db,
+        );
+
+        let result = handlers.revert_curvy_state(2).await;
+
+        assert!(matches!(
+            result,
+            Err(CoreEthereumIndexerError::CurvyStateInvariant(message))
+                if message == "cannot restore retained Curvy history because its checkpoint is missing"
+        ));
+        Ok(())
+    }
+}

--- a/chain/indexer/src/handlers/mod.rs
+++ b/chain/indexer/src/handlers/mod.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use blokli_chain_rpc::{HoprIndexerRpcOperations, Log};
 use blokli_chain_types::{AlloyAddressExt, ContractAddresses};
 use blokli_db::{BlokliDbAllOperations, OpenTransaction};
+use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::CurvyAggregatorAlphaV2Events;
 use hopr_bindings::{
     exports::alloy::{
         primitives::{Address as AlloyAddress, B256, Log as AlloyLog},
@@ -38,6 +39,7 @@ use crate::{
 mod announcements;
 mod channel_utils;
 mod channels;
+mod curvy;
 mod helpers;
 mod node_safe_registry;
 mod oracles;
@@ -71,8 +73,7 @@ fn increment_indexer_contract_log_count(contract: &str) {
 /// and passed on to this object that handles event-specific actions for each on-chain operation.
 #[derive(Clone)]
 pub struct ContractEventHandlers<T, Db> {
-    /// channels, announcements, token: contract addresses
-    /// whose event we process
+    /// Contract addresses whose events are processed, including the optional Curvy Aggregator.
     pub(super) addresses: Arc<ContractAddresses>,
     /// callbacks to inform other modules
     pub(super) db: Db,
@@ -81,6 +82,7 @@ pub struct ContractEventHandlers<T, Db> {
     /// indexer state for publishing events to subscribers
     pub(super) indexer_state: IndexerState,
     pub(super) enable_safe_indexing: bool,
+    pub(super) enable_curvy_indexing: bool,
 }
 
 impl<T, Db> Debug for ContractEventHandlers<T, Db> {
@@ -118,6 +120,7 @@ where
         rpc_operations: T,
         indexer_state: IndexerState,
         enable_safe_indexing: bool,
+        enable_curvy_indexing: bool,
     ) -> Self {
         Self {
             addresses: Arc::new(addresses),
@@ -125,6 +128,7 @@ where
             _rpc_operations: rpc_operations,
             indexer_state,
             enable_safe_indexing,
+            enable_curvy_indexing,
         }
     }
 
@@ -232,6 +236,9 @@ where
         } else if log.address.eq(&self.addresses.token) {
             let event = HoprTokenEvents::decode_log(&primitive_log)?;
             self.on_token_event(tx, event.data, is_synced).await
+        } else if self.enable_curvy_indexing && log.address.eq(&self.addresses.curvy_aggregator) {
+            let event = CurvyAggregatorAlphaV2Events::decode_log(&primitive_log)?;
+            self.on_curvy_aggregator_event(tx, &log, event.data).await
         } else if log.address.eq(&self.addresses.node_safe_registry) {
             let event = HoprNodeSafeRegistryEvents::decode_log(&primitive_log)?;
             self.on_node_safe_registry_event(tx, &log, event.data, is_synced).await
@@ -286,7 +293,8 @@ where
     ///
     /// `Vec<Address>` containing the monitored contract addresses in the following order:
     /// announcements, channels, ticket_price_oracle, winning_probability_oracle,
-    /// node_safe_registry, node_stake_factory, token.
+    /// node_safe_registry, node_stake_factory, token, followed by the configured
+    /// Curvy Aggregator address.
     ///
     /// # Examples
     ///
@@ -294,10 +302,10 @@ where
     /// let addrs = handlers.contract_addresses();
     /// assert_eq!(addrs.len(), 7);
     /// // order: announcements, channels, ticket_price_oracle, winning_probability_oracle,
-    /// // node_safe_registry, node_stake_factory, token
+    /// // node_safe_registry, node_stake_factory, token, optional Curvy Aggregator
     /// ```
     fn contract_addresses(&self) -> Vec<Address> {
-        vec![
+        let mut addresses = vec![
             self.addresses.announcements,
             self.addresses.channels,
             self.addresses.ticket_price_oracle,
@@ -305,11 +313,19 @@ where
             self.addresses.node_safe_registry,
             self.addresses.node_stake_factory,
             self.addresses.token,
-        ]
+        ];
+        if self.enable_curvy_indexing {
+            addresses.push(self.addresses.curvy_aggregator);
+        }
+        addresses
     }
 
     fn contract_addresses_map(&self) -> Arc<ContractAddresses> {
         self.addresses.clone()
+    }
+
+    fn should_process_log(&self, log: &SerializableLog) -> bool {
+        !(log.removed && log.address == self.addresses.curvy_aggregator)
     }
 
     /// Map a contract address to its associated event topics.
@@ -343,6 +359,8 @@ where
             crate::constants::topics::stake_factory()
         } else if contract.eq(&self.addresses.token) {
             crate::constants::topics::token()
+        } else if contract.eq(&self.addresses.curvy_aggregator) {
+            crate::constants::topics::curvy_aggregator()
         } else {
             panic!("use of unsupported contract address: {contract}");
         }
@@ -383,6 +401,10 @@ where
         }
 
         Ok(())
+    }
+
+    async fn revert_block_derived_state(&self, from_block: u64) -> Result<()> {
+        self.revert_curvy_state(from_block).await
     }
 }
 

--- a/chain/indexer/src/handlers/test_utils.rs
+++ b/chain/indexer/src/handlers/test_utils.rs
@@ -184,11 +184,15 @@ pub(super) mod test_helpers {
                 winning_probability_oracle: *WIN_PROB_ORACLE_ADDR,
                 node_stake_factory: Default::default(),
                 xhopr_token: *XHOPR_TOKEN_ADDR,
+                curvy_aggregator: Default::default(),
+                curvy_vault: Default::default(),
+                curvy_portal_factory: Default::default(),
             },
             db,
             rpc_operations,
             indexer_state.clone(),
             true,
+            false,
         );
 
         (handlers, indexer_state, event_receiver)

--- a/chain/indexer/src/state.rs
+++ b/chain/indexer/src/state.rs
@@ -14,7 +14,8 @@ use std::sync::{
 
 use async_broadcast::{Receiver, Sender, broadcast};
 use blokli_api_types::{
-    Account, ChannelUpdate, RedeemTicketDetails, RedemptionResult, TicketParameters, TokenValueString, UInt64,
+    Account, ChannelUpdate, CurvyCommittedNote, CurvyCommittedNullifier, CurvyPendingNote, RedeemTicketDetails,
+    RedemptionResult, TicketParameters, TokenValueString, UInt64,
 };
 use hopr_types::primitive::prelude::Address;
 use tokio::sync::RwLock;
@@ -76,6 +77,12 @@ impl From<RedeemTicketDetailsInfo> for RedeemTicketDetails {
 /// and to ensure temporal consistency.
 #[derive(Clone, Debug)]
 pub enum IndexerEvent {
+    /// A note emitted by the Curvy Aggregator's `PendingNotes` event.
+    CurvyPendingNote(CurvyPendingNote),
+    /// A note emitted by the Curvy Aggregator's `CommittedNotes` event.
+    CurvyCommittedNote(CurvyCommittedNote),
+    /// A nullifier emitted by the Curvy Aggregator's `CommittedNullifiers` event.
+    CurvyCommittedNullifier(CurvyCommittedNullifier),
     /// An account was updated (balance change, announcement, safe registration, etc.)
     ///
     /// Contains complete account data including all balances and multiaddresses.

--- a/chain/indexer/src/traits.rs
+++ b/chain/indexer/src/traits.rs
@@ -47,6 +47,16 @@ pub trait ChainLogHandler {
     /// # Returns
     /// * `Result<()>` - Success or error
     async fn collect_log_event(&self, log: SerializableLog, is_synced: bool) -> Result<()>;
+
+    /// Returns whether a fetched log should be dispatched to the contract handler.
+    fn should_process_log(&self, _log: &SerializableLog) -> bool {
+        true
+    }
+
+    /// Reverts handler-owned derived state from the first affected block onward.
+    async fn revert_block_derived_state(&self, _from_block: u64) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/chain/indexer/tests/indexer_integration_test.rs
+++ b/chain/indexer/tests/indexer_integration_test.rs
@@ -210,6 +210,10 @@ mod integration_tests {
                 ticket_price_oracle: Address::default(),
                 winning_probability_oracle: Address::default(),
                 node_stake_factory: Address::default(),
+                xhopr_token: Address::default(),
+                curvy_aggregator: Address::default(),
+                curvy_vault: Address::default(),
+                curvy_portal_factory: Address::default(),
             });
 
             let handlers = ContractEventHandlers {

--- a/chain/rpc/Cargo.toml
+++ b/chain/rpc/Cargo.toml
@@ -37,6 +37,7 @@ url                        = { workspace = true }
 validator                  = { workspace = true }
 
 blokli-chain-types = { workspace = true }
+curvy-bindings = { workspace = true }
 hopr-bindings = { workspace = true }
 hopr-types = { workspace = true, features = [
   "crypto",

--- a/chain/rpc/src/lib.rs
+++ b/chain/rpc/src/lib.rs
@@ -260,6 +260,46 @@ pub struct Eip1559FeeEstimation {
     pub max_priority_fee_per_gas: u128,
 }
 
+/// Current Curvy Aggregator state returned by typed RPC operations.
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct CurvyAggregatorState {
+    pub notes_tree_root: [u8; 32],
+    pub notes_batch_index: [u8; 32],
+    pub nullifiers_batch_index: [u8; 32],
+    pub note_index: [u8; 32],
+}
+
+/// Curvy Aggregator fee configuration required to build a valid aggregation proof.
+///
+/// The aggregation-side counterpart to [`CurvyGasFees`]: the protocol fee rate, the
+/// root of the per-token commitment gas-fee tree, and the BabyJubJub public key the
+/// circuit constrains the fee note's owner to.
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct CurvyAggregatorFees {
+    /// `protocolFeePerThousand()` — parts per thousand.
+    pub protocol_fee_per_thousand: [u8; 32],
+    /// `commitmentFeeRoot()` — root of the depth-6 per-token gas-fee tree.
+    pub commitment_fee_root: [u8; 32],
+    /// `feeNotePublicKey(0)` and `feeNotePublicKey(1)`.
+    pub fee_note_public_key: [[u8; 32]; 2],
+}
+
+/// Curvy per-token gas fee values returned by the Vault.
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct CurvyGasFees {
+    pub token_id: [u8; 32],
+    pub portal_deployment: [u8; 32],
+    pub pending_note_commitment: [u8; 32],
+    pub withdrawal: [u8; 32],
+}
+
+/// Curvy Vault token metadata returned by typed RPC operations.
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct CurvyVaultToken {
+    pub token_address: Address,
+    pub gas_fees: CurvyGasFees,
+}
+
 /// Trait defining a general set of operations an RPC provider
 /// must provide to the HOPR node.
 #[async_trait]
@@ -298,6 +338,47 @@ pub trait HoprRpcOperations {
 
     /// Retrieves EIP-1559 gas fee estimates (wei).
     async fn estimate_eip1559_fees(&self) -> Result<Eip1559FeeEstimation>;
+
+    /// Retrieves the current notes root and dense indices from the Curvy Aggregator.
+    async fn get_curvy_aggregator_state(&self) -> Result<CurvyAggregatorState>;
+
+    /// Retrieves the raw status for a Curvy note identifier.
+    async fn get_curvy_note_status(&self, note_id: [u8; 32]) -> Result<u8>;
+
+    /// Checks whether a Curvy notes root is currently accepted.
+    async fn is_curvy_notes_root_valid(&self, root: [u8; 32]) -> Result<bool>;
+
+    /// Checks whether a Curvy nullifier is already spent.
+    async fn is_curvy_nullifier_spent(&self, nullifier: [u8; 32]) -> Result<bool>;
+
+    /// Retrieves protocol-level deposit and withdrawal fees from the Curvy Vault.
+    async fn get_curvy_vault_fees(&self) -> Result<([u8; 32], [u8; 32])>;
+
+    /// Retrieves the Curvy Aggregator's fee configuration.
+    async fn get_curvy_aggregator_fees(&self) -> Result<CurvyAggregatorFees>;
+
+    /// Retrieves the number of tokens registered in the Curvy Vault.
+    async fn get_curvy_vault_token_count(&self) -> Result<[u8; 32]>;
+
+    /// Retrieves a Curvy Vault token and its configured gas fees.
+    ///
+    /// `None` means the token id is not registered. Transport and undecodable
+    /// contract failures remain errors.
+    async fn get_curvy_vault_token(&self, token_id: [u8; 32]) -> Result<Option<CurvyVaultToken>>;
+
+    /// Derives a Curvy entry portal address.
+    async fn derive_curvy_entry_portal_address(&self, owner_hash: [u8; 32], recovery: Address) -> Result<Address>;
+
+    /// Derives a Curvy exit portal address.
+    async fn derive_curvy_exit_portal_address(
+        &self,
+        exit_address: Address,
+        exit_chain_id: [u8; 32],
+        recovery: Address,
+    ) -> Result<Address>;
+
+    /// Checks whether a portal is registered with the Curvy PortalFactory.
+    async fn is_curvy_portal_registered(&self, portal_address: Address) -> Result<bool>;
 
     /// Sends transaction to the RPC provider, does not await confirmation.
     async fn send_transaction(&self, tx: TransactionRequest) -> Result<PendingTransaction>;

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -9,7 +9,11 @@ use std::{
 
 use async_trait::async_trait;
 use blokli_chain_types::{AlloyAddressExt, ContractAddresses, ContractInstances};
+use curvy_bindings::{
+    curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2, curvy_vault_v2::CurvyVaultV2, portal_factory::PortalFactory,
+};
 use hopr_bindings::exports::alloy::{
+    contract::Error as AlloyContractError,
     primitives::{Address as AlloyAddress, FixedBytes, U256},
     providers::{
         Identity, PendingTransaction, Provider, ProviderBuilder, RootProvider,
@@ -33,11 +37,22 @@ use validator::Validate;
 
 // use crate::middleware::GnosisScan;
 use crate::{
-    Eip1559FeeEstimation, HoprRpcOperations,
+    CurvyAggregatorFees, CurvyAggregatorState, CurvyGasFees, CurvyVaultToken, Eip1559FeeEstimation, HoprRpcOperations,
     client::GasOracleFiller,
     errors::{Result, RpcError},
     transport::HttpRequestor,
 };
+
+fn configured_contract(address: Address, name: &str) -> Result<AlloyAddress> {
+    if address == Address::default() {
+        return Err(RpcError::Other(format!("{name} contract address is not configured")));
+    }
+    Ok(AlloyAddress::from_hopr_address(address))
+}
+
+fn is_curvy_token_not_registered(error: &AlloyContractError) -> bool {
+    error.as_decoded_error::<CurvyVaultV2::TokenNotRegistered>().is_some()
+}
 
 // define basic safe abi
 sol!(
@@ -684,6 +699,176 @@ impl<R: HttpRequestor + 'static + Clone> HoprRpcOperations for RpcOperations<R> 
         })
     }
 
+    async fn get_curvy_aggregator_state(&self) -> Result<CurvyAggregatorState> {
+        let contract = CurvyAggregatorAlphaV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_aggregator, "Curvy Aggregator")?,
+            self.provider.clone(),
+        );
+        let (notes_tree_root, notes_batch_index, nullifiers_batch_index, note_index) = futures::try_join!(
+            async { contract.getCurrentNotesTreeRoot().call().await },
+            async { contract.getCurrentNotesBatchIndex().call().await },
+            async { contract.getCurrentNullifiersBatchIndex().call().await },
+            async { contract.getCurrentNoteIndex().call().await },
+        )?;
+        Ok(CurvyAggregatorState {
+            notes_tree_root: notes_tree_root.to_be_bytes(),
+            notes_batch_index: notes_batch_index.to_be_bytes(),
+            nullifiers_batch_index: nullifiers_batch_index.to_be_bytes(),
+            note_index: note_index.to_be_bytes(),
+        })
+    }
+
+    async fn get_curvy_note_status(&self, note_id: [u8; 32]) -> Result<u8> {
+        CurvyAggregatorAlphaV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_aggregator, "Curvy Aggregator")?,
+            self.provider.clone(),
+        )
+        .noteStatus(U256::from_be_bytes(note_id))
+        .call()
+        .await
+        .map_err(Into::into)
+    }
+
+    async fn is_curvy_notes_root_valid(&self, root: [u8; 32]) -> Result<bool> {
+        CurvyAggregatorAlphaV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_aggregator, "Curvy Aggregator")?,
+            self.provider.clone(),
+        )
+        .validNotesRoot(U256::from_be_bytes(root))
+        .call()
+        .await
+        .map_err(Into::into)
+    }
+
+    async fn is_curvy_nullifier_spent(&self, nullifier: [u8; 32]) -> Result<bool> {
+        CurvyAggregatorAlphaV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_aggregator, "Curvy Aggregator")?,
+            self.provider.clone(),
+        )
+        .nullifiers(U256::from_be_bytes(nullifier))
+        .call()
+        .await
+        .map_err(Into::into)
+    }
+
+    async fn get_curvy_vault_fees(&self) -> Result<([u8; 32], [u8; 32])> {
+        let contract = CurvyVaultV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_vault, "Curvy Vault")?,
+            self.provider.clone(),
+        );
+        let (deposit_fee, withdrawal_fee) = futures::try_join!(async { contract.depositFee().call().await }, async {
+            contract.withdrawalFee().call().await
+        },)?;
+        Ok((
+            U256::from(deposit_fee).to_be_bytes(),
+            U256::from(withdrawal_fee).to_be_bytes(),
+        ))
+    }
+
+    async fn get_curvy_aggregator_fees(&self) -> Result<CurvyAggregatorFees> {
+        let contract = CurvyAggregatorAlphaV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_aggregator, "Curvy Aggregator")?,
+            self.provider.clone(),
+        );
+        let (protocol_fee_per_thousand, commitment_fee_root, fee_note_public_key_x, fee_note_public_key_y) = futures::try_join!(
+            async { contract.protocolFeePerThousand().call().await },
+            async { contract.commitmentFeeRoot().call().await },
+            async { contract.feeNotePublicKey(U256::ZERO).call().await },
+            async { contract.feeNotePublicKey(U256::ONE).call().await },
+        )?;
+        Ok(CurvyAggregatorFees {
+            protocol_fee_per_thousand: U256::from(protocol_fee_per_thousand).to_be_bytes(),
+            commitment_fee_root: U256::from(commitment_fee_root).to_be_bytes(),
+            fee_note_public_key: [
+                U256::from(fee_note_public_key_x).to_be_bytes(),
+                U256::from(fee_note_public_key_y).to_be_bytes(),
+            ],
+        })
+    }
+
+    async fn get_curvy_vault_token_count(&self) -> Result<[u8; 32]> {
+        let count = CurvyVaultV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_vault, "Curvy Vault")?,
+            self.provider.clone(),
+        )
+        .getNumberOfTokens()
+        .call()
+        .await?;
+        Ok(U256::from(count).to_be_bytes())
+    }
+
+    async fn get_curvy_vault_token(&self, token_id: [u8; 32]) -> Result<Option<CurvyVaultToken>> {
+        let contract = CurvyVaultV2::new(
+            configured_contract(self.cfg.contract_addrs.curvy_vault, "Curvy Vault")?,
+            self.provider.clone(),
+        );
+        let token_id = U256::from_be_bytes(token_id);
+        let token_address = match contract.getTokenAddress(token_id).call().await {
+            Ok(token_address) => token_address,
+            Err(error) if is_curvy_token_not_registered(&error) => {
+                return Ok(None);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let fees = contract.perTokenGasFees(token_id).call().await?;
+        Ok(Some(CurvyVaultToken {
+            token_address: token_address.to_hopr_address(),
+            gas_fees: CurvyGasFees {
+                token_id: fees.tokenId.to_be_bytes(),
+                portal_deployment: fees.portalDeployment.to_be_bytes(),
+                pending_note_commitment: fees.pendingNoteCommitment.to_be_bytes(),
+                withdrawal: fees.withdrawal.to_be_bytes(),
+            },
+        }))
+    }
+
+    async fn derive_curvy_entry_portal_address(&self, owner_hash: [u8; 32], recovery: Address) -> Result<Address> {
+        PortalFactory::new(
+            configured_contract(self.cfg.contract_addrs.curvy_portal_factory, "Curvy PortalFactory")?,
+            self.provider.clone(),
+        )
+        .getEntryPortalAddress(
+            U256::from_be_bytes(owner_hash),
+            AlloyAddress::from_hopr_address(recovery),
+        )
+        .call()
+        .await
+        .map(AlloyAddressExt::to_hopr_address)
+        .map_err(Into::into)
+    }
+
+    async fn derive_curvy_exit_portal_address(
+        &self,
+        exit_address: Address,
+        exit_chain_id: [u8; 32],
+        recovery: Address,
+    ) -> Result<Address> {
+        PortalFactory::new(
+            configured_contract(self.cfg.contract_addrs.curvy_portal_factory, "Curvy PortalFactory")?,
+            self.provider.clone(),
+        )
+        .getExitPortalAddress(
+            AlloyAddress::from_hopr_address(exit_address),
+            U256::from_be_bytes(exit_chain_id),
+            AlloyAddress::from_hopr_address(recovery),
+        )
+        .call()
+        .await
+        .map(AlloyAddressExt::to_hopr_address)
+        .map_err(Into::into)
+    }
+
+    async fn is_curvy_portal_registered(&self, portal_address: Address) -> Result<bool> {
+        PortalFactory::new(
+            configured_contract(self.cfg.contract_addrs.curvy_portal_factory, "Curvy PortalFactory")?,
+            self.provider.clone(),
+        )
+        .portalIsRegistered(AlloyAddress::from_hopr_address(portal_address))
+        .call()
+        .await
+        .map_err(Into::into)
+    }
+
     //     // Check on-chain status of, node, safe, and module
     //     async fn check_node_safe_module_status(&self, node_address: Address) -> Result<NodeSafeModuleStatus> {
     //         // 1) check if the node is already included into the module
@@ -754,11 +939,16 @@ mod tests {
     use std::borrow::Cow;
 
     use hopr_bindings::exports::alloy::{
+        contract::Error as AlloyContractError,
         rpc::json_rpc::ErrorPayload,
         transports::{RpcError as AlloyRpcError, TransportErrorKind},
     };
+    use serde_json::value::RawValue;
 
-    use super::{DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP, LogBlockRangeLimit, is_log_block_range_limit_error};
+    use super::{
+        DEFAULT_AUTO_LOG_BLOCK_RANGE_CAP, LogBlockRangeLimit, is_curvy_token_not_registered,
+        is_log_block_range_limit_error,
+    };
     use crate::errors::RpcError;
 
     fn rpc_error_response(code: i64, message: &'static str) -> RpcError {
@@ -767,6 +957,18 @@ mod tests {
             message: Cow::Borrowed(message),
             data: None,
         }))
+    }
+
+    #[test]
+    fn test_curvy_token_not_registered_decodes_only_its_custom_error() {
+        let revert_data = RawValue::from_string("\"0x259ba1ad\"".to_string()).expect("valid raw JSON");
+        let error = AlloyContractError::TransportError(AlloyRpcError::<TransportErrorKind>::ErrorResp(ErrorPayload {
+            code: 3,
+            message: Cow::Borrowed("execution reverted"),
+            data: Some(revert_data),
+        }));
+
+        assert!(is_curvy_token_not_registered(&error));
     }
 
     fn converge_limit(cap: u64, allowed_limit: u64) -> LogBlockRangeLimit {

--- a/chain/types/Cargo.toml
+++ b/chain/types/Cargo.toml
@@ -12,6 +12,7 @@ version     = "0.4.0"
 crate-type = ["rlib"]
 
 [dependencies]
+curvy-core      = { workspace = true }
 hex-literal     = { workspace = true }
 lazy_static     = { workspace = true }
 libp2p-identity = { workspace = true }

--- a/chain/types/src/curvy_tree.rs
+++ b/chain/types/src/curvy_tree.rs
@@ -1,0 +1,16 @@
+//! Canonical Curvy notes-tree primitives used by the indexer.
+//!
+//! Cryptographic behavior and the versioned frontier snapshot format live in
+//! `curvy-core`; this module only exposes them through the chain-types boundary.
+
+pub use curvy_core::{
+    field::fr_to_be_32,
+    imt::{CompletedShard, FrontierAppend, NotesFrontier, TreeError},
+};
+
+/// Schema version persisted with blokli Curvy checkpoints.
+pub const NOTES_TREE_VERSION: i64 = curvy_core::imt::NOTES_TREE_VERSION as i64;
+/// Depth of the production Curvy notes tree.
+pub const NOTES_TREE_DEPTH: usize = curvy_core::imt::NOTES_TREE_DEPTH;
+/// Height of each production Curvy notes-tree shard.
+pub const NOTES_SHARD_HEIGHT: usize = curvy_core::imt::NOTES_SHARD_HEIGHT;

--- a/chain/types/src/lib.rs
+++ b/chain/types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod actions;
 pub mod chain_events;
 pub mod channel;
 pub mod constants;
+pub mod curvy_tree;
 pub mod errors;
 // Various (mostly testing related) utility functions
 pub mod utils;
@@ -128,6 +129,15 @@ pub struct ContractAddresses {
     #[serde_as(as = "DisplayFromStr")]
     #[serde(default)]
     pub xhopr_token: Address,
+    /// Curvy Aggregator proxy contract
+    #[serde(default)]
+    pub curvy_aggregator: Address,
+    /// Curvy Vault proxy contract
+    #[serde(default)]
+    pub curvy_vault: Address,
+    /// Curvy PortalFactory contract
+    #[serde(default)]
+    pub curvy_portal_factory: Address,
 }
 
 /// Holds instances to contracts.
@@ -313,6 +323,9 @@ where
             winning_probability_oracle: instances.winning_probability_oracle.address().to_hopr_address(),
             node_stake_factory: instances.node_stake_factory.address().to_hopr_address(),
             xhopr_token: instances.xhopr_token.address().to_hopr_address(),
+            curvy_aggregator: Address::default(),
+            curvy_vault: Address::default(),
+            curvy_portal_factory: Address::default(),
         }
     }
 }

--- a/db/core/src/info.rs
+++ b/db/core/src/info.rs
@@ -2,8 +2,9 @@ use async_trait::async_trait;
 use blokli_db_entity::{
     chain_info,
     prelude::{
-        Account, AccountState, Announcement, ChainInfo, Channel, ChannelState, HoprBalance as HoprBalanceEntity,
-        HoprSafeContract, NativeBalance,
+        Account, AccountState, Announcement, ChainInfo, Channel, ChannelState, CurvyCommittedNote,
+        CurvyCommittedNullifier, CurvyPendingNote, CurvyShardRoot, CurvySyncCheckpoint,
+        HoprBalance as HoprBalanceEntity, HoprSafeContract, NativeBalance,
     },
 };
 use futures::TryFutureExt;
@@ -142,6 +143,26 @@ impl BlokliDbInfoOperations for BlokliDb {
             return Ok(false);
         }
 
+        if CurvyPendingNote::find().one(c).await?.is_some() {
+            return Ok(false);
+        }
+
+        if CurvyCommittedNote::find().one(c).await?.is_some() {
+            return Ok(false);
+        }
+
+        if CurvyCommittedNullifier::find().one(c).await?.is_some() {
+            return Ok(false);
+        }
+
+        if CurvyShardRoot::find().one(c).await?.is_some() {
+            return Ok(false);
+        }
+
+        if CurvySyncCheckpoint::find().one(c).await?.is_some() {
+            return Ok(false);
+        }
+
         Ok(true)
     }
 
@@ -153,6 +174,11 @@ impl BlokliDbInfoOperations for BlokliDb {
                     Account::delete_many().exec(tx.as_ref()).await?;
                     Announcement::delete_many().exec(tx.as_ref()).await?;
                     Channel::delete_many().exec(tx.as_ref()).await?;
+                    CurvySyncCheckpoint::delete_many().exec(tx.as_ref()).await?;
+                    CurvyShardRoot::delete_many().exec(tx.as_ref()).await?;
+                    CurvyPendingNote::delete_many().exec(tx.as_ref()).await?;
+                    CurvyCommittedNote::delete_many().exec(tx.as_ref()).await?;
+                    CurvyCommittedNullifier::delete_many().exec(tx.as_ref()).await?;
                     ChainInfo::delete_many().exec(tx.as_ref()).await?;
 
                     // Initial row is needed in the ChainInfo table
@@ -405,10 +431,12 @@ impl BlokliDbInfoOperations for BlokliDb {
 
 #[cfg(test)]
 mod tests {
+    use blokli_db_entity::{curvy_pending_note, curvy_shard_root, curvy_sync_checkpoint};
     use hex_literal::hex;
     use hopr_types::primitive::{balance::HoprBalance, prelude::Address};
+    use sea_orm::{ActiveModelTrait, EntityTrait, PaginatorTrait, Set};
 
-    use crate::{db::BlokliDb, info::BlokliDbInfoOperations};
+    use crate::{BlokliDbGeneralModelOperations, TargetDb, db::BlokliDb, info::BlokliDbInfoOperations};
 
     lazy_static::lazy_static! {
         static ref ADDR_1: Address = Address::from(hex!("86fa27add61fafc955e2da17329bba9f31692fe7"));
@@ -502,6 +530,70 @@ mod tests {
             "ticket price must be reset to None after third clear"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_curvy_history_participates_in_index_lifecycle() -> anyhow::Result<()> {
+        let db = BlokliDb::new_in_memory().await?;
+        let connection = db.conn(TargetDb::Index);
+        curvy_pending_note::ActiveModel {
+            id: Default::default(),
+            note_id: Set(vec![1; 32]),
+            ephemeral_key_x: Set(vec![2; 32]),
+            ephemeral_key_y: Set(vec![3; 32]),
+            view_tag: Set(4),
+            token_id: Set(vec![5; 32]),
+            amount: Set(vec![6; 32]),
+            is_plaintext: Set(true),
+            event_item_index: Set(0),
+            chain_tx_hash: Set(vec![7; 32]),
+            published_block: Set(8),
+            published_tx_index: Set(0),
+            published_log_index: Set(0),
+            block_hash: Set(vec![8; 32]),
+            ..Default::default()
+        }
+        .insert(connection)
+        .await?;
+        curvy_shard_root::ActiveModel {
+            tree_version: Set(1),
+            shard_height: Set(14),
+            shard_index: Set(0),
+            root: Set(vec![11; 32]),
+            block_hash: Set(vec![12; 32]),
+            chain_tx_hash: Set(vec![13; 32]),
+            completion_block: Set(8),
+            completion_tx_index: Set(0),
+            completion_log_index: Set(0),
+            completion_event_item_index: Set(0),
+            ..Default::default()
+        }
+        .insert(connection)
+        .await?;
+        curvy_sync_checkpoint::ActiveModel {
+            block_number: Set(8),
+            block_hash: Set(vec![12; 32]),
+            aggregator_address: Set(vec![14; 20]),
+            tree_version: Set(1),
+            tree_depth: Set(30),
+            shard_height: Set(14),
+            leaf_count: Set(16_384),
+            nullifier_count: Set(1),
+            shard_count: Set(1),
+            root: Set(vec![9; 32]),
+            frontier_snapshot: Set(vec![10]),
+            ..Default::default()
+        }
+        .insert(connection)
+        .await?;
+
+        assert!(!db.index_is_empty().await?);
+        db.clear_index_db(None).await?;
+        assert!(db.index_is_empty().await?);
+        assert_eq!(curvy_pending_note::Entity::find().count(connection).await?, 0);
+        assert_eq!(curvy_shard_root::Entity::find().count(connection).await?, 0);
+        assert_eq!(curvy_sync_checkpoint::Entity::find().count(connection).await?, 0);
         Ok(())
     }
 }

--- a/db/core/src/version.rs
+++ b/db/core/src/version.rs
@@ -1,6 +1,7 @@
 use blokli_db_entity::prelude::{
-    Account, AccountState, Announcement, ChainInfo, Channel, ChannelState, HoprBalance, HoprNodeSafeRegistration,
-    HoprSafeContract, HoprSafeContractState, HoprSafeRedeemedStats, Log, LogStatus, LogTopicInfo, NativeBalance,
+    Account, AccountState, Announcement, ChainInfo, Channel, ChannelState, CurvyCommittedNote, CurvyCommittedNullifier,
+    CurvyPendingNote, CurvyShardRoot, CurvySyncCheckpoint, HoprBalance, HoprNodeSafeRegistration, HoprSafeContract,
+    HoprSafeContractState, HoprSafeRedeemedStats, Log, LogStatus, LogTopicInfo, NativeBalance,
 };
 use migration::{Migrator, MigratorChainLogs, MigratorIndex, MigratorTrait};
 use sea_orm::{ConnectionTrait, DatabaseConnection, EntityTrait, Statement};
@@ -29,7 +30,8 @@ use crate::errors::{DbSqlError, Result};
 /// - `"1.1.0"`: Initial schema (consolidated from prior migration stack)
 /// - `"1.2.0"`:
 /// - `"1.3.0"`: SC set updated through a binding update.
-pub const SCHEMA_VERSION: &str = "1.3.0";
+/// - `"1.4.0"`: Curvy event history, dense indices, notes-tree shards, and checkpoints
+pub const SCHEMA_VERSION: &str = "1.4.0";
 
 /// The singleton ID used for the schema_version table.
 const SCHEMA_VERSION_TABLE_ID: i64 = 1;
@@ -240,6 +242,12 @@ async fn clear_all_data(db: &DatabaseConnection, logs_db: Option<&DatabaseConnec
 ///
 /// Returns an error if any database operations fail.
 async fn clear_index_data(db: &DatabaseConnection) -> Result<()> {
+    CurvySyncCheckpoint::delete_many().exec(db).await?;
+    CurvyShardRoot::delete_many().exec(db).await?;
+    CurvyPendingNote::delete_many().exec(db).await?;
+    CurvyCommittedNote::delete_many().exec(db).await?;
+    CurvyCommittedNullifier::delete_many().exec(db).await?;
+
     ChannelState::delete_many().exec(db).await?;
     Channel::delete_many().exec(db).await?;
 
@@ -276,7 +284,7 @@ async fn clear_logs_data(db: &DatabaseConnection) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use blokli_db_entity::{chain_info, log, prelude::HoprSafeContract};
+    use blokli_db_entity::{chain_info, curvy_committed_nullifier, log, prelude::HoprSafeContract};
     use sea_orm::{ActiveModelTrait, DbBackend, EntityTrait, PaginatorTrait, Set, Statement};
 
     use super::*;
@@ -378,6 +386,21 @@ mod tests {
         }
         .update(db.conn(crate::TargetDb::Index))
         .await?;
+        curvy_committed_nullifier::ActiveModel {
+            id: Default::default(),
+            batch_index: Set(vec![1; 32]),
+            nullifier: Set(vec![2; 32]),
+            event_item_index: Set(0),
+            chain_tx_hash: Set(vec![3; 32]),
+            published_block: Set(100),
+            published_tx_index: Set(5),
+            published_log_index: Set(10),
+            nullifier_index: Set(0),
+            block_hash: Set(vec![4; 32]),
+            ..Default::default()
+        }
+        .insert(db.conn(crate::TargetDb::Index))
+        .await?;
 
         // Verify data exists
         let chain_info_before = ChainInfo::find_by_id(1)
@@ -418,6 +441,13 @@ mod tests {
         );
         assert_eq!(chain_info_after.last_indexed_tx_index, None);
         assert_eq!(chain_info_after.last_indexed_log_index, None);
+        assert!(
+            curvy_committed_nullifier::Entity::find()
+                .one(db.conn(crate::TargetDb::Index))
+                .await?
+                .is_none(),
+            "Curvy event history should be cleared during a version reset"
+        );
 
         Ok(())
     }

--- a/db/migration/src/lib.rs
+++ b/db/migration/src/lib.rs
@@ -6,6 +6,7 @@ mod m002_initial_log_schema;
 mod m003_safe_history_schema;
 mod m004_safe_redeemed_stats_rejections;
 mod m005_optimize_current_views;
+mod m006_curvy_events;
 
 /// This is a special block ID that even pre-dates the v3 contract deployment on Gnosis chain,
 /// and therefore could be safely used to mark data added via the migration.
@@ -33,6 +34,7 @@ impl MigratorTrait for Migrator {
             Box::new(m003_safe_history_schema::Migration),
             Box::new(m004_safe_redeemed_stats_rejections::Migration),
             Box::new(m005_optimize_current_views::Migration),
+            Box::new(m006_curvy_events::Migration),
         ]
     }
 }
@@ -52,6 +54,7 @@ impl MigratorTrait for MigratorIndex {
             Box::new(m003_safe_history_schema::Migration),
             Box::new(m004_safe_redeemed_stats_rejections::Migration),
             Box::new(m005_optimize_current_views::Migration),
+            Box::new(m006_curvy_events::Migration),
         ]
     }
 }

--- a/db/migration/src/m006_curvy_events.rs
+++ b/db/migration/src/m006_curvy_events.rs
@@ -1,0 +1,357 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        create_pending_note_table(manager).await?;
+        create_batch_item_table(
+            manager,
+            CurvyCommittedNote::Table,
+            CurvyCommittedNote::Id,
+            CurvyCommittedNote::BatchIndex,
+            CurvyCommittedNote::NoteId,
+            CurvyCommittedNote::EventItemIndex,
+            CurvyCommittedNote::ChainTxHash,
+            CurvyCommittedNote::BlockHash,
+            CurvyCommittedNote::PublishedBlock,
+            CurvyCommittedNote::PublishedTxIndex,
+            CurvyCommittedNote::PublishedLogIndex,
+            CurvyCommittedNote::LeafIndex,
+            "idx_curvy_committed_note_unique_position",
+            "idx_curvy_committed_note_leaf_index",
+        )
+        .await?;
+        create_batch_item_table(
+            manager,
+            CurvyCommittedNullifier::Table,
+            CurvyCommittedNullifier::Id,
+            CurvyCommittedNullifier::BatchIndex,
+            CurvyCommittedNullifier::Nullifier,
+            CurvyCommittedNullifier::EventItemIndex,
+            CurvyCommittedNullifier::ChainTxHash,
+            CurvyCommittedNullifier::BlockHash,
+            CurvyCommittedNullifier::PublishedBlock,
+            CurvyCommittedNullifier::PublishedTxIndex,
+            CurvyCommittedNullifier::PublishedLogIndex,
+            CurvyCommittedNullifier::NullifierIndex,
+            "idx_curvy_committed_nullifier_unique_position",
+            "idx_curvy_committed_nullifier_index",
+        )
+        .await?;
+
+        for index in [
+            Index::create()
+                .name("idx_curvy_pending_note_note_id")
+                .table(CurvyPendingNote::Table)
+                .col(CurvyPendingNote::NoteId)
+                .to_owned(),
+            Index::create()
+                .name("idx_curvy_committed_note_note_id")
+                .table(CurvyCommittedNote::Table)
+                .col(CurvyCommittedNote::NoteId)
+                .to_owned(),
+        ] {
+            manager.create_index(index).await?;
+        }
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(CurvyShardRoot::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(CurvyShardRoot::Id)
+                            .big_integer()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(CurvyShardRoot::TreeVersion).integer().not_null())
+                    .col(ColumnDef::new(CurvyShardRoot::ShardHeight).integer().not_null())
+                    .col(ColumnDef::new(CurvyShardRoot::ShardIndex).big_integer().not_null())
+                    .col(ColumnDef::new(CurvyShardRoot::Root).binary_len(32).not_null())
+                    .col(ColumnDef::new(CurvyShardRoot::BlockHash).binary_len(32).not_null())
+                    .col(ColumnDef::new(CurvyShardRoot::ChainTxHash).binary_len(32).not_null())
+                    .col(ColumnDef::new(CurvyShardRoot::CompletionBlock).big_integer().not_null())
+                    .col(
+                        ColumnDef::new(CurvyShardRoot::CompletionTxIndex)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(CurvyShardRoot::CompletionLogIndex)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(CurvyShardRoot::CompletionEventItemIndex)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .index(
+                        Index::create()
+                            .name("idx_curvy_shard_root_geometry_index")
+                            .col(CurvyShardRoot::TreeVersion)
+                            .col(CurvyShardRoot::ShardHeight)
+                            .col(CurvyShardRoot::ShardIndex)
+                            .unique(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(CurvySyncCheckpoint::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(CurvySyncCheckpoint::Id)
+                            .big_integer()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(CurvySyncCheckpoint::BlockNumber)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(CurvySyncCheckpoint::BlockHash)
+                            .binary_len(32)
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(
+                        ColumnDef::new(CurvySyncCheckpoint::AggregatorAddress)
+                            .binary_len(20)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(CurvySyncCheckpoint::TreeVersion).integer().not_null())
+                    .col(ColumnDef::new(CurvySyncCheckpoint::TreeDepth).integer().not_null())
+                    .col(ColumnDef::new(CurvySyncCheckpoint::ShardHeight).integer().not_null())
+                    .col(ColumnDef::new(CurvySyncCheckpoint::LeafCount).big_integer().not_null())
+                    .col(
+                        ColumnDef::new(CurvySyncCheckpoint::NullifierCount)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(CurvySyncCheckpoint::ShardCount).big_integer().not_null())
+                    .col(ColumnDef::new(CurvySyncCheckpoint::Root).binary_len(32).not_null())
+                    .col(ColumnDef::new(CurvySyncCheckpoint::FrontierSnapshot).blob().not_null())
+                    .index(
+                        Index::create()
+                            .name("idx_curvy_sync_checkpoint_block")
+                            .col(CurvySyncCheckpoint::BlockNumber)
+                            .unique(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for table in [
+            CurvySyncCheckpoint::Table.to_string(),
+            CurvyShardRoot::Table.to_string(),
+            CurvyCommittedNullifier::Table.to_string(),
+            CurvyCommittedNote::Table.to_string(),
+            CurvyPendingNote::Table.to_string(),
+        ] {
+            manager
+                .drop_table(Table::drop().table(Alias::new(table)).to_owned())
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+async fn create_pending_note_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(CurvyPendingNote::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(CurvyPendingNote::Id)
+                        .big_integer()
+                        .auto_increment()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(CurvyPendingNote::NoteId).binary_len(32).not_null())
+                .col(
+                    ColumnDef::new(CurvyPendingNote::EphemeralKeyX)
+                        .binary_len(32)
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(CurvyPendingNote::EphemeralKeyY)
+                        .binary_len(32)
+                        .not_null(),
+                )
+                .col(ColumnDef::new(CurvyPendingNote::ViewTag).integer().not_null())
+                .col(ColumnDef::new(CurvyPendingNote::TokenId).binary_len(32).not_null())
+                .col(ColumnDef::new(CurvyPendingNote::Amount).binary_len(32).not_null())
+                .col(ColumnDef::new(CurvyPendingNote::IsPlaintext).boolean().not_null())
+                .col(ColumnDef::new(CurvyPendingNote::EventItemIndex).integer().not_null())
+                .col(ColumnDef::new(CurvyPendingNote::ChainTxHash).binary_len(32).not_null())
+                .col(ColumnDef::new(CurvyPendingNote::BlockHash).binary_len(32).not_null())
+                .col(
+                    ColumnDef::new(CurvyPendingNote::PublishedBlock)
+                        .big_integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(CurvyPendingNote::PublishedTxIndex)
+                        .big_integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(CurvyPendingNote::PublishedLogIndex)
+                        .big_integer()
+                        .not_null(),
+                )
+                .index(
+                    Index::create()
+                        .name("idx_curvy_pending_note_unique_position")
+                        .col(CurvyPendingNote::PublishedBlock)
+                        .col(CurvyPendingNote::PublishedTxIndex)
+                        .col(CurvyPendingNote::PublishedLogIndex)
+                        .col(CurvyPendingNote::EventItemIndex)
+                        .unique(),
+                )
+                .to_owned(),
+        )
+        .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_batch_item_table<T: Iden + Clone + 'static>(
+    manager: &SchemaManager<'_>,
+    table: T,
+    id: T,
+    batch_index: T,
+    item_value: T,
+    event_item_index: T,
+    chain_tx_hash: T,
+    block_hash: T,
+    published_block: T,
+    published_tx_index: T,
+    published_log_index: T,
+    dense_index: T,
+    position_index_name: &str,
+    dense_index_name: &str,
+) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(table)
+                .if_not_exists()
+                .col(ColumnDef::new(id).big_integer().auto_increment().primary_key())
+                .col(ColumnDef::new(batch_index).binary_len(32).not_null())
+                .col(ColumnDef::new(item_value).binary_len(32).not_null())
+                .col(ColumnDef::new(event_item_index.clone()).integer().not_null())
+                .col(ColumnDef::new(chain_tx_hash).binary_len(32).not_null())
+                .col(ColumnDef::new(block_hash).binary_len(32).not_null())
+                .col(ColumnDef::new(published_block.clone()).big_integer().not_null())
+                .col(ColumnDef::new(published_tx_index.clone()).big_integer().not_null())
+                .col(ColumnDef::new(published_log_index.clone()).big_integer().not_null())
+                .col(ColumnDef::new(dense_index.clone()).big_integer().not_null())
+                .index(
+                    Index::create()
+                        .name(position_index_name)
+                        .col(published_block)
+                        .col(published_tx_index)
+                        .col(published_log_index)
+                        .col(event_item_index)
+                        .unique(),
+                )
+                .index(Index::create().name(dense_index_name).col(dense_index).unique())
+                .to_owned(),
+        )
+        .await
+}
+
+#[derive(DeriveIden)]
+enum CurvyPendingNote {
+    Table,
+    Id,
+    NoteId,
+    EphemeralKeyX,
+    EphemeralKeyY,
+    ViewTag,
+    TokenId,
+    Amount,
+    IsPlaintext,
+    EventItemIndex,
+    ChainTxHash,
+    BlockHash,
+    PublishedBlock,
+    PublishedTxIndex,
+    PublishedLogIndex,
+}
+
+#[derive(DeriveIden, Clone)]
+enum CurvyCommittedNote {
+    Table,
+    Id,
+    BatchIndex,
+    NoteId,
+    EventItemIndex,
+    ChainTxHash,
+    BlockHash,
+    PublishedBlock,
+    PublishedTxIndex,
+    PublishedLogIndex,
+    LeafIndex,
+}
+
+#[derive(DeriveIden, Clone)]
+enum CurvyCommittedNullifier {
+    Table,
+    Id,
+    BatchIndex,
+    Nullifier,
+    EventItemIndex,
+    ChainTxHash,
+    BlockHash,
+    PublishedBlock,
+    PublishedTxIndex,
+    PublishedLogIndex,
+    NullifierIndex,
+}
+
+#[derive(DeriveIden)]
+enum CurvyShardRoot {
+    Table,
+    Id,
+    TreeVersion,
+    ShardHeight,
+    ShardIndex,
+    Root,
+    BlockHash,
+    ChainTxHash,
+    CompletionBlock,
+    CompletionTxIndex,
+    CompletionLogIndex,
+    CompletionEventItemIndex,
+}
+
+#[derive(DeriveIden)]
+enum CurvySyncCheckpoint {
+    Table,
+    Id,
+    BlockNumber,
+    BlockHash,
+    AggregatorAddress,
+    TreeVersion,
+    TreeDepth,
+    ShardHeight,
+    LeafCount,
+    NullifierCount,
+    ShardCount,
+    Root,
+    FrontierSnapshot,
+}

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -1475,6 +1475,76 @@ threshold.
 **Configuration Flow**: Finality is defined by the selected network, propagated through runtime configuration into the RPC layer, and reused
 by the readiness checks.
 
+## Local Contract Deployment
+
+There is a single local Anvil image, and it always deploys the Curvy suite on the same
+chain and with the same signer as the HOPR contracts, immediately after them. It also
+enables Curvy indexing, so the deployed suite and the indexed events cannot diverge:
+deploying the contracts without indexing their events surfaces much later, at a
+consumer, as a notes-root mismatch that points at nothing. Curvy deployment is
+compiled in through an optional dependency, so the production binary remains
+HOPR-only.
+
+The deployment artifact and generated Blokli configuration include the Curvy
+Aggregator, Vault, and PortalFactory addresses. The configured Aggregator address
+extends the indexer's address/topic filter only when Curvy indexing is explicitly
+enabled. Pending-note, committed-note, and
+committed-nullifier events are stored as append-only, position-keyed records; zero
+padding is omitted and array-valued events are normalized into one row per array item.
+PortalFactory has no indexed event in the supported surface.
+
+Committed notes and nullifiers also receive independent dense, zero-based indices.
+The note index is the canonical leaf position in Curvy's depth-30 Poseidon tree. The
+indexer advances a constant-space frontier transactionally with each committed-note
+event and persists completed depth-14 shard roots when a 16,384-leaf boundary is
+crossed. This keeps steady-state indexer memory bounded; it does not retain the full
+tree or generate user witnesses.
+
+The tree's cryptographic behaviour is not defined here. Poseidon hashing, the field
+encoding, the tree geometry, and the versioned frontier snapshot format all come from
+Curvy's canonical Rust core, which Blokli consumes as an external dependency and
+re-exports through the chain-types boundary; no Curvy cryptography is reimplemented in
+this repository. The same core backs Curvy's own indexing services, so a shared upstream
+release — rather than agreement between parallel implementations — is what guarantees
+that Blokli's derived leaf indices, shard roots, and tree roots match the protocol's.
+Snapshot compatibility is therefore a property of that release, and the tree version
+recorded on every checkpoint is what detects a geometry change across an upgrade.
+
+Each state-changing Curvy log atomically persists its event rows, completed shard roots,
+and a checkpoint identified by the containing block hash. Multiple state-changing logs
+in one block replace that block's checkpoint inside their respective transactions, so
+the latest checkpoint always describes all durable Curvy rows through the latest
+committed log. Pending-only blocks do not write redundant frontier snapshots. A
+checkpoint records the tree geometry, dense note/nullifier counts, completed-shard
+count, tree root, and canonical frontier snapshot; it is also the sole persisted live
+frontier state. GraphQL synchronization pages are pinned to one checkpoint and bounded
+by its counts, so concurrent indexing cannot change a client's dataset. Note pages
+batch-associate the latest preceding `PendingNotes` announcement when available;
+shard-root and tail-leaf pages let an SDK bootstrap the compact tree representation
+without rebuilding every completed shard.
+
+On a reorganization, the Curvy handler removes rows, shard roots, and checkpoints at or
+after the first affected block through the indexer's derived-state rollback seam. The
+live frontier is restored from the latest earlier checkpoint before canonical
+replacement logs are replayed. Checkpoint counts are cross-checked against retained
+dense note and nullifier indices; a missing or inconsistent checkpoint is fatal when
+retained Curvy history exists, because continuing would make dense indices and roots
+silently diverge. Ordinary restarts restore the latest checkpoint; the existing logs
+snapshot remains the source for rebuilding all derived index state on a fresh
+installation.
+
+GraphQL exposes cursor-paginated event-history queries ordered by the full normalized
+event position, including the item index within array-valued events. Two-phase
+subscriptions stream historical rows without materializing the full history, then
+bridge a synchronized database watermark to live indexer events while retaining the
+client's lower block bound. Checkpoint-pinned dense pages are separate from this event
+history surface and are intended for deterministic SDK synchronization. Curvy view
+functions and non-note protocol state are read directly from the configured contracts
+through the existing RPC layer. State-changing Curvy calls use Blokli's existing
+pre-signed raw-transaction mutations, keeping signing and proof construction outside
+the service. A failure in either requested deployment prevents final address/configuration
+artifacts from being published.
+
 ## Design Principles and Patterns
 
 ### Event Sourcing

--- a/design/db-schema.sql
+++ b/design/db-schema.sql
@@ -66,6 +66,83 @@ CREATE TABLE "channel_state" (
     FOREIGN KEY ("channel_id") REFERENCES "channel" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+CREATE TABLE "curvy_committed_note" (
+    "id" integer PRIMARY KEY AUTOINCREMENT,
+    "batch_index" blob (32) NOT NULL,
+    "note_id" blob (32) NOT NULL,
+    "event_item_index" integer NOT NULL,
+    "chain_tx_hash" blob (32) NOT NULL,
+    "published_block" integer NOT NULL,
+    "published_tx_index" integer NOT NULL,
+    "published_log_index" integer NOT NULL,
+    "leaf_index" integer NOT NULL,
+    "block_hash" blob (32) NOT NULL,
+    CONSTRAINT "idx_curvy_committed_note_unique_position" UNIQUE ("published_block", "published_tx_index", "published_log_index", "event_item_index")
+);
+
+CREATE TABLE "curvy_committed_nullifier" (
+    "id" integer PRIMARY KEY AUTOINCREMENT,
+    "batch_index" blob (32) NOT NULL,
+    "nullifier" blob (32) NOT NULL,
+    "event_item_index" integer NOT NULL,
+    "chain_tx_hash" blob (32) NOT NULL,
+    "published_block" integer NOT NULL,
+    "published_tx_index" integer NOT NULL,
+    "published_log_index" integer NOT NULL,
+    "nullifier_index" integer NOT NULL,
+    "block_hash" blob (32) NOT NULL,
+    CONSTRAINT "idx_curvy_committed_nullifier_unique_position" UNIQUE ("published_block", "published_tx_index", "published_log_index", "event_item_index")
+);
+
+CREATE TABLE "curvy_pending_note" (
+    "id" integer PRIMARY KEY AUTOINCREMENT,
+    "note_id" blob (32) NOT NULL,
+    "ephemeral_key_x" blob (32) NOT NULL,
+    "ephemeral_key_y" blob (32) NOT NULL,
+    "view_tag" integer NOT NULL,
+    "token_id" blob (32) NOT NULL,
+    "amount" blob (32) NOT NULL,
+    "is_plaintext" boolean NOT NULL,
+    "event_item_index" integer NOT NULL,
+    "chain_tx_hash" blob (32) NOT NULL,
+    "published_block" integer NOT NULL,
+    "published_tx_index" integer NOT NULL,
+    "published_log_index" integer NOT NULL,
+    "block_hash" blob (32) NOT NULL,
+    CONSTRAINT "idx_curvy_pending_note_unique_position" UNIQUE ("published_block", "published_tx_index", "published_log_index", "event_item_index")
+);
+
+CREATE TABLE "curvy_shard_root" (
+    "id" integer PRIMARY KEY AUTOINCREMENT,
+    "tree_version" integer NOT NULL,
+    "shard_height" integer NOT NULL,
+    "shard_index" integer NOT NULL,
+    "root" blob (32) NOT NULL,
+    "block_hash" blob (32) NOT NULL,
+    "chain_tx_hash" blob (32) NOT NULL,
+    "completion_block" integer NOT NULL,
+    "completion_tx_index" integer NOT NULL,
+    "completion_log_index" integer NOT NULL,
+    "completion_event_item_index" integer NOT NULL,
+    CONSTRAINT "idx_curvy_shard_root_geometry_index" UNIQUE ("tree_version", "shard_height", "shard_index")
+);
+
+CREATE TABLE "curvy_sync_checkpoint" (
+    "id" integer PRIMARY KEY AUTOINCREMENT,
+    "block_number" integer NOT NULL,
+    "block_hash" blob (32) NOT NULL UNIQUE,
+    "aggregator_address" blob (20) NOT NULL,
+    "tree_version" integer NOT NULL,
+    "tree_depth" integer NOT NULL,
+    "shard_height" integer NOT NULL,
+    "leaf_count" integer NOT NULL,
+    "nullifier_count" integer NOT NULL,
+    "shard_count" integer NOT NULL,
+    "root" blob (32) NOT NULL,
+    "frontier_snapshot" blob NOT NULL,
+    CONSTRAINT "idx_curvy_sync_checkpoint_block" UNIQUE ("block_number")
+);
+
 CREATE TABLE "hopr_balance" (
     "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
     "address" blob (20) NOT NULL UNIQUE,
@@ -394,6 +471,14 @@ CREATE UNIQUE INDEX "idx_channel_state_unique_position" ON "channel_state" ("cha
 
 CREATE UNIQUE INDEX "idx_contract_log_topic" ON "log_topic_info" ("address", "topic");
 
+CREATE UNIQUE INDEX "idx_curvy_committed_note_leaf_index" ON "curvy_committed_note" ("leaf_index");
+
+CREATE INDEX "idx_curvy_committed_note_note_id" ON "curvy_committed_note" ("note_id");
+
+CREATE UNIQUE INDEX "idx_curvy_committed_nullifier_index" ON "curvy_committed_nullifier" ("nullifier_index");
+
+CREATE INDEX "idx_curvy_pending_note_note_id" ON "curvy_pending_note" ("note_id");
+
 CREATE INDEX "idx_hopr_balance_last_changed_block" ON "hopr_balance" ("last_changed_block");
 
 CREATE UNIQUE INDEX "idx_hopr_node_safe_registration_binding" ON "hopr_node_safe_registration" ("safe_address", "node_address");
@@ -443,4 +528,3 @@ CREATE INDEX "idx_safe_threshold_state_current_lookup" ON "hopr_safe_threshold_s
 CREATE UNIQUE INDEX "idx_safe_threshold_state_unique_position" ON "hopr_safe_threshold_state" ("hopr_safe_contract_id", "published_block", "published_tx_index", "published_log_index");
 
 CREATE INDEX "idx_unprocessed_log_status" ON "log_status" ("processed", "block_number", "tx_index", "log_index");
-

--- a/design/target-api-schema.graphql
+++ b/design/target-api-schema.graphql
@@ -378,6 +378,203 @@ type OpenedChannelsGraphEntry {
   source: Account!
 }
 
+"""Address derived or returned by a Curvy contract read."""
+type CurvyAddress {
+  address: String!
+}
+
+"""Current Curvy Aggregator protocol fee parameters."""
+type CurvyAggregatorFees {
+  protocolFeePerThousand: UInt256!
+  commitmentFeeRoot: Hex32!
+  feeNotePublicKey: [UInt256!]!
+}
+
+"""Current Curvy Aggregator indices and notes-tree root."""
+type CurvyAggregatorState {
+  notesTreeRoot: Hex32!
+  notesBatchIndex: UInt256!
+  nullifiersBatchIndex: UInt256!
+  noteIndex: UInt256!
+}
+
+union CurvyAggregatorStateResult = CurvyAggregatorState | QueryFailedError
+
+"""Boolean value returned by a Curvy contract read."""
+type CurvyBooleanValue {
+  value: Boolean!
+}
+
+"""
+Exclusive pagination cursor for indexed Curvy events.
+
+Supplying `blockHash` anchors the cursor to the branch it was issued on, so a cursor
+orphaned by a reorganization is rejected instead of silently skipping the canonical
+replacement at the same position. It is optional for backwards compatibility.
+"""
+input CurvyEventCursor {
+  block: UInt64!
+  transactionIndex: UInt64!
+  logIndex: UInt64!
+  eventItemIndex: UInt64!
+  blockHash: Hex32
+}
+
+"""Position and transaction identity shared by indexed Curvy events."""
+type CurvyEventPosition {
+  transactionHash: Hex32!
+  blockHash: Hex32!
+  block: UInt64!
+  transactionIndex: UInt64!
+  logIndex: UInt64!
+  eventItemIndex: UInt64!
+}
+
+"""Gas costs associated with a Curvy Vault token."""
+type CurvyGasFees {
+  tokenId: UInt256!
+  portalDeployment: UInt256!
+  pendingNoteCommitment: UInt256!
+  withdrawal: UInt256!
+}
+
+"""One note emitted by the Curvy Aggregator `PendingNotes` event."""
+type CurvyPendingNote {
+  noteId: Hex32!
+  ephemeralKey: [UInt256!]!
+  viewTag: Int!
+  tokenId: UInt256!
+  amount: UInt256!
+  isPlaintext: Boolean!
+  position: CurvyEventPosition!
+}
+
+"""One note emitted by the Curvy Aggregator `CommittedNotes` event."""
+type CurvyCommittedNote {
+  batchIndex: Hex32!
+  noteId: Hex32!
+  leafIndex: UInt64!
+  position: CurvyEventPosition!
+}
+
+"""One nullifier emitted by the Curvy Aggregator `CommittedNullifiers` event."""
+type CurvyCommittedNullifier {
+  batchIndex: Hex32!
+  nullifier: Hex32!
+  nullifierIndex: UInt64!
+  position: CurvyEventPosition!
+}
+
+"""Finalized, immutable Curvy synchronization checkpoint."""
+type CurvySyncCheckpoint {
+  blockNumber: UInt64!
+  blockHash: Hex32!
+  aggregatorAddress: String!
+  treeVersion: Int!
+  treeDepth: Int!
+  shardHeight: Int!
+  shardSize: UInt64!
+  noteCount: UInt64!
+  nullifierCount: UInt64!
+  shardCount: UInt64!
+  notesRoot: Hex32!
+}
+
+"""Committed note plus its optional announcement metadata for SDK synchronization."""
+type CurvySyncNote {
+  leafIndex: UInt64!
+  noteId: Hex32!
+  batchIndex: Hex32!
+  announcement: CurvyPendingNote
+  commitPosition: CurvyEventPosition!
+}
+
+"""One completed Curvy notes-tree shard."""
+type CurvyShardRoot {
+  shardIndex: UInt64!
+  root: Hex32!
+  completionPosition: CurvyEventPosition!
+}
+
+"""Checkpoint-pinned page of dense Curvy committed notes."""
+type CurvySyncNotePage {
+  checkpoint: Hex32!
+  notes: [CurvySyncNote!]!
+  nextIndex: UInt64!
+  total: UInt64!
+}
+
+"""Checkpoint-pinned page of dense Curvy nullifiers."""
+type CurvySyncNullifierPage {
+  checkpoint: Hex32!
+  nullifiers: [CurvyCommittedNullifier!]!
+  nextIndex: UInt64!
+  total: UInt64!
+}
+
+"""Checkpoint-pinned page of completed Curvy shard roots."""
+type CurvyShardRootPage {
+  checkpoint: Hex32!
+  shardRoots: [CurvyShardRoot!]!
+  nextIndex: UInt64!
+  total: UInt64!
+}
+
+"""Current Curvy Vault protocol-level fees."""
+type CurvyVaultFees {
+  depositFee: UInt256!
+  withdrawalFee: UInt256!
+}
+
+"""A Curvy Vault token and its configured gas fees."""
+type CurvyVaultToken {
+  tokenAddress: String!
+  gasFees: CurvyGasFees!
+}
+
+"""The number of tokens registered in the Curvy Vault."""
+type CurvyVaultTokenCount {
+  count: UInt256!
+}
+
+"""Successful Curvy pending-note history response."""
+type CurvyPendingNotes {
+  notes: [CurvyPendingNote!]!
+}
+
+"""Successful Curvy committed-note history response."""
+type CurvyCommittedNotes {
+  notes: [CurvyCommittedNote!]!
+}
+
+"""Successful Curvy committed-nullifier history response."""
+type CurvyCommittedNullifiers {
+  nullifiers: [CurvyCommittedNullifier!]!
+}
+
+"""Raw Curvy note status returned by the Aggregator."""
+type CurvyNoteStatus {
+  status: Int!
+}
+
+union CurvyAggregatorFeesResult = CurvyAggregatorFees | QueryFailedError
+union CurvyCommittedNotesResult = CurvyCommittedNotes | QueryFailedError
+union CurvyCommittedNullifiersResult = CurvyCommittedNullifiers | QueryFailedError
+union CurvyEntryPortalAddressResult = CurvyAddress | InvalidAddressError | QueryFailedError
+union CurvyExitPortalAddressResult = CurvyAddress | InvalidAddressError | QueryFailedError
+union CurvyNoteStatusResult = CurvyNoteStatus | QueryFailedError
+union CurvyNullifierSpentResult = CurvyBooleanValue | QueryFailedError
+union CurvyPendingNotesResult = CurvyPendingNotes | QueryFailedError
+union CurvyPortalRegisteredResult = CurvyBooleanValue | InvalidAddressError | QueryFailedError
+union CurvyShardRootsResult = CurvyShardRootPage | QueryFailedError
+union CurvySyncCheckpointResult = CurvySyncCheckpoint | QueryFailedError
+union CurvySyncNotesResult = CurvySyncNotePage | QueryFailedError
+union CurvySyncNullifiersResult = CurvySyncNullifierPage | QueryFailedError
+union CurvyValidNotesRootResult = CurvyBooleanValue | QueryFailedError
+union CurvyVaultFeesResult = CurvyVaultFees | QueryFailedError
+union CurvyVaultTokenCountResult = CurvyVaultTokenCount | QueryFailedError
+union CurvyVaultTokenResult = CurvyVaultToken | QueryFailedError
+
 """
 Internal query error
 """
@@ -526,6 +723,50 @@ type QueryRoot {
   Returns the API version and a semver requirement for compatible blokli-client releases.
   """
   compatibility: Compatibility!
+  "Read the Curvy Aggregator protocol fee, commitment fee root and fee-note public key directly from chain."
+  curvyAggregatorFees: CurvyAggregatorFeesResult!
+  "Read the current Curvy Aggregator root and indices directly from chain."
+  curvyAggregatorState: CurvyAggregatorStateResult!
+  "Retrieve Curvy notes emitted by `CommittedNotes`, ordered by chain position."
+  curvyCommittedNotes(fromBlock: UInt64, after: CurvyEventCursor, first: Int): CurvyCommittedNotesResult!
+  "Retrieve Curvy nullifiers emitted by `CommittedNullifiers`, ordered by chain position."
+  curvyCommittedNullifiers(
+    fromBlock: UInt64
+    after: CurvyEventCursor
+    first: Int
+  ): CurvyCommittedNullifiersResult!
+  "Derive a Curvy entry portal address directly from PortalFactory."
+  curvyEntryPortalAddress(ownerHash: UInt256!, recovery: String!): CurvyEntryPortalAddressResult!
+  "Derive a Curvy exit portal address directly from PortalFactory."
+  curvyExitPortalAddress(
+    exitAddress: String!
+    exitChainId: UInt256!
+    recovery: String!
+  ): CurvyExitPortalAddressResult!
+  "Read a Curvy note's raw `NoteStatus` value directly from chain."
+  curvyNoteStatus(noteId: Hex32!): CurvyNoteStatusResult!
+  "Check whether a nullifier is already present in the Curvy Aggregator."
+  curvyNullifierSpent(nullifier: Hex32!): CurvyNullifierSpentResult!
+  "Retrieve Curvy notes emitted by `PendingNotes`, ordered by chain position."
+  curvyPendingNotes(fromBlock: UInt64, after: CurvyEventCursor, first: Int): CurvyPendingNotesResult!
+  "Check whether an address is registered with Curvy PortalFactory."
+  curvyPortalRegistered(portalAddress: String!): CurvyPortalRegisteredResult!
+  "Retrieve checkpoint-pinned completed notes-tree shard roots."
+  curvyShardRoots(checkpoint: Hex32!, fromIndex: UInt64, first: Int): CurvyShardRootsResult!
+  "Retrieve the latest Curvy synchronization checkpoint or one pinned by block hash."
+  curvySyncCheckpoint(blockHash: Hex32): CurvySyncCheckpointResult!
+  "Retrieve checkpoint-pinned committed notes by dense leaf index."
+  curvySyncNotes(checkpoint: Hex32!, fromIndex: UInt64, first: Int): CurvySyncNotesResult!
+  "Retrieve checkpoint-pinned nullifiers by dense nullifier index."
+  curvySyncNullifiers(checkpoint: Hex32!, fromIndex: UInt64, first: Int): CurvySyncNullifiersResult!
+  "Check whether a notes root is valid in the Curvy Aggregator."
+  curvyValidNotesRoot(root: Hex32!): CurvyValidNotesRootResult!
+  "Read the Curvy Vault deposit and withdrawal fees directly from chain."
+  curvyVaultFees: CurvyVaultFeesResult!
+  "Read a Curvy Vault token address and per-token gas fees directly from chain."
+  curvyVaultToken(tokenId: UInt256!): CurvyVaultTokenResult!
+  "Read how many tokens are registered in the Curvy Vault, so a client can enumerate `curvyVaultToken` over the real set."
+  curvyVaultTokenCount: CurvyVaultTokenCountResult!
   """
   Health check endpoint
 
@@ -970,6 +1211,12 @@ type SubscriptionRoot {
     "Filter by channel status"
     status: ChannelStatus
   ): Channel!
+  "Stream indexed Curvy `CommittedNotes` entries with an optional historical phase."
+  curvyCommittedNote(fromBlock: UInt64): CurvyCommittedNote!
+  "Stream indexed Curvy `CommittedNullifiers` entries with an optional historical phase."
+  curvyCommittedNullifier(fromBlock: UInt64): CurvyCommittedNullifier!
+  "Stream indexed Curvy `PendingNotes` entries with an optional historical phase."
+  curvyPendingNote(fromBlock: UInt64): CurvyPendingNote!
   """
   Subscribe to readiness-state updates for the API instance
 
@@ -1170,3 +1417,9 @@ Used for values that exceed the 32-bit signed integer range of GraphQL Int.
 Maximum value: 18446744073709551615
 """
 scalar UInt64
+
+"""
+Unsigned 256-bit integer represented as a decimal string.
+Maximum value: 2^256 - 1.
+"""
+scalar UInt256

--- a/design/target-db-schema.mmd
+++ b/design/target-db-schema.mmd
@@ -140,6 +140,7 @@ erDiagram
         bigint hopr_safe_contract_id FK "Foreign key to hopr_safe_contract.id (NOT NULL)"
         string event_kind "Safe event type (SAFE_SETUP, ADDED_OWNER, REMOVED_OWNER, CHANGED_THRESHOLD, EXECUTION_SUCCESS, EXECUTION_FAILURE)"
         binary(32) chain_tx_hash "Containing chain transaction hash (NOT NULL)"
+        binary(32) block_hash "Containing block hash (NOT NULL)"
         bigint published_block "Published block (NOT NULL)"
         bigint published_tx_index "Published tx index (NOT NULL)"
         bigint published_log_index "Published log index (NOT NULL)"
@@ -203,6 +204,82 @@ erDiagram
         bigint last_redeemed_tx_index "Last successful redemption tx index, or 0 when none has succeeded yet (NOT NULL)"
         bigint last_redeemed_log_index "Last successful redemption log index, or 0 when none has succeeded yet (NOT NULL)"
     }
+
+    curvy_pending_note {
+        bigint id PK "Primary key"
+        binary(32) note_id "Note identifier (NOT NULL)"
+        binary(32) ephemeral_key_x "Ephemeral key X coordinate (NOT NULL)"
+        binary(32) ephemeral_key_y "Ephemeral key Y coordinate (NOT NULL)"
+        int view_tag "View tag (NOT NULL)"
+        binary(32) token_id "Token identifier (NOT NULL)"
+        binary(32) amount "Note amount (NOT NULL)"
+        bool is_plaintext "Whether the note is plaintext (NOT NULL)"
+        int event_item_index "Position in the event arrays (NOT NULL)"
+        binary(32) chain_tx_hash "Containing chain transaction hash (NOT NULL)"
+        binary(32) block_hash "Containing block hash (NOT NULL)"
+        bigint published_block "Published block (NOT NULL)"
+        bigint published_tx_index "Published transaction index (NOT NULL)"
+        bigint published_log_index "Published log index (NOT NULL)"
+    }
+    %% Composite unique constraint: UNIQUE(published_block, published_tx_index, published_log_index, event_item_index)
+
+    curvy_committed_note {
+        bigint id PK "Primary key"
+        binary(32) batch_index "Notes batch index (NOT NULL)"
+        binary(32) note_id "Committed note identifier (NOT NULL)"
+        int event_item_index "Position in the event array (NOT NULL)"
+        binary(32) chain_tx_hash "Containing chain transaction hash (NOT NULL)"
+        bigint leaf_index UK "Dense zero-based notes-tree leaf index (NOT NULL)"
+        binary(32) block_hash "Containing block hash (NOT NULL)"
+        bigint published_block "Published block (NOT NULL)"
+        bigint published_tx_index "Published transaction index (NOT NULL)"
+        bigint published_log_index "Published log index (NOT NULL)"
+    }
+    %% Composite unique constraint: UNIQUE(published_block, published_tx_index, published_log_index, event_item_index)
+
+    curvy_shard_root {
+        bigint id PK "Primary key"
+        int tree_version "Curvy notes-tree version (NOT NULL)"
+        int shard_height "Height of each completed subtree (NOT NULL)"
+        bigint shard_index "Dense zero-based shard index (NOT NULL)"
+        binary(32) root "Completed shard root (NOT NULL)"
+        binary(32) block_hash "Completion block hash (NOT NULL)"
+        binary(32) chain_tx_hash "Completion transaction hash (NOT NULL)"
+        bigint completion_block "Completion block (NOT NULL)"
+        bigint completion_tx_index "Completion transaction index (NOT NULL)"
+        bigint completion_log_index "Completion log index (NOT NULL)"
+        bigint completion_event_item_index "Completion item index inside the event (NOT NULL)"
+    }
+    %% Composite unique constraint: UNIQUE(tree_version, shard_height, shard_index)
+
+    curvy_sync_checkpoint {
+        bigint id PK "Primary key"
+        bigint block_number UK "Completed Curvy block number (NOT NULL)"
+        binary(32) block_hash UK "Completed Curvy block hash and immutable checkpoint id (NOT NULL)"
+        binary(20) aggregator_address "Indexed Curvy Aggregator address (NOT NULL)"
+        int tree_version "Curvy notes-tree version (NOT NULL)"
+        int tree_depth "Full notes-tree depth (NOT NULL)"
+        int shard_height "Height of each shard (NOT NULL)"
+        bigint leaf_count "Committed leaves visible at the checkpoint (NOT NULL)"
+        bigint nullifier_count "Committed nullifiers visible at the checkpoint (NOT NULL)"
+        bigint shard_count "Completed shards visible at the checkpoint (NOT NULL)"
+        binary(32) root "Notes-tree root at the checkpoint (NOT NULL)"
+        blob frontier_snapshot "Canonical constant-space CVYFRONT snapshot (NOT NULL)"
+    }
+
+    curvy_committed_nullifier {
+        bigint id PK "Primary key"
+        binary(32) batch_index "Nullifiers batch index (NOT NULL)"
+        binary(32) nullifier "Committed nullifier (NOT NULL)"
+        int event_item_index "Position in the event array (NOT NULL)"
+        binary(32) chain_tx_hash "Containing chain transaction hash (NOT NULL)"
+        bigint nullifier_index UK "Dense zero-based nullifier index (NOT NULL)"
+        binary(32) block_hash "Containing block hash (NOT NULL)"
+        bigint published_block "Published block (NOT NULL)"
+        bigint published_tx_index "Published transaction index (NOT NULL)"
+        bigint published_log_index "Published log index (NOT NULL)"
+    }
+    %% Composite unique constraint: UNIQUE(published_block, published_tx_index, published_log_index, event_item_index)
 
     %% ========================================
     %% RELATIONSHIPS

--- a/docker/blokli-anvil-entrypoint.sh
+++ b/docker/blokli-anvil-entrypoint.sh
@@ -51,12 +51,20 @@ if [ "${anvil_ready}" != "true" ]; then
 fi
 
 CONTRACTS_PATH="${DATA_DIR}/contracts-deploy.toml"
-DEPLOYER_ARGS=()
+CONTRACTS_DIR="$(dirname "${CONTRACTS_PATH}")"
+
+mkdir -p "${CONTRACTS_DIR}"
+
+# This image always deploys the Curvy suite alongside the HOPR one. It is built from
+# the `-curvy` binary, whose deployer is the only one that accepts `--with-curvy`, so
+# there is nothing here to make conditional.
+CURVY_JSON_PATH="${CURVY_JSON_PATH:-${CONTRACTS_DIR}/curvy_deployed_addresses.json}"
+
+DEPLOYER_ARGS=(--with-curvy --curvy-json-out "${CURVY_JSON_PATH}")
 if [ -n "${ANVIL_DEPLOYER_PRIVATE_KEY:-}" ]; then
   DEPLOYER_ARGS+=(--private-key "${ANVIL_DEPLOYER_PRIVATE_KEY}")
 fi
 
-# Deploy contracts with error handling
 if ! blokli-contract-deployer \
   --rpc-url "${ANVIL_RPC_URL}" \
   --output "${CONTRACTS_PATH}" \
@@ -80,6 +88,11 @@ max_connections = 10
 [indexer]
 fast_sync = false
 enable_logs_snapshot = false
+# Not optional here, and it defaults to false. Deploying the Curvy suite and then not
+# indexing its events produces an aggregator whose notes never reach the API, which
+# surfaces at a consumer as a notes-root mismatch rather than as anything pointing
+# back at this file.
+enable_curvy_indexing = true
 
 [indexer.subscription]
 event_bus_capacity = 100

--- a/docs/curvy-local-deployment.md
+++ b/docs/curvy-local-deployment.md
@@ -1,0 +1,84 @@
+# Curvy local contract deployment
+
+Curvy indexing is opt-in through `indexer.enable_curvy_indexing` and requires a
+non-zero Aggregator address. The stock Blokli binary stays HOPR-only; the local
+Anvil image described below is the Curvy development environment and always
+deploys the suite.
+
+## Dependencies
+
+Both Curvy crates come from crates.io and are pinned exactly, so a routine
+`cargo update` cannot move them:
+
+```toml
+curvy-bindings = "=0.1.0-rc.5"
+curvy-core = "=0.1.0-rc.3"
+```
+
+`curvy-bindings` supplies the contract bindings and the development deployer;
+`curvy-core` supplies the notes-tree primitives. Both are release candidates.
+When Curvy publishes stable releases, bump the pins together and refresh
+`Cargo.lock`:
+
+```bash
+cargo update -p curvy-bindings -p curvy-core
+cargo check --locked -p bloklid --bin blokli-contract-deployer
+cargo check --locked -p bloklid --bin blokli-contract-deployer \
+  --features curvy-test-deployment
+```
+
+A `curvy-bindings` bump changes how many transactions `deploy_for_testing`
+issues, which shifts the absolute block numbers recorded in the Curvy pipeline
+snapshots. Re-accept those snapshots after bumping; the event payloads should be
+unchanged.
+
+## Linux/Nix validation
+
+Run these checks in the Linux VM from a clean Blokli checkout:
+
+```bash
+cargo fetch --locked
+cargo check --locked --offline -p bloklid --bin blokli-contract-deployer
+cargo check --locked --offline -p bloklid --bin blokli-contract-deployer \
+  --features curvy-test-deployment
+
+nix build -L .#binary-bloklid-x86_64-linux-curvy
+nix build -L .#binary-bloklid-aarch64-linux-curvy
+nix build -L .#docker-bloklid-anvil-curvy-x86_64-linux \
+  --out-link result-curvy-image
+docker load < result-curvy-image
+```
+
+Start the image with a writable data directory. The entrypoint writes
+`curvy_deployed_addresses.json` only after both HOPR and Curvy deployment succeed.
+The deployer also registers the local wxHOPR contract in the Curvy vault after the
+native asset and Curvy mock token, so its local token id is `3`. This is the id the
+Curvy PIX node configuration must use.
+
+```bash
+mkdir -p /tmp/blokli-curvy-data
+docker run --rm --name bloklid-anvil-curvy \
+  -e ANVIL_HOST=0.0.0.0 \
+  -p 8545:8545 -p 8080:8080 \
+  -v /tmp/blokli-curvy-data:/data \
+  bloklid-anvil-curvy:latest
+```
+
+There is one anvil image and it always deploys Curvy. The entrypoint passes
+`--with-curvy` unconditionally and sets `enable_curvy_indexing = true`, and only the
+`-curvy` binary's deployer accepts that flag, so there is no stock variant to build
+or regression-test against. Deploying the suite and then not indexing its events was
+the failure this removed: it surfaces at a consumer as a notes-root mismatch, with
+nothing pointing back at the image.
+
+Confirm both halves of that in a running container:
+
+```bash
+jq 'keys' /tmp/blokli-curvy-data/curvy_deployed_addresses.json
+curl -s http://127.0.0.1:8080/graphql -H 'content-type: application/json' \
+  --data '{"query":"{ curvySyncCheckpoint { __typename } }"}'
+```
+
+The image must emit the exact Ignition-compatible key set documented by
+`curvy-bindings`. Run rs-sdk's `curvy-e2e` flow against ports 8545 and 8080 before
+handing the image off.

--- a/flake.nix
+++ b/flake.nix
@@ -245,16 +245,19 @@
               ];
             };
 
-          # Helper: build the bloklid-anvil Docker image for a target platform.
+          # Build the local Anvil image. It always deploys the Curvy suite: the
+          # entrypoint passes `--with-curvy` unconditionally, and only the `-curvy`
+          # binary's deployer accepts that flag, so a stock variant would exit at
+          # startup on `validate_args`. There is one anvil image here, not two.
           mkBloklidAnvilDocker =
             targetPlatform:
             let
               platformPkgs = platformPkgsMap.${targetPlatform};
-              binary = bloklidPackages."binary-bloklid-${targetPlatform}";
+              binary = bloklidPackages."binary-bloklid-${targetPlatform}-curvy";
               anvilEntrypoint = mkBlokliAnvilEntrypoint targetPlatform;
             in
             nixLib.mkDockerImage {
-              name = "bloklid-anvil";
+              name = "bloklid-anvil-curvy";
               Entrypoint = [ "/bin/blokli-anvil-entrypoint" ];
               pkgsLinux = platformPkgs;
               env = [ "SSL_CERT_FILE=${platformPkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
@@ -274,10 +277,10 @@
           bloklidDocker = {
             docker-bloklid-x86_64-linux = mkBloklidDocker "x86_64-linux" null;
             docker-bloklid-x86_64-linux-dev = mkBloklidDocker "x86_64-linux" "dev";
-            docker-bloklid-anvil-x86_64-linux = mkBloklidAnvilDocker "x86_64-linux";
+            docker-bloklid-anvil-curvy-x86_64-linux = mkBloklidAnvilDocker "x86_64-linux";
             docker-bloklid-aarch64-linux = mkBloklidDocker "aarch64-linux" null;
             docker-bloklid-aarch64-linux-dev = mkBloklidDocker "aarch64-linux" "dev";
-            docker-bloklid-anvil-aarch64-linux = mkBloklidAnvilDocker "aarch64-linux";
+            docker-bloklid-anvil-curvy-aarch64-linux = mkBloklidAnvilDocker "aarch64-linux";
           };
 
           # Combine all packages

--- a/justfile
+++ b/justfile
@@ -69,6 +69,14 @@ nextest:
 nextest-package package:
     cargo nextest run -p {{ package }}
 
+# Run integration tests (requires Docker image with BLOKLI_TEST_REMOTE_IMAGE env var)
+integration-test:
+    cargo test -p blokli-integration-tests
+
+# Run the Curvy on-chain event indexing and GraphQL subscription test (requires Anvil)
+test-curvy-events:
+    cargo test -p blokli-api --test curvy_event_pipeline_test -- --nocapture
+
 # Run system tests (full smoke test suite)
 system-test: smoke-test-full
 
@@ -225,14 +233,14 @@ docker-build:
     nix build .#docker-bloklid-x86_64-linux
     docker load < result
 
-# Build bloklid + anvil Docker image from Nix
+# Build bloklid + anvil Docker image from Nix (always includes the Curvy suite)
 docker-build-anvil:
-    nix build .#docker-bloklid-anvil-x86_64-linux
+    nix build .#docker-bloklid-anvil-curvy-x86_64-linux
     docker load < result
 
 # Run bloklid + anvil container (GraphQL API on port 8080)
 docker-run-anvil log_level="info":
-    docker run --rm -p 8080:8080 -e RUST_LOG={{ log_level }} bloklid-anvil:latest
+    docker run --rm -p 8080:8080 -e RUST_LOG={{ log_level }} bloklid-anvil-curvy:latest
 
 # Rebuild bloklid and restart Docker Compose
 docker-restart: docker-build

--- a/nix/packages/bloklid.nix
+++ b/nix/packages/bloklid.nix
@@ -41,7 +41,7 @@ let
         })
         // {
           prependPackageName = false;
-          cargoExtraArgs = "-p bloklid --bins";
+          cargoExtraArgs = "-p bloklid --bins --locked";
         };
       name = "binary-bloklid-${platform}";
     in
@@ -51,6 +51,12 @@ let
     // lib.optionalAttrs (lib.hasSuffix "-linux" platform) {
       "${name}-dev" = builders.${platform}.callPackage nixLib.mkRustPackage (
         args // { CARGO_PROFILE = "dev"; }
+      );
+      "${name}-curvy" = builders.${platform}.callPackage nixLib.mkRustPackage (
+        args
+        // {
+          cargoExtraArgs = "-p bloklid --bins --locked --features curvy-test-deployment";
+        }
       );
     };
 
@@ -134,7 +140,7 @@ in
     })
     // {
       runTests = true;
-      cargoExtraArgs = "-Z panic-abort-tests"; # Nightly feature for test optimization
+      cargoExtraArgs = "--locked -Z panic-abort-tests"; # Nightly feature for test optimization
     }
   );
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -110,6 +110,303 @@ impl ScalarType for UInt64 {
     }
 }
 
+/// Unsigned 256-bit integer represented as a decimal string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UInt256(pub String);
+
+#[Scalar(name = "UInt256")]
+impl ScalarType for UInt256 {
+    fn parse(value: Value) -> async_graphql::InputValueResult<Self> {
+        let value = match value {
+            Value::String(value) => value,
+            Value::Number(value) => value.to_string(),
+            _ => return Err("UInt256 must be a decimal string or non-negative integer".into()),
+        };
+        if value.is_empty() {
+            return Err("UInt256 must not be empty".into());
+        }
+        let normalized = value.trim_start_matches('0');
+        let normalized = if normalized.is_empty() { "0" } else { normalized };
+        const MAX_U256: &str = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+        if !normalized.bytes().all(|byte| byte.is_ascii_digit())
+            || normalized.len() > MAX_U256.len()
+            || (normalized.len() == MAX_U256.len() && normalized > MAX_U256)
+        {
+            return Err("UInt256 must be a decimal integer between 0 and 2^256 - 1".into());
+        }
+        Ok(Self(normalized.to_string()))
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.0.clone())
+    }
+}
+
+/// Exclusive pagination cursor for indexed Curvy events.
+///
+/// The numeric position alone is not reorg-safe: a reorganization can place a different
+/// canonical event at the same block/transaction/log/item position, and an exclusive
+/// `>` comparison would skip it. Supplying `blockHash` anchors the cursor to the branch
+/// it was issued on, so a cursor that has been orphaned is rejected instead of silently
+/// skipping the replacement. It is optional for backwards compatibility; clients that
+/// omit it keep the previous, unchecked behaviour.
+#[derive(InputObject, Clone, Debug, PartialEq, Eq)]
+pub struct CurvyEventCursor {
+    pub block: UInt64,
+    #[graphql(name = "transactionIndex")]
+    pub transaction_index: UInt64,
+    #[graphql(name = "logIndex")]
+    pub log_index: UInt64,
+    #[graphql(name = "eventItemIndex")]
+    pub event_item_index: UInt64,
+    /// Block hash the cursor position was observed on, as returned in the event's
+    /// `position.blockHash`.
+    #[graphql(name = "blockHash")]
+    pub block_hash: Option<Hex32>,
+}
+
+/// Position and transaction identity shared by indexed Curvy events.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyEventPosition {
+    #[graphql(name = "transactionHash")]
+    pub transaction_hash: Hex32,
+    #[graphql(name = "blockHash")]
+    pub block_hash: Hex32,
+    pub block: UInt64,
+    #[graphql(name = "transactionIndex")]
+    pub transaction_index: UInt64,
+    #[graphql(name = "logIndex")]
+    pub log_index: UInt64,
+    #[graphql(name = "eventItemIndex")]
+    pub event_item_index: UInt64,
+}
+
+/// One note emitted by `PendingNotes`.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyPendingNote {
+    #[graphql(name = "noteId")]
+    pub note_id: Hex32,
+    #[graphql(name = "ephemeralKey")]
+    pub ephemeral_key: Vec<UInt256>,
+    #[graphql(name = "viewTag")]
+    pub view_tag: i32,
+    #[graphql(name = "tokenId")]
+    pub token_id: UInt256,
+    pub amount: UInt256,
+    #[graphql(name = "isPlaintext")]
+    pub is_plaintext: bool,
+    pub position: CurvyEventPosition,
+}
+
+/// One note emitted by `CommittedNotes`.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyCommittedNote {
+    #[graphql(name = "batchIndex")]
+    pub batch_index: Hex32,
+    #[graphql(name = "noteId")]
+    pub note_id: Hex32,
+    #[graphql(name = "leafIndex")]
+    pub leaf_index: UInt64,
+    pub position: CurvyEventPosition,
+}
+
+/// One nullifier emitted by `CommittedNullifiers`.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyCommittedNullifier {
+    #[graphql(name = "batchIndex")]
+    pub batch_index: Hex32,
+    pub nullifier: Hex32,
+    #[graphql(name = "nullifierIndex")]
+    pub nullifier_index: UInt64,
+    pub position: CurvyEventPosition,
+}
+
+/// Finalized, immutable Curvy synchronization checkpoint.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvySyncCheckpoint {
+    #[graphql(name = "blockNumber")]
+    pub block_number: UInt64,
+    #[graphql(name = "blockHash")]
+    pub block_hash: Hex32,
+    #[graphql(name = "aggregatorAddress")]
+    pub aggregator_address: String,
+    #[graphql(name = "treeVersion")]
+    pub tree_version: i32,
+    #[graphql(name = "treeDepth")]
+    pub tree_depth: i32,
+    #[graphql(name = "shardHeight")]
+    pub shard_height: i32,
+    #[graphql(name = "shardSize")]
+    pub shard_size: UInt64,
+    #[graphql(name = "noteCount")]
+    pub note_count: UInt64,
+    #[graphql(name = "nullifierCount")]
+    pub nullifier_count: UInt64,
+    #[graphql(name = "shardCount")]
+    pub shard_count: UInt64,
+    #[graphql(name = "notesRoot")]
+    pub notes_root: Hex32,
+}
+
+/// Committed note plus its optional announcement metadata for SDK synchronization.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvySyncNote {
+    #[graphql(name = "leafIndex")]
+    pub leaf_index: UInt64,
+    #[graphql(name = "noteId")]
+    pub note_id: Hex32,
+    #[graphql(name = "batchIndex")]
+    pub batch_index: Hex32,
+    pub announcement: Option<CurvyPendingNote>,
+    #[graphql(name = "commitPosition")]
+    pub commit_position: CurvyEventPosition,
+}
+
+/// One completed Curvy notes-tree shard.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyShardRoot {
+    #[graphql(name = "shardIndex")]
+    pub shard_index: UInt64,
+    pub root: Hex32,
+    #[graphql(name = "completionPosition")]
+    pub completion_position: CurvyEventPosition,
+}
+
+/// Checkpoint-pinned page of dense Curvy committed notes.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvySyncNotePage {
+    pub checkpoint: Hex32,
+    pub notes: Vec<CurvySyncNote>,
+    #[graphql(name = "nextIndex")]
+    pub next_index: UInt64,
+    pub total: UInt64,
+}
+
+/// Checkpoint-pinned page of dense Curvy nullifiers.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvySyncNullifierPage {
+    pub checkpoint: Hex32,
+    pub nullifiers: Vec<CurvyCommittedNullifier>,
+    #[graphql(name = "nextIndex")]
+    pub next_index: UInt64,
+    pub total: UInt64,
+}
+
+/// Checkpoint-pinned page of completed Curvy shard roots.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyShardRootPage {
+    pub checkpoint: Hex32,
+    #[graphql(name = "shardRoots")]
+    pub shard_roots: Vec<CurvyShardRoot>,
+    #[graphql(name = "nextIndex")]
+    pub next_index: UInt64,
+    pub total: UInt64,
+}
+
+/// Current per-token gas fees read from the Curvy Vault.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyGasFees {
+    #[graphql(name = "tokenId")]
+    pub token_id: UInt256,
+    #[graphql(name = "portalDeployment")]
+    pub portal_deployment: UInt256,
+    #[graphql(name = "pendingNoteCommitment")]
+    pub pending_note_commitment: UInt256,
+    pub withdrawal: UInt256,
+}
+
+/// Current Curvy Aggregator indices and notes-tree root.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyAggregatorState {
+    #[graphql(name = "notesTreeRoot")]
+    pub notes_tree_root: Hex32,
+    #[graphql(name = "notesBatchIndex")]
+    pub notes_batch_index: UInt256,
+    #[graphql(name = "nullifiersBatchIndex")]
+    pub nullifiers_batch_index: UInt256,
+    #[graphql(name = "noteIndex")]
+    pub note_index: UInt256,
+}
+
+/// Current Curvy Vault protocol-level fees.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyVaultFees {
+    #[graphql(name = "depositFee")]
+    pub deposit_fee: UInt256,
+    #[graphql(name = "withdrawalFee")]
+    pub withdrawal_fee: UInt256,
+}
+
+/// Curvy Aggregator fee configuration needed to build a valid aggregation proof.
+///
+/// `commitmentFeeRoot` is rendered as `Hex32` to match the other Curvy tree roots
+/// (`notesTreeRoot`, shard roots); the fee rate and the BabyJubJub fee-note key are
+/// `UInt256` like the Vault fees and `ephemeralKey`.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyAggregatorFees {
+    #[graphql(name = "protocolFeePerThousand")]
+    pub protocol_fee_per_thousand: UInt256,
+    #[graphql(name = "commitmentFeeRoot")]
+    pub commitment_fee_root: Hex32,
+    /// `[x, y]` of the key the circuit constrains the fee note's owner to.
+    #[graphql(name = "feeNotePublicKey")]
+    pub fee_note_public_key: Vec<UInt256>,
+}
+
+/// The number of tokens registered in the Curvy Vault.
+///
+/// Lets a client enumerate `curvyVaultToken(tokenId)` over the real token set instead
+/// of probing every id the gas-fee tree could hold.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyVaultTokenCount {
+    pub count: UInt256,
+}
+
+/// A Curvy Vault token and its configured gas fees.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyVaultToken {
+    #[graphql(name = "tokenAddress")]
+    pub token_address: String,
+    #[graphql(name = "gasFees")]
+    pub gas_fees: CurvyGasFees,
+}
+
+/// Successful Curvy pending-note history response.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyPendingNotes {
+    pub notes: Vec<CurvyPendingNote>,
+}
+
+/// Successful Curvy committed-note history response.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyCommittedNotes {
+    pub notes: Vec<CurvyCommittedNote>,
+}
+
+/// Successful Curvy committed-nullifier history response.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyCommittedNullifiers {
+    pub nullifiers: Vec<CurvyCommittedNullifier>,
+}
+
+/// Boolean value returned by a Curvy contract read.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyBooleanValue {
+    pub value: bool,
+}
+
+/// Raw Curvy note status returned by the Aggregator.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyNoteStatus {
+    pub status: i32,
+}
+
+/// Address derived or returned by a Curvy contract read.
+#[derive(SimpleObject, Clone, Debug)]
+pub struct CurvyAddress {
+    pub address: String,
+}
+
 /// Map of contract identifiers to contract addresses
 ///
 /// This scalar type represents a mapping from contract identifier strings
@@ -835,6 +1132,9 @@ impl From<&blokli_chain_types::ContractAddresses> for ContractAddressMap {
             ("winning_probability_oracle", &addresses.winning_probability_oracle),
             ("node_stake_factory", &addresses.node_stake_factory),
             ("xhopr_token", &addresses.xhopr_token),
+            ("curvy_aggregator", &addresses.curvy_aggregator),
+            ("curvy_vault", &addresses.curvy_vault),
+            ("curvy_portal_factory", &addresses.curvy_portal_factory),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))

--- a/types/src/tests.rs
+++ b/types/src/tests.rs
@@ -135,3 +135,38 @@ mod contract_address_map_tests {
         assert!(result.is_err(), "Should reject invalid JSON string");
     }
 }
+
+#[cfg(test)]
+mod uint256_tests {
+    use async_graphql::{ScalarType, Value};
+
+    use crate::UInt256;
+
+    #[test]
+    fn test_uint256_accepts_and_normalizes_decimal_values() {
+        let parsed = UInt256::parse(Value::String("00042".to_string())).unwrap();
+
+        assert_eq!(parsed, UInt256("42".to_string()));
+        assert_eq!(parsed.to_value(), Value::String("42".to_string()));
+    }
+
+    #[test]
+    fn test_uint256_accepts_maximum_value() {
+        let maximum = "115792089237316195423570985008687907853269984665640564039457584007913129639935";
+
+        assert_eq!(
+            UInt256::parse(Value::String(maximum.to_string())).unwrap(),
+            UInt256(maximum.to_string())
+        );
+    }
+
+    #[test]
+    fn test_uint256_rejects_out_of_range_and_non_decimal_values() {
+        let too_large = "115792089237316195423570985008687907853269984665640564039457584007913129639936";
+
+        assert!(UInt256::parse(Value::String(too_large.to_string())).is_err());
+        assert!(UInt256::parse(Value::String(String::new())).is_err());
+        assert!(UInt256::parse(Value::String("-1".to_string())).is_err());
+        assert!(UInt256::parse(Value::String("0x2a".to_string())).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

  - Index Curvy pending notes, committed notes, nullifiers, checkpoints, and completed shard roots
  - Maintain the Curvy notes-tree frontier with reorg-safe rollback and consistency validation
  - Expose paginated and checkpoint-pinned Curvy GraphQL queries and live subscriptions
  - Add Curvy contract reads for Aggregator state, fees, note status, nullifiers, Vault tokens, and portals
  - Add the Curvy database migration and schema documentation
  - Build the local Anvil image with Curvy deployment and indexing enabled

  ## Validation

  - `cargo check --locked -p bloklid --features curvy-test-deployment --bin blokli-contract-deployer`
  - `cargo test --locked -p blokli-chain-indexer`
  - `cargo test --locked -p blokli-api`
  - The Curvy-enabled Blokli Anvil image was exercised by the passing HOPRd PIX local-cluster integration test.