### PR TITLE
chore: use foundry-bin to fix trivy scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "bloklid"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/flake.nix
+++ b/flake.nix
@@ -261,7 +261,7 @@
               extraContents = [
                 binary
                 platformPkgs.curl
-                platformPkgs.foundry
+                platformPkgs.foundry-bin
                 (mkStaticEntrypoint {
                   pkgs = platformPkgs;
                   binary = anvilEntrypoint;


### PR DESCRIPTION
Fix the Anvil Docker image’s Trivy scan by using the pinned `foundry-bin` package, which includes a patched `quinn-proto` version.